### PR TITLE
TP_CheckIfTestpulseIsRunning: Fix it by using the correct index

### DIFF
--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -235,6 +235,7 @@ Constant INITIAL_KEY_WAVE_COL_COUNT = 4
 StrConstant AUTOBIAS_LAST_INVOCATION_KEY   = "AutoBiasLastInvocation"
 StrConstant DIMENSION_SCALING_LAST_INVOC   = "DimensionScalingLastInvocation"
 StrConstant PRESSURE_CTRL_LAST_INVOC       = "PressureControlLastInvocation"
+StrConstant INDEX_ON_TP_START              = "IndexOnTestPulseStart"
 /// @}
 
 /// @name Modes for SaveExperimentSpecial

--- a/Packages/MIES/MIES_TestPulse.ipf
+++ b/Packages/MIES/MIES_TestPulse.ipf
@@ -714,7 +714,7 @@ End
 Function TP_SetupCommon(panelTitle)
 	string panelTitle
 
-	variable now
+	variable now, index
 
 	// ticks are relative to OS start time
 	// so we can have "future" timestamps from existing experiments
@@ -732,6 +732,9 @@ Function TP_SetupCommon(panelTitle)
 	if(GetNumberFromWaveNote(TPStorage, PRESSURE_CTRL_LAST_INVOC) > now)
 		SetNumberInWaveNote(TPStorage, PRESSURE_CTRL_LAST_INVOC, 0)
 	endif
+
+	index = GetNumberFromWaveNote(TPStorage, NOTE_INDEX)
+	SetNumberInWaveNote(TPStorage, INDEX_ON_TP_START, index)
 
 	WAVE tpAsyncBuffer = GetTPResultAsyncBuffer(panelTitle)
 	KillOrMoveToTrash(wv=tpAsyncBuffer)
@@ -816,9 +819,13 @@ Function TP_TestPulseHasCycled(panelTitle, cycles)
 	string panelTitle
 	variable cycles
 
-	Wave TPStorage = GetTPStorage(panelTitle)
+	variable index, indexOnTPStart
 
-	return GetNumberFromWaveNote(TPStorage, NOTE_INDEX) > cycles
+	WAVE TPStorage = GetTPStorage(panelTitle)
+	index          = GetNumberFromWaveNote(TPStorage, NOTE_INDEX)
+	indexOnTPStart = GetNumberFromWaveNote(TPStorage, INDEX_ON_TP_START)
+
+	return (index - indexOnTPStart) > cycles
 End
 
 /// @brief Save the amplifier holding command in the TPStorage wave

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -2091,7 +2091,7 @@ Function/Wave GetTPStorage(panelTitle)
 	string 	panelTitle
 
 	dfref dfr = GetDeviceTestPulse(panelTitle)
-	variable versionOfNewWave = 11
+	variable versionOfNewWave = 12
 
 	WAVE/Z/SDFR=dfr/D wv = TPStorage
 
@@ -2144,6 +2144,7 @@ Function/Wave GetTPStorage(panelTitle)
 	SetNumberInWaveNote(wv, AUTOBIAS_LAST_INVOCATION_KEY, 0)
 	SetNumberInWaveNote(wv, DIMENSION_SCALING_LAST_INVOC, 0)
 	SetNumberInWaveNote(wv, PRESSURE_CTRL_LAST_INVOC, 0)
+	SetNumberInWaveNote(wv, INDEX_ON_TP_START, 0)
 
 	SetWaveVersion(wv, versionOfNewWave)
 


### PR DESCRIPTION
Ever since 916f26e4 (TPStorage: Keep all data in one wave, 2018-10-17)
the check that the TPStorage index is larger than the request number of
cycles is wrong as we don't create a new TPStorage wave on every TP start.

Let's introduce a new index to the TPStorage wave note which tracks the
NOTE_INDEX when starting TP. We can then use the difference between the
two to judge if we are done or not.

Close #263.