### PR TITLE
Change location/timing of POST_DAQ_EVENT call to later in DAP_OneTime…

### DIFF
--- a/Packages/MIES/MIES_AnalysisFunctions.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions.ipf
@@ -35,7 +35,8 @@
 /// Post Sweep   After each sweep (before possible ITI pause)   None
 /// Post Set     After a *full* set has been acquired           This event is not always reached as the user might not acquire all steps
 ///                                                             of a set or indexing on multiple headstages is used.
-/// Post DAQ     After all DAQ has been finished                None
+/// Post DAQ     After DAQ has finished and before potential    None
+///              "TP after DAQ"
 /// =========== ============================================== ===============================================================
 ///
 /// \endrst
@@ -43,6 +44,7 @@
 /// Useful helper functions are defined in MIES_AnalysisFunctionHelpers.ipf.
 ///
 /// The Post/Pre Sweep/Set/DAQ functions are *not* executed if a currently running sweep is aborted.
+/// Changing the stimset in the Post DAQ event is only possible without indexing active.
 ///
 /// @anchor AnalysisFunctionReturnTypes Analysis function return types
 ///

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -1296,12 +1296,12 @@ Function DAP_OneTimeCallAfterDAQ(panelTitle, [forcedStop, startTPAfterDAQ])
 
 	DAP_ResetGUIAfterDAQ(panelTitle)
 
+	NVAR dataAcqRunMode = $GetDataAcqRunMode(panelTitle)
+	dataAcqRunMode = DAQ_NOT_RUNNING
+
 	if(!forcedStop)
 		AFM_CallAnalysisFunctions(panelTitle, POST_DAQ_EVENT)
 	endif
-
-	NVAR dataAcqRunMode = $GetDataAcqRunMode(panelTitle)
-	dataAcqRunMode = DAQ_NOT_RUNNING
 
 #if (IgorVersion() < 8.00)
 	StopAsyncIfDone()

--- a/Packages/Testing-MIES/UserAnalysisFunctions.ipf
+++ b/Packages/Testing-MIES/UserAnalysisFunctions.ipf
@@ -514,3 +514,17 @@ Function WriteIntoLBNOnPreDAQ(panelTitle, s)
 
 	return 0
 End
+
+Function ChangeStimSet(panelTitle, s)
+	string panelTitle
+	STRUCT AnalysisFunction_V3& s
+
+	string ctrl
+
+	if(s.eventType == POST_DAQ_EVENT)
+		ctrl = GetPanelControl(0, CHANNEL_TYPE_DAC, CHANNEL_CONTROL_WAVE)
+		PGC_SeTAndActivateControl(panelTitle, ctrl, str = "StimulusSetA_DA_0")
+	endif
+
+	return 0
+End


### PR DESCRIPTION
Old behavior: Analysis function POST_DAQ_EVENT called after setting the dataAcqRunMode 

New behavior: Analysis function POST_DAQ_EVENT immediately after TP_teardown for TP during DAQ 