### PR TITLE
fix that the experiment was always modified, even when newly created

### DIFF
--- a/Packages/MIES/MIES_IgorHooks.ipf
+++ b/Packages/MIES/MIES_IgorHooks.ipf
@@ -187,7 +187,16 @@ End
 
 static Function AfterCompiledHook()
 
+	variable modifiedBefore
+
+	ExperimentModified
+	modifiedBefore = V_flag
+
 	ASYNC_Start(threadprocessorCount, disableTask=1)
+
+	if(!modifiedBefore)
+		ExperimentModified 0
+	endif
 End
 
 #endif


### PR DESCRIPTION
With IP8 AfterCompileHook with the start of the ASYNC framework modified always the
experiment. This prevents running Igor automatically with
Igor64.exe /I "experiment.pxp" as Igor asks for save of changes after startup
and compilation before loading experiment.pxp.

This change lets Igor ignore the ExperimentModified condition through the
Async FW start. Igor does not save the threadstate anyway on experiment save.