### PR TITLE
Fix for Stored TPs + Tests

### DIFF
--- a/Packages/MIES/MIES_Oscilloscope.ipf
+++ b/Packages/MIES/MIES_Oscilloscope.ipf
@@ -592,6 +592,7 @@ Function SCOPE_UpdateOscilloscopeData(panelTitle, dataAcqOrTP, [chunk, fifoPos, 
 							if(TPChanIndex != j)
 								MultiThread StoreTPWave[][TPChanIndex] = channelData[p]
 							endif
+							TPChanIndex += 1
 						endif
 
 					endif


### PR DESCRIPTION
This PR adds the fix for the problem that only the last TP channel was stored.

Add Tests for TPDuringDAQ on multiple channels and check for TPs in stored data.

closes https://github.com/AllenInstitute/MIES/issues/255