### PR TITLE
Speedup some functions which are called often during DAQ/TP

### DIFF
--- a/Packages/MIES/MIES_Cache.ipf
+++ b/Packages/MIES/MIES_Cache.ipf
@@ -206,6 +206,27 @@ static Function/S CA_WaveCRCs(waveRefs, [crcMode])
 	return NumericWaveToList(crc, ";", format = "%d")
 End
 
+/// @brief Calculate the cache key for SI_FindMatchingTableEntry.
+///
+/// We are deliberatly not using a WaveCRC here as know that the wave is not
+/// changed in IP once loaded. Therefore using its name and ModDate is enough.
+Function/S CA_SamplingIntervalKey(lut, s)
+	WAVE lut
+	STRUCT ActiveChannels &s
+
+	variable crc
+
+	crc = StringCRC(crc, num2istr(s.numDARack1))
+	crc = StringCRC(crc, num2istr(s.numADRack1))
+	crc = StringCRC(crc, num2istr(s.numTTLRack1))
+	crc = StringCRC(crc, num2istr(s.numDARack2))
+	crc = StringCRC(crc, num2istr(s.numADRack2))
+	crc = StringCRC(crc, num2istr(s.numTTLRack2))
+
+	ASSERT(!IsFreeWave(lut), "lut can not be a free wave")
+	return num2istr(crc) + NameOfWave(lut) + num2str(ModDate(lut)) + "Version 1"
+End
+
 /// @}
 
 /// @brief Make space for one new entry in the cache waves

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -1149,3 +1149,13 @@ Constant MATCH_WILDCARD = 0x2
 Constant TTL_RESCALE_OFF = 0x0
 Constant TTL_RESCALE_ON  = 0x1
 /// @}
+
+/// @brief Helper struct for storing the number of active channels per rack
+Structure ActiveChannels
+	int32 numDARack1
+	int32 numADRack1
+	int32 numTTLRack1
+	int32 numDARack2
+	int32 numADRack2
+	int32 numTTLRack2
+EndStructure

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -1661,16 +1661,17 @@ Function DAP_GetSampInt(panelTitle, dataAcqOrTP, [valid])
 	variable dataAcqOrTP
 	variable &valid
 
-	variable multiplier, fixedFreqkHz, sampInt
+	variable multiplier, sampInt
+	string fixedFreqkHzStr
 
 	if(!ParamIsDefault(valid))
 		valid = 1
 	endif
 
 	if(dataAcqOrTP == DATA_ACQUISITION_MODE)
-		fixedFreqkHz = str2numSafe(DAG_GetTextualValue(panelTitle, "Popup_Settings_FixedFreq"))
-		if(IsFinite(fixedFreqkHz))
-			sampInt = 1 / (fixedFreqkHz * 1e3) * 1e6
+		fixedFreqkHzStr = DAG_GetTextualValue(panelTitle, "Popup_Settings_FixedFreq")
+		if(cmpstr(fixedFreqkHzStr, "Maximum"))
+			sampInt = 1 / (str2num(fixedFreqkHzStr) * 1e3) * 1e6
 
 			if(!ParamIsDefault(valid))
 				valid = sampInt >= SI_CalculateMinSampInterval(panelTitle, DATA_ACQUISITION_MODE)

--- a/Packages/MIES/MIES_DataAcquisition_Multi.ipf
+++ b/Packages/MIES/MIES_DataAcquisition_Multi.ipf
@@ -77,7 +77,7 @@ Function DQM_FIFOMonitor(s)
 				// Update ActiveChunk Entry for ITC, not used in DAQ mode
 				gotTPChannels = GotTPChannelsOnADCs(paneltitle)
 				if(gotTPChannels)
-					tpLengthPoints = TP_GetTestPulseLengthInPoints(panelTitle, DATA_ACQUISITION_MODE)
+					tpLengthPoints = ROVar(GetTestPulseLengthInPoints(panelTitle, DATA_ACQUISITION_MODE))
 					lastTP = trunc(fifoLatest / tpLengthPoints) - 1
 					if(lastTP >= 0 && lastTP != ActiveDeviceList[i][%ActiveChunk])
 						ActiveDeviceList[i][%ActiveChunk] = lastTP

--- a/Packages/MIES/MIES_DataConfiguratorITC.ipf
+++ b/Packages/MIES/MIES_DataConfiguratorITC.ipf
@@ -25,6 +25,12 @@ static Function DC_UpdateGlobals(panelTitle)
 
 	SVAR panelTitleG = $GetPanelTitleGlobal()
 	panelTitleG = panelTitle
