### PR TITLE
TimeAlignmentIfReq: Handle missing reference position

### DIFF
--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -3739,7 +3739,10 @@ Function TimeAlignmentIfReq(graphtrace, mode, level, pos1x, pos2x, [force])
 		pulseIndexStr = GetUserData(graph, trace, "pulseIndex")
 		indexStr = sweepNo + ":" + pulseIndexStr
 		idx = GetRowIndex(refIndex, str = indexStr)
-		ASSERT(IsFinite(idx), "Could not find index")
+
+		if(IsNaN(idx))
+			continue
+		endif
 
 		WAVE backup = CreateBackupWave(wv)
 		offset = - (refPos + featurePos[idx])


### PR DESCRIPTION
With headstage removal we can have sweeps where we don't have data
in the reference/diagonal elements. Currently we bug out in this case.

But let's just not align these.

Close #206.

This fix now results in some pulses not being aligned as the reference traces for the alignment are not available. We can have a chat if this is not what you expect.