### PR TITLE
fix for cases where DA_Ephys panel is not in sync with GUIState waves

### DIFF
--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -4539,6 +4539,8 @@ Function DAP_LockDevice(panelTitle)
 
 	DoWindow/W=$panelTitle/C $panelTitleLocked
 
+	KillOrMoveToTrash(wv = GetDA_EphysGuiStateNum(panelTitleLocked))
+	KillOrMoveToTrash(wv = GetDA_EphysGuiStateTxT(panelTitleLocked))
 	// initial fill of the GUI state wave
 	// all other changes are propagated immediately to the GUI state waves
 	DAG_RecordGuiStateNum(panelTitleLocked)
@@ -4693,6 +4695,9 @@ static Function DAP_UnlockDevice(panelTitle)
 	DAP_ResetGUIAfterDAQ(panelTitle)
 	DAP_ToggleTestpulseButton(panelTitle, TESTPULSE_BUTTON_TO_START)
 
+	KillOrMoveToTrash(wv = GetDA_EphysGuiStateNum(panelTitle))
+	KillOrMoveToTrash(wv = GetDA_EphysGuiStateTxT(panelTitle))
+
 	string panelTitleUnlocked = BASE_WINDOW_TITLE
 	if(CheckName(panelTitleUnlocked,CONTROL_PANEL_TYPE))
 		panelTitleUnlocked = UniqueName(BASE_WINDOW_TITLE + "_",CONTROL_PANEL_TYPE,1)
@@ -4747,6 +4752,9 @@ static Function DAP_UnlockDevice(panelTitle)
 
 		KillOrMoveToTrash(wv = GetDeviceMapping())
 	endif
+
+	KillOrMoveToTrash(wv = GetDA_EphysGuiStateNum(panelTitleUnlocked))
+	KillOrMoveToTrash(wv = GetDA_EphysGuiStateTxT(panelTitleUnlocked))
 End
 
 /// @brief Return the number of ITC devices of the given `type`


### PR DESCRIPTION
There still existed a few situations where it happens that existing
GUIState waves are not in sync with the available controls of the
DA_Ephys panel. e.g. if a dev has changed controls without increasing
the PANEL VERSION constant. Or if an experiment was loaded with an open
panel with a different control state.

The fix is to reset the GUIState waves if
- The panel is recreated after an experiment load with the name
  BASE_WINDOW_TITLE. The reset is done in AfterFileOpenHook.
- The panel is locked as this changes the panel title and thus the
  the path to the GUIState waves
- The panel is unlocked as this changes the panel title and thus the
  the path to the GUIState waves
- The panel is created