### PR TITLE
Tests: Remove RandomTest

### DIFF
--- a/Packages/Testing-MIES/UTF_Utils.ipf
+++ b/Packages/Testing-MIES/UTF_Utils.ipf
@@ -1788,22 +1788,6 @@ End
 
 /// @}
 
-/// GetReproducibleRandom
-/// @{
-
-Function RandomTest()
-
-	NewRandomSeed()
-	Make/FREE/N=(1e4)/D data
-	Multithread data = GetReproducibleRandom()
-
-	Make/D/N=0 dupsWave
-	FindDuplicates/DN=dupsWave data
-	CHECK_EQUAL_VAR(DimSize(dupsWave, ROWS), 0)
-End
-
-/// @}
-
 /// GetListOfObjects
 /// @{
 


### PR DESCRIPTION
We can not be sure that the numbers from GetReproducibleRandom() do not
repeat.

This test is already failing occasionally in IP7 as well.

Close #209.