### PR TITLE
tools: Handle additional tags properly

### DIFF
--- a/tools/build-documentation.sh
+++ b/tools/build-documentation.sh
@@ -2,7 +2,7 @@
 
 top_level=$(git rev-parse --show-toplevel)
 branch=$(git rev-parse --abbrev-ref HEAD)
-version=$(git describe --always --tags)
+version=$(git describe --always --tags --match "Release_*")
 
 function Passed {
   cp "$top_level/tools/JU_Passed.xml" "$top_level/tools/unit-testing/"

--- a/tools/create-release.sh
+++ b/tools/create-release.sh
@@ -41,7 +41,7 @@ then
 fi
 
 git_dir=$(git rev-parse --git-dir)
-superproject_version=$(git --git-dir=$git_dir describe --tags --always)
+superproject_version=$(git --git-dir=$git_dir describe --tags --always --match "Release_*")
 submodule_status=$(git --git-dir=$git_dir submodule status)
 date_of_version=$(git --git-dir=$git_dir log -1 --pretty=format:%cI)
 output_file=${superproject_version}.zip

--- a/tools/publish-docs-on-github.sh
+++ b/tools/publish-docs-on-github.sh
@@ -22,7 +22,7 @@ then
   exit 1
 fi
 
-project_version=$(git describe --tags --always)
+project_version=$(git describe --tags --always --match "Release_*")
 public_mies_repo=~/devel/public-mies-igor
 
 top_level=$(git rev-parse --show-toplevel)

--- a/tools/upload-github-release-asset.sh
+++ b/tools/upload-github-release-asset.sh
@@ -52,7 +52,7 @@ case "$branch" in
     git push --force origin $tag
     ;;
   release/*)
-    tag=$(git tag | tail -1)
+    tag=$(git tag --list "Release_*" | tail -1)
     ;;
   *)
     echo "Unexpected branch $branch"


### PR DESCRIPTION
Since the move to github we are using the latest tag for publishing the
master releases.

This tag interfered with our naming scheme for the release packages.

Using the --match option of git describe limits the search to our
expected tags.