+
+	NVAR tpLengthInPointsTP = $GetTestpulseLengthInPoints(panelTitle, TEST_PULSE_MODE)
+	tpLengthInPointsTP = TP_GetTestPulseLengthInPoints(panelTitle, TEST_PULSE_MODE)
+
+	NVAR tpLengthInPointsDAQ = $GetTestpulseLengthInPoints(panelTitle, DATA_ACQUISITION_MODE)
+	tpLengthInPointsDAQ = TP_GetTestPulseLengthInPoints(panelTitle, DATA_ACQUISITION_MODE)
 End
 
 /// @brief Prepare test pulse/data acquisition
@@ -401,15 +407,19 @@ static Function DC_MakeOscilloscopeWave(panelTitle, numActiveChannels, dataAcqOr
 	string panelTitle
 	variable numActiveChannels, dataAcqOrTP
 
-	variable numRows, sampleIntervall, col
+	variable numRows, sampleIntervall, col, testPulseLength
+
 	WAVE config = GetITCChanConfigWave(panelTitle)
 	WAVE OscilloscopeData = GetOscilloscopeWave(panelTitle)
 	variable hardwareType = GetHardwareType(panelTitle)
+
+	testPulseLength = ROVar(GetTestPulseLengthInPoints(panelTitle, TEST_PULSE_MODE))
+
 	switch(hardwareType)
 		case HARDWARE_ITC_DAC:
 			WAVE ITCDataWave      = GetHardwareDataWave(panelTitle)
 			if(dataAcqOrTP == TEST_PULSE_MODE)
-				numRows = TP_GetTestPulseLengthInPoints(panelTitle, TEST_PULSE_MODE)
+				numRows = testPulseLength
 			elseif(dataAcqOrTP == DATA_ACQUISITION_MODE)
 				numRows = DimSize(ITCDataWave, ROWS)
 			else
@@ -420,7 +430,7 @@ static Function DC_MakeOscilloscopeWave(panelTitle, numActiveChannels, dataAcqOr
 		case HARDWARE_NI_DAC:
 			WAVE/WAVE NIDataWave      = GetHardwareDataWave(panelTitle)
 			if(dataAcqOrTP == TEST_PULSE_MODE)
-				numRows = TP_GetTestPulseLengthInPoints(panelTitle, TEST_PULSE_MODE)
+				numRows = testPulseLength
 			elseif(dataAcqOrTP == DATA_ACQUISITION_MODE)
 				if(numpnts(NIDataWave))
 					numRows = numpnts(NIDataWave[0])
@@ -712,7 +722,7 @@ static Function DC_PlaceDataInHardwareDataWave(panelTitle, numActiveChannels, da
 	decimationFactor      = DC_GetDecimationFactor(panelTitle, dataAcqOrTP)
 	samplingInterval      = DAP_GetSampInt(panelTitle, dataAcqOrTP)
 	multiplier            = str2num(DAG_GetTextualValue(panelTitle, "Popup_Settings_SampIntMult"))
-	testPulseLength       = TP_GetTestPulseLengthInPoints(panelTitle, DATA_ACQUISITION_MODE)
+	testPulseLength       = ROVar(GetTestPulseLengthInPoints(panelTitle, DATA_ACQUISITION_MODE))
 	WAVE/T allSetNames    = DAG_GetChannelTextual(panelTitle, CHANNEL_TYPE_DAC, CHANNEL_CONTROL_WAVE)
 	DC_ReturnTotalLengthIncrease(panelTitle, onsetdelayUser=onsetDelayUser, onsetDelayAuto=onsetDelayAuto, distributedDAQDelay=distributedDAQDelay)
 	onsetDelay            = onsetDelayUser + onsetDelayAuto

--- a/Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf
+++ b/Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf
@@ -32,6 +32,20 @@
 /// 		iceCreamCounter += 1
 /// 	End
 /// \endrst
+///
+/// if you want to ensure that you only get read-only access you can use ROVar() as in
+///
+/// \rst
+/// .. code-block:: igorpro
+///
+/// 	Function doStuffReadOnly()
+/// 		variable iceCreamCounter = ROVar(GetIceCreamCounterAsVariable())
+///
+/// 		iceCreamCounter += 1
+/// 	End
+/// \endrst
+///
+/// this avoids accidental changes.
 
 /// @brief Returns the full path to a global variable
 ///
@@ -85,6 +99,30 @@ threadsafe static Function/S GetSVARAsString(dfr, globalStrName, [initialValue])
 	endif
 
 	return GetDataFolder(1, dfr) + globalStrName
+End
+
+/// @brief Helper function to get read-only access to a global variable
+///
+/// @param path absolute path to a global variable
+Function ROVar(path)
+	string path
+
+	NVAR/Z var = $path
+	ASSERT(NVAR_Exists(var), "Could not recreate " + path)
+
+	return var
+End
+
+/// @brief Helper function to get read-only access to a global string
+///
+/// @param path absolute path to a global string
+Function/S ROStr(path)
+	string path
+
+	SVAR/Z str = $path
+	ASSERT(SVAR_Exists(str), "Could not recreate " + path)
+
+	return str
 End
 
 /// @brief Returns the full path to the mies-igor version string. Creating it when necessary.

--- a/Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf
+++ b/Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf
@@ -597,3 +597,29 @@ Function/S GetPxPVersionForAB(dfr)
 
 	return GetNVARAsString(dfr, "pxpVersion", initialValue = NaN)
 End
+
+/// @brief Wrapper for fast access during DAQ/TP for TP_GetTestPulseLengthInPoints().
+///
+/// Can only be called during DAQ/TP, returns the same data as
+/// TP_GetTestPulseLengthInPoints().
+///
+/// @param panelTitle device
+/// @param mode       one of @ref DataAcqModes
+Function/S GetTestpulseLengthInPoints(panelTitle, mode)
+	string panelTitle
+	variable mode
+
+	switch(mode)
+		case TEST_PULSE_MODE:
+			DFREF dfr = GetDeviceTestPulse(panelTitle)
+			break
+		case DATA_ACQUISITION_MODE:
+			DFREF dfr = GetDevicePath(panelTitle)
+			break
+		default:
+			ASSERT(0, "Invalid mode")
+			break
+	endswitch
+
+	return GetNVARAsString(dfr, "testpulseLengthInPoints", initialValue=NaN)
+End

--- a/Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf
+++ b/Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf
@@ -10,7 +10,7 @@
 ///
 /// @brief Helper functions for accessing global variables and strings.
 ///
-/// The functions GetNVARAsString and GetSVARAsString are static as they should
+/// The functions GetNVARAsString() and GetSVARAsString() are static as they should
 /// not be used directly.
 ///
 /// Instead if you have a global variable named `iceCreamCounter` in `root:myfood` you

--- a/Packages/MIES/MIES_Oscilloscope.ipf
+++ b/Packages/MIES/MIES_Oscilloscope.ipf
@@ -383,7 +383,7 @@ Function SCOPE_CreateGraph(panelTitle, dataAcqOrTP)
 	elseif(gotTPChan)
 			Label/W=$graph bottomTP "Time TP (\\U)"
 			sampInt = DAP_GetSampInt(panelTitle, TEST_PULSE_MODE) / 1000
-			testPulseLength = TP_GetTestPulseLengthInPoints(panelTitle, TEST_PULSE_MODE) * sampInt
+			testPulseLength = ROVar(GetTestPulseLengthInPoints(panelTitle, TEST_PULSE_MODE)) * sampInt
 			NVAR duration = $GetTestpulseDuration(panelTitle)
 			NVAR baselineFrac = $GetTestpulseBaselineFraction(panelTitle)
 			cutOff = max(0, baseLineFrac * testPulseLength - duration/2 * sampInt)
@@ -519,7 +519,7 @@ Function SCOPE_UpdateOscilloscopeData(panelTitle, dataAcqOrTP, [chunk, fifoPos, 
 			WAVE GUIState = GetDA_EphysGuiStateNum(panelTitle)
 			saveTP = GUIState[0][%check_Settings_TP_SaveTP]
 
-			tpLengthPoints = TP_GetTestPulseLengthInPoints(panelTitle, dataAcqOrTP)
+			tpLengthPoints = ROVAR(GetTestPulseLengthInPoints(panelTitle, dataAcqOrTP))
 			// use a 'virtual' end position for fifoLatest for TP Mode since the input data contains one TP only
 			fifoLatest = (dataAcqOrTP == TEST_PULSE_MODE) ? tpLengthPoints : fifoPos
 
@@ -674,7 +674,7 @@ static Function SCOPE_ITC_UpdateOscilloscope(panelTitle, dataAcqOrTP, chunk, fif
 	Make/FREE/N=(numEntries) gain = DA_EphysGuiState[ADCs[p]][%$GetSpecialControlLabel(CHANNEL_TYPE_ADC, CHANNEL_CONTROL_GAIN)] * HARDWARE_ITC_BITS_PER_VOLT
 
 	if(dataAcqOrTP == TEST_PULSE_MODE)
-		length = TP_GetTestPulseLengthInPoints(panelTitle, TEST_PULSE_MODE)
+		length = ROVAR(GetTestPulseLengthInPoints(panelTitle, TEST_PULSE_MODE))
 		first  = chunk * length
 		last   = first + length - 1
 		ASSERT(first >= 0 && last < DimSize(ITCDataWave, ROWS) && first < last, "Invalid wave subrange")

--- a/Packages/MIES/MIES_Oscilloscope.ipf
+++ b/Packages/MIES/MIES_Oscilloscope.ipf
@@ -507,21 +507,22 @@ Function SCOPE_UpdateOscilloscopeData(panelTitle, dataAcqOrTP, [chunk, fifoPos, 
 
 	// In DAQ mode, fifopos is NaN when ITC finishes
 	if(isFinite(fifopos))
-		WAVE GUIState = GetDA_EphysGuiStateNum(panelTitle)
-		saveTP = GUIState[0][%check_Settings_TP_SaveTP]
-
-		// send data to TP Analysis if TP present
-		NVAR fifoPosGlobal = $GetFifoPosition(panelTitle)
-
-		tpLengthPoints = TP_GetTestPulseLengthInPoints(panelTitle, dataAcqOrTP)
-		// use a 'virtual' end position for fifoLatest for TP Mode since the input data contains one TP only
-		fifoLatest = (dataAcqOrTP == TEST_PULSE_MODE) ? tpLengthPoints : fifoPos
 
 		WAVE config = GetITCChanConfigWave(panelTitle)
 		WAVE ADCmode = GetADCTypesFromConfig(config)
 		tpChannels = GetNrOfTypedChannels(ADCmode, DAQ_CHANNEL_TYPE_TP)
 
+		// send data to TP Analysis if TP present
+		NVAR fifoPosGlobal = $GetFifoPosition(panelTitle)
+
 		if(tpChannels)
+			WAVE GUIState = GetDA_EphysGuiStateNum(panelTitle)
+			saveTP = GUIState[0][%check_Settings_TP_SaveTP]
+
+			tpLengthPoints = TP_GetTestPulseLengthInPoints(panelTitle, dataAcqOrTP)
+			// use a 'virtual' end position for fifoLatest for TP Mode since the input data contains one TP only
+			fifoLatest = (dataAcqOrTP == TEST_PULSE_MODE) ? tpLengthPoints : fifoPos
+
 			WAVE ADCs = GetADCListFromConfig(config)
 			WAVE hsProp = GetHSProperties(panelTitle)
 			NVAR duration = $GetTestpulseDuration(panelTitle)

--- a/Packages/MIES/MIES_TestPulse.ipf
+++ b/Packages/MIES/MIES_TestPulse.ipf
@@ -74,6 +74,7 @@ End
 ///        chunk for the MD case, in points for the real sampling interval type for the given mode.
 ///
 /// See DAP_GetSampInt() for the difference regarding the modes
+/// Use GetTestpulseLengthInPoints() for fast access during DAQ/TP.
 ///
 /// @param panelTitle device
 /// @param mode       one of @ref DataAcqModes
@@ -502,7 +503,7 @@ static Function TP_RecordTP(panelTitle, BaselineSSAvg, InstResistance, SSResista
 
 		if(!count) // initial estimate
 			WAVE OscilloscopeData = GetOscilloscopeWave(panelTitle)
-			delta = TP_GetTestPulseLengthInPoints(panelTitle, TEST_PULSE_MODE) * DimDelta(OscilloscopeData, ROWS) / 1000
+			delta = ROVAR(GetTestPulseLengthInPoints(panelTitle, TEST_PULSE_MODE)) * DimDelta(OscilloscopeData, ROWS) / 1000
 		else
 			delta = TPStorage[count][0][%DeltaTimeInSeconds] / count
 		endif
@@ -857,7 +858,7 @@ Function TP_CreateTestPulseWave(panelTitle)
 
 	WAVE TestPulse = GetTestPulse()
 
-	length = TP_GetTestPulseLengthInPoints(panelTitle, TEST_PULSE_MODE)
+	length = ROVAR(GetTestPulseLengthInPoints(panelTitle, TEST_PULSE_MODE))
 
 	Redimension/N=(length) TestPulse
 	FastOp TestPulse = 0

--- a/Packages/MIES/MIES_TestPulse_Multi.ipf
+++ b/Packages/MIES/MIES_TestPulse_Multi.ipf
@@ -297,7 +297,7 @@ Function TPM_BkrdTPFuncMD(s)
 
 			// extract the last fully completed chunk
 			// for ITC only the last complete TP is evaluated, all earlier TPs get discarded
-			tpLengthPoints = TP_GetTestPulseLengthInPoints(panelTitle, TEST_PULSE_MODE)
+			tpLengthPoints = ROVAR(GetTestPulseLengthInPoints(panelTitle, TEST_PULSE_MODE))
 			lastTP = trunc(fifoLatest / tpLengthPoints) - 1
 
 			// Ensures that the new TP chunk isn't the same as the last one.


### PR DESCRIPTION
- [x] cleanup changes
- [x] Store the result of  `TP_GetTestPulseLengthInPoints` for both TP and DAQ flags in the TP/DAQ folders and add global var getters so that we can query that really cheap during DAQ

We do call TP_GetTestPulseLengthInPoints for every oscilloscope update when "TP during DAQ channels" are on.