### PR TITLE
Utility function num2strHighPrec to extend num2str with defined precision

### DIFF
--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -4261,3 +4261,25 @@ Function DeleteWavePoint(wv, dim, index)
 	   ASSERT(0, "index out of range")
    endif
 End
+
+/// @brief Converts a number to a string with specified precision (digits after decimal dot).
+/// This function is an extension for the regular num2str that is limited to 5 digits.
+/// Input numbers are rounded using the "round-half-to-even" rule to the given precision.
+/// The default precision is 5.
+/// If val is complex only the real part is converted to a string.
+/// @param[in] val       number that should be converted to a string
+/// @param[in] precision [optional, default 5] number of precision digits after the decimal dot using "round-half-to-even" rounding rule.
+///                      Precision must be in the range 0 to 15.
+/// @return string with textual number representation
+Function/S num2strHighPrec(val, [precision])
+	variable val, precision
+
+	string str
+
+	precision = ParamIsDefault(precision) ? 5 : precision
+	ASSERT(precision >= 0 && precision <= 15, "Invalid precision, must be >= 0 and <= 15.")
+
+	sprintf str, "%.*f", precision, val
+
+	return str
+End

--- a/Packages/Testing-MIES/UTF_Utils.ipf
+++ b/Packages/Testing-MIES/UTF_Utils.ipf
@@ -2282,3 +2282,103 @@ Function TextWaveToListWorks5()
 	CHECK_EQUAL_STR(list, refList)
 End
 /// @}
+
+/// num2strHighPrec
+/// @{
+
+/// @brief Fail due to negative precision
+Function num2strHighPrecFail0()
+
+	variable err
+
+	try
+		num2strHighPrec(NaN, precision = -1)
+		FAIL()
+	catch
+		err = getRTError(1)
+		PASS()
+	endtry
+End
+
+/// @brief Fail due to too high precision
+Function num2strHighPrecFail1()
+
+	variable err
+
+	try
+		num2strHighPrec(NaN, precision = 16)
+		FAIL()
+	catch
+		err = getRTError(1)
+		PASS()
+	endtry
+End
+
+/// @brief default
+Function num2strHighPrecWorks0()
+
+	string sref = "1.66667"
+	string s = num2strHighPrec(1.6666666)
+	CHECK_EQUAL_STR(s, sref)
+End
+
+/// @brief precision 0
+Function num2strHighPrecWorks1()
+
+	string sref = "2"
+	string s = num2strHighPrec(1.6666666, precision = 0)
+	CHECK_EQUAL_STR(s, sref)
+End
+
+/// @brief precision 15
+Function num2strHighPrecWorks2()
+
+//                  123456789012345
+	string sref = "1.666666666666667"
+//                              1234567890123456
+	string s = num2strHighPrec(1.6666666666666666, precision = 15)
+	CHECK_EQUAL_STR(s, sref)
+End
+
+/// @brief correct rounding of 1.5 -> 2 and 2.5 -> 2 with precision 0
+Function num2strHighPrecWorks3()
+
+	string sref = "2"
+	string s = num2strHighPrec(1.5, precision = 0)
+	CHECK_EQUAL_STR(s, sref)
+
+	s = num2strHighPrec(2.5, precision = 0)
+	CHECK_EQUAL_STR(s, sref)
+
+	sref = "-2"
+	s = num2strHighPrec(-2.5, precision = 0)
+	CHECK_EQUAL_STR(s, sref)
+	s = num2strHighPrec(-1.5, precision = 0)
+	CHECK_EQUAL_STR(s, sref)
+End
+
+/// @brief special cases nan, inf, -inf
+Function num2strHighPrecWorks4()
+
+	string sref = "nan"
+	string s = num2strHighPrec(NaN)
+	CHECK_EQUAL_STR(s, sref)
+
+	sref = "inf"
+	s = num2strHighPrec(Inf)
+	CHECK_EQUAL_STR(s, sref)
+
+	sref = "-inf"
+	s = num2strHighPrec(-Inf)
+	CHECK_EQUAL_STR(s, sref)
+End
+
+/// @brief Only real part of complex is returned
+Function num2strHighPrecWorks5()
+
+	variable/C c = cmplx(Inf, NaN)
+	string sref = "inf"
+	string s = num2strHighPrec(c)
+	CHECK_EQUAL_STR(s, sref)
+End
+/// @}


### PR DESCRIPTION
The num2str standard function uses a precision of 5 digits by default.
In some cases this is not sufficient. num2strHighPrec solves this by adding an
optional precision parameter to be able to use a defined number of digits.

- also added tests to UTF_Utils.ipf for num2strHighPrec.