### PR TITLE
Bugfix: Use floating point conversion %g for building the region list

### DIFF
--- a/Packages/MIES/MIES_OptimzedOverlapDistributedAcquisition.ipf
+++ b/Packages/MIES/MIES_OptimzedOverlapDistributedAcquisition.ipf
@@ -94,7 +94,7 @@ static Function/S OOD_AddToRegionList(first, last, list)
 
 	string str
 
-	sprintf str, "%d-%d", first * WAVEBUILDER_MIN_SAMPINT, last * WAVEBUILDER_MIN_SAMPINT
+	sprintf str, "%g-%g", first * WAVEBUILDER_MIN_SAMPINT, last * WAVEBUILDER_MIN_SAMPINT
 
 	return AddListItem(str, list, ";", INF)
 End


### PR DESCRIPTION
There is no reason why we only want integers.

Broken since d102c07d (Add new data acquisition mode: Optimized overlap
distributed acquisition, 2016-08-10).

The oodDAQ regression test data was also regenerated.

Bug pointed out by Michael Huth.