### PR TITLE
NWB_GetStimsetFromSweepGeneric: Don't fail without TTL stimsets

### DIFF
--- a/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
+++ b/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
@@ -633,6 +633,11 @@ static Function/S NWB_GetStimsetFromSweepGeneric(sweep, numericalValues, textual
 
 	// handle TTL channels
 	for(i = 0; i < NUM_DA_TTL_CHANNELS; i += 1)
+
+		if(!WaveExists(ttlStimsets))
+			break
+		endif
+
 		name = ttlStimSets[i]
 		if(isEmpty(name))
 			continue


### PR DESCRIPTION
Bug introduced in d25b9d57 (Refactor GetTTLStimSets to be hardware
independent, 2019-06-28).