### PR TITLE
IsValidSweepAndConfig: Only require version 0 config waves in special…

### DIFF
--- a/Packages/MIES/MIES_AnalysisBrowser.ipf
+++ b/Packages/MIES/MIES_AnalysisBrowser.ipf
@@ -2113,7 +2113,7 @@ static Function AB_SplitSweepIntoComponents(expFolder, device, sweep, sweepWave)
 	DFREF sweepFolder = GetAnalysisSweepDataPath(expFolder, device, sweep)
 	Wave configSweep  = GetAnalysisConfigWave(expFolder, device, sweep)
 
-	if(!IsValidSweepAndConfig(sweepWave, configSweep))
+	if(!IsValidSweepAndConfig(sweepWave, configSweep, configVersion = 0))
 		printf "The sweep %d of device %s in experiment %s does not match its configuration data. Therefore we ignore it.\r", sweep, device, expFolder
 		return 1
 	endif

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -3048,7 +3048,7 @@ Function/Wave ExtractOneDimDataFromSweep(config, sweep, index)
 	WAVE sweep
 	variable index
 
-	ASSERT(IsValidSweepAndConfig(sweep, config), "Sweep and config are not compatible")
+	ASSERT(IsValidSweepAndConfig(sweep, config, configVersion = 0), "Sweep and config are not compatible")
 
 	if(IsWaveRefWave(sweep))
 		ASSERT(index < DimSize(sweep, ROWS), "The index is out of range")
@@ -4944,7 +4944,7 @@ Function SplitSweepIntoComponents(numericalValues, sweep, sweepWave, configWave,
 
 	ASSERT(DataFolderExistsDFR(targetDFR), "targetDFR must exist")
 	ASSERT(IsFinite(sweep), "Sweep number must be finite")
-	ASSERT(IsValidSweepAndConfig(sweepWave, configWave), "Sweep and config waves are not compatible")
+	ASSERT(IsValidSweepAndConfig(sweepWave, configWave, configVersion = 0), "Sweep and config waves are not compatible")
 
 	numRows = DimSize(configWave, ROWS)
 	for(i = 0; i < numRows; i += 1)
@@ -5279,16 +5279,25 @@ threadsafe Function IsValidSweepWave(sweep)
 End
 
 /// @brief Check if the two waves are valid and compatible
-threadsafe Function IsValidSweepAndConfig(sweep, config)
+///
+/// @param sweep         sweep wave
+/// @param config        config wave
+/// @param configVersion [optional, defaults to #ITC_CONFIG_WAVE_VERSION] minimum required version of the config wave
+threadsafe Function IsValidSweepAndConfig(sweep, config, [configVersion])
 	WAVE/Z sweep, config
+	variable configVersion
+
+	if(ParamIsDefault(configVersion))
+		configVersion = ITC_CONFIG_WAVE_VERSION
+	endif
 
 	if(IsWaveRefWave(sweep))
-		return IsValidConfigWave(config) &&                  \
-				 IsValidSweepWave(sweep) &&                    \
+		return IsValidConfigWave(config, version = configVersion) &&  \
+				 IsValidSweepWave(sweep) &&                           \
 				 DimSize(sweep, ROWS) == DimSize(config, ROWS)
 	else
-		return IsValidConfigWave(config) &&                  \
-				 IsValidSweepWave(sweep) &&                    \
+		return IsValidConfigWave(config, version = configVersion) &&  \
+				 IsValidSweepWave(sweep) &&                           \
 				 DimSize(sweep, COLS) == DimSize(config, ROWS)
 	endif
 End

--- a/Packages/MIES/MIES_OverlaySweeps.ipf
+++ b/Packages/MIES/MIES_OverlaySweeps.ipf
@@ -161,8 +161,12 @@ Function OVS_UpdatePanel(win, listBoxWave, listBoxSelWave, sweepSelectionChoices
 	for(i = 0; i < numEntries; i += 1)
 		WAVE/T stimsets = GetLastSetting(allTextualValues[i], sweeps[i], STIM_WAVE_NAME_KEY, DATA_ACQUISITION_MODE)
 		sweepSelectionChoices[i][][%Stimset] = stimsets[q]
-		WAVE/T TTLStimSets = GetTTLstimSets(allNumericalValues[i], allTextualValues[i], sweeps[i])
-		sweepSelectionChoices[i][][%TTLStimSet] = TTLStimSets[q]
+		WAVE/T/Z TTLStimSets = GetTTLstimSets(allNumericalValues[i], allTextualValues[i], sweeps[i])
+		if(WaveExists(TTLStimSets))
+			sweepSelectionChoices[i][][%TTLStimSet] = TTLStimSets[q]
+		else
+			sweepSelectionChoices[i][][%TTLStimSet] = ""
+		endif
 
 		WAVE clampModes = GetLastSetting(allNumericalValues[i], sweeps[i], "Clamp Mode", DATA_ACQUISITION_MODE)
 		sweepSelectionChoices[i][][%StimsetAndClampMode] = SelectString(IsFinite(clampModes[q]), "", stimsets[q] + " (" + ConvertAmplifierModeShortStr(clampModes[q]) + ")")


### PR DESCRIPTION
… cases

In 9caf4680 (Added test for version 2 of ITCChanConfigWave, updated
IsLatestConfigWaveVersion, 2018-12-21) IsValidConfigWave learned to
check for a specific config wave version using the version 2 as default.

But it was forgotten to be able to allow passing in the minimum required config
version into IsValidSweepAndConfig.

This is required in places like the DataBrowser/SweepBrowser and
functions used from there where we want to be able to browse very old
data as well.