### PR TITLE
DC_GetChannelTypefromHS: Handle inactive headstages properly

### DIFF
--- a/Packages/MIES/MIES_DataConfiguratorITC.ipf
+++ b/Packages/MIES/MIES_DataConfiguratorITC.ipf
@@ -1808,6 +1808,11 @@ Function DC_GetChannelTypefromHS(panelTitle, headstage)
 	WAVE config = GetITCChanConfigWave(panelTitle)
 
 	dac = AFH_GetDACFromHeadstage(panelTitle, headstage)
+
+	if(!IsFinite(dac))
+		return DAQ_CHANNEL_TYPE_UNKOWN
+	endif
+
 	row = AFH_GetITCDataColumn(config, dac, ITC_XOP_CHANNEL_TYPE_DAC)
 	ASSERT(IsFinite(row), "Invalid column")
 	return config[row][%DAQChannelType]


### PR DESCRIPTION
Since 0f5cac24 (P_PressureMethodPossible: Handle TP during DAQ as well,
2019-02-18) we use DC_GetChannelTypefromHS to figure out if we can use
the pressure methods or not.

But we call this function also for the currently selected headstage for
pressure control and this might just be not active.

AFH_GetDACFromHeadstage returns NaN for inactive headstages so we need
to handle that before AFH_GetITCDataColumn correctly complains.