### PR TITLE
FIX: DC_PlaceDataInHardwareDataWave auto indexing by q was used with fixed index

### DIFF
--- a/Packages/MIES/MIES_DataConfiguratorITC.ipf
+++ b/Packages/MIES/MIES_DataConfiguratorITC.ipf
@@ -1031,7 +1031,7 @@ static Function DC_PlaceDataInHardwareDataWave(panelTitle, numActiveChannels, da
 					case HARDWARE_ITC_DAC:
 						Multithread ITCDataWave[][i] =   	                    \
 						limit(                                                  \
-						(DAGain[q] * DAScale[q]) * testPulse[mod(p, TPLength)], \
+						(DAGain[i] * DAScale[i]) * testPulse[mod(p, TPLength)], \
 						SIGNED_INT_16BIT_MIN,                                   \
 						SIGNED_INT_16BIT_MAX); AbortOnRTE
 						cutOff = mod(DimSize(ITCDataWave, ROWS), TPLength)
@@ -1067,7 +1067,7 @@ static Function DC_PlaceDataInHardwareDataWave(panelTitle, numActiveChannels, da
 							// space in ITCDataWave for the testpulse is allocated via an automatic increase
 							// of the onset delay
 							ITCDataWave[baselineFrac * testPulseLength, (1 - baselineFrac) * testPulseLength][i] = \
-							limit(testPulseAmplitude[q] * DAGain[q], SIGNED_INT_16BIT_MIN, SIGNED_INT_16BIT_MAX); AbortOnRTE
+							limit(testPulseAmplitude[i] * DAGain[i], SIGNED_INT_16BIT_MIN, SIGNED_INT_16BIT_MAX); AbortOnRTE
 						endif
 						break
 					case HARDWARE_NI_DAC:


### PR DESCRIPTION
At two locations on filling the DA wave the auto indexing with q was used while
the index was set constant at the target wave.
This did not break the algorithm, but could lead to confusion later.

It was replaced by the well defined index i.