### PR TITLE
SCOPE_NI_UpdateOscilloscope: Remove useless y scale setting

### DIFF
--- a/Packages/MIES/MIES_Oscilloscope.ipf
+++ b/Packages/MIES/MIES_Oscilloscope.ipf
@@ -652,7 +652,6 @@ static Function SCOPE_NI_UpdateOscilloscope(panelTitle, dataAcqOrTP, deviceiD, f
 			Multithread OscilloscopeData[fifoPosGlobal, fifoPos - 1][channel] = NIChannel[p]
 		endfor
 	endif
-	SetScale/P y, DimOffset(NIChannel, ROWS), DimDelta(NIChannel, ROWS), "" OscilloscopeData
 End
 
 static Function SCOPE_ITC_UpdateOscilloscope(panelTitle, dataAcqOrTP, chunk, fifoPos)


### PR DESCRIPTION
We don't use any dimension offsets and delta for the columns/y
dimension.

Bug introduced in fac268c1 (Acquisition support for NI DAC devices in
multi device mode, 2018-08-03).