### PR TITLE
SetupBackgroundTasks: Don't start the timer task for single device DAQ

### DIFF
--- a/Packages/MIES/MIES_DAC-Hardware.ipf
+++ b/Packages/MIES/MIES_DAC-Hardware.ipf
@@ -685,8 +685,8 @@ Function/S HW_ITC_ListDevices()
 				if(V_ITCError == 0x8D101000)
 					ITCGeterrorString2 V_ITCError
 					printf "Missing ITC initialization due to error \"%s\".\r", S_errorMessage
-					printf "Please run Igor Pro once as administrator to create the required registry keys.\r"
-					printf "Or run regedit.exe as administrator and allow READ/WRITE access to \"HKEY_LOCAL_MACHINE\SOFTWARE\Instrutech\".\r"
+					printf "Please run the ITCDemo applications once for 32bit and 64bit (ITCDemoG32.exe and ITCDemoG64.exe) as administrator to create the required registry keys.\r"
+					printf "And then run regedit.exe as administrator and allow READ/WRITE (better known as FULL) access to \"HKEY_LOCAL_MACHINE\SOFTWARE\Instrutech\" and \"HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Instrutech\" for all users.\r"
 					ControlWindowToFront()
 					return ""
 				endif

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -5404,7 +5404,7 @@ Function SetupBackgroundTasks()
 	CtrlNamedBackground $TASKNAME_TIMERMD, period = 6, proc=DQM_Timer
 	CtrlNamedBackground $TASKNAME_FIFOMONMD, period=1, proc=DQM_FIFOMonitor
 	CtrlNamedBackground $TASKNAME_FIFOMON, period = 5, proc=DQS_FIFOMonitor
-	CtrlNamedBackground $TASKNAME_TIMER, period = 5, proc=DQS_Timer, start
+	CtrlNamedBackground $TASKNAME_TIMER, period = 5, proc=DQS_Timer
 	CtrlNamedBackground $TASKNAME_TPMD, period=5, proc=TPM_BkrdTPFuncMD
 	CtrlNamedBackground $TASKNAME_TP, period = 5, proc=TPS_TestPulseFunc
 	CtrlNamedBackground P_ITC_FIFOMonitor, period = 10, proc=P_ITC_FIFOMonitorProc


### PR DESCRIPTION
Bug introduced in f256dc50 (Move background tasks initialization into
common routine, 2019-04-10).

Close #248.