### PR TITLE
Restore always all cursors

### DIFF
--- a/Packages/MIES/MIES_AnalysisBrowser_SweepBrowser.ipf
+++ b/Packages/MIES/MIES_AnalysisBrowser_SweepBrowser.ipf
@@ -319,7 +319,7 @@ Function SB_UpdateSweepPlot(win, [newSweep])
 	string win
 	variable newSweep
 
-	string device, dataFolder, graph, bsPanel, scPanel, lbPanel, csrA, csrB
+	string device, dataFolder, graph, bsPanel, scPanel, lbPanel
 	variable mapIndex, i, numEntries, sweepNo, highlightSweep, traceIndex, currentSweep
 
 	graph = GetMainWindow(win)
@@ -356,8 +356,7 @@ Function SB_UpdateSweepPlot(win, [newSweep])
 
 	WAVE axesRanges = GetAxesRanges(graph)
 
-	csrA = CsrInfo(A, graph)
-	csrB = CsrInfo(B, graph)
+	WAVE/T cursorInfos = GetCursorInfos(graph)
 	RemoveTracesFromGraph(graph)
 
 	WAVE/T sweepMap = SB_GetSweepBrowserMap(sweepBrowserDFR)
@@ -398,8 +397,7 @@ Function SB_UpdateSweepPlot(win, [newSweep])
 		AR_UpdateTracesIfReq(graph, sweepDFR, numericalValues, sweepNo)
 	endfor
 
-	RestoreCursor(graph, csrA)
-	RestoreCursor(graph, csrB)
+	RestoreCursors(graph, cursorInfos)
 
 	dataFolder = sweepMap[currentSweep][%DataFolder]
 	device     = sweepMap[currentSweep][%Device]

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -165,6 +165,8 @@ Constant CONTROL_TYPE_LISTBOX       = 11
 Constant CONTROL_TYPE_CUSTOMCONTROL = 12
 /// @}
 
+StrConstant CURSOR_NAMES = "A;B;C;D;E;F;G;H;I;J"
+
 // Conversion factor from ticks to seconds, exact value is 1/60
 Constant TICKS_TO_SECONDS = 0.0166666666666667
 

--- a/Packages/MIES/MIES_DataBrowser.ipf
+++ b/Packages/MIES/MIES_DataBrowser.ipf
@@ -206,7 +206,7 @@ Function DB_UpdateSweepPlot(win)
 	string win
 
 	variable numEntries, i, sweepNo, highlightSweep, referenceTime, traceIndex
-	string device, mainPanel, lbPanel, bsPanel, scPanel, graph, csrA, csrB
+	string device, mainPanel, lbPanel, bsPanel, scPanel, graph
 
 	if(BSP_MainPanelNeedsUpdate(win))
 		DoAbortNow("Can not display data. The Databrowser panel is too old to be usable. Please close it and open a new one.")
@@ -222,8 +222,7 @@ Function DB_UpdateSweepPlot(win)
 
 	WAVE axesRanges = GetAxesRanges(graph)
 
-	csrA = CsrInfo(A, graph)
-	csrB = CsrInfo(B, graph)
+	WAVE/T cursorInfos = GetCursorInfos(graph)
 	RemoveTracesFromGraph(graph)
 
 	if(!BSP_HasBoundDevice(win))
@@ -285,8 +284,7 @@ Function DB_UpdateSweepPlot(win)
 		AR_UpdateTracesIfReq(graph, dfr, numericalValues, sweepNo)
 	endfor
 
-	RestoreCursor(graph, csrA)
-	RestoreCursor(graph, csrB)
+	RestoreCursors(graph, cursorInfos)
 
 	DEBUGPRINT_ELAPSED(referenceTime)
 

--- a/Packages/MIES/MIES_GuiUtilities.ipf
+++ b/Packages/MIES/MIES_GuiUtilities.ipf
@@ -1067,27 +1067,38 @@ Function/S GetCurrentWindow()
 	return s_value
 End
 
-/// @brief Restore the given cursor
+/// @brief Return a 1D text wave with all infos about the cursors
 ///
-/// @param graph      name of the graph
-/// @param cursorInfo the returned string of `CsrInfo`
-Function RestoreCursor(graph, cursorInfo)
-	string graph, cursorInfo
+/// The data is sorted like `CURSOR_NAMES`.
+Function/WAVE GetCursorInfos(graph)
+	string graph
 
-	string cursorTrace, traceList
+	Make/T/FREE/N=(ItemsInList(CURSOR_NAMES)) info = CsrInfo($StringFromList(p, CURSOR_NAMES), graph)
 
-	if(isEmpty(cursorInfo))
-		return NaN
-	endif
+	return info
+End
 
-	cursorTrace = StringByKey("TNAME", cursorInfo)
+/// @brief Restore the cursors from the info of GetCursorInfos().
+Function RestoreCursors(graph, cursorInfos)
+	string graph
+	WAVE/T cursorInfos
+
+	string traceList, cursorTrace
+	variable i, numEntries
 
 	traceList = TraceNameList(graph, ";", 0 + 1)
-	if(FindListItem(cursorTrace, traceList) == -1)
-		return NaN
-	endif
 
-	Execute StringByKey("RECREATION", cursorInfo)
+	numEntries = DimSize(cursorInfos, ROWS)
+	for(i = 0; i < numEntries; i += 1)
+
+		cursorTrace = StringByKey("TNAME", cursorInfos[i])
+
+		if(FindListItem(cursorTrace, traceList) == -1)
+			continue
+		endif
+
+		Execute StringByKey("RECREATION", cursorInfos[i])
+	endfor
 End
 
 /// @brief Autoscale all vertical axes in the visible x range

--- a/Packages/MIES/MIES_PulseAveraging.ipf
+++ b/Packages/MIES/MIES_PulseAveraging.ipf
@@ -481,7 +481,7 @@ Function PA_ShowPulses(win, dfr, pa)
 	variable red, green, blue, channelNumber, region, channelType, numHeadstages, length
 	variable numChannelTypeTraces, activeRegionCount, activeChanCount, totalOnsetDelay
 	string listOfWaves, channelList, vertAxis, horizAxis, channelNumberStr
-	string baseName, traceName, csrA, csrB
+	string baseName, traceName
 	string newlyCreatedGraphs = ""
 	string referenceTraceList = ""
 
@@ -597,8 +597,7 @@ Function PA_ShowPulses(win, dfr, pa)
 				PA_GetAxes(pa.multipleGraphs, activeRegionCount, activeChanCount, vertAxis, horizAxis)
 
 				if(WhichListItem(graph, newlyCreatedGraphs) == -1)
-					csrA = CsrInfo(A, graph)
-					csrB = CsrInfo(B, graph)
+					WAVE/T cursorInfos = GetCursorInfos(graph)
 					RemoveTracesFromGraph(graph)
 					SetWindow $graph, userData($PA_USERDATA_SPECIAL_TRACES) = ""
 					SetWindow $graph, userData($PA_USERDATA_REFERENCE_TRACES) = ""
@@ -637,10 +636,7 @@ Function PA_ShowPulses(win, dfr, pa)
 					listOfWavesPerChannel[channelNumber] = AddListItem(GetWavesDataFolder(plotWave, 2), listOfWavesPerChannel[channelNumber], ";", inf)
 				endfor
 
-				if(!isEmpty(csrA) && !isEmpty(csrB))
-					RestoreCursor(graph, csrA)
-					RestoreCursor(graph, csrB)
-				endif
+				RestoreCursors(graph, cursorInfos)
 			endfor
 
 			activeChanCount = 0

--- a/Packages/MIES/MIES_WaveBuilderPanel.ipf
+++ b/Packages/MIES/MIES_WaveBuilderPanel.ipf
@@ -2952,8 +2952,6 @@ Function WBP_ShowFFTSpectrumIfReq(segmentWave, sweep)
 	DEBUGPRINT("sweep=", var=sweep)
 
 	string extPanel, graphMag, graphPhase, trace
-	string cursorInfoMagA, cursorInfoMagB
-	string cursorInfoPhaseA, cursorInfoPhaseB
 	variable red, green, blue
 
 	if(!WindowExists(panel))
@@ -3014,11 +3012,8 @@ Function WBP_ShowFFTSpectrumIfReq(segmentWave, sweep)
 
 	WAVE axesRangesMag   = GetAxesRanges(graphMag)
 	WAVE axesRangesPhase = GetAxesRanges(graphPhase)
-
-	cursorInfoMagA   = CsrInfo(A, graphMag)
-	cursorInfoMagB   = CsrInfo(B, graphMag)
-	cursorInfoPhaseA = CsrInfo(A, graphPhase)
-	cursorInfoPhaseB = CsrInfo(B, graphPhase)
+	WAVE/T cursorInfosMag = GetCursorInfos(graphMag)
+	WAVE/T cursorInfosPhase = GetCursorInfos(graphPhase)
 
 	if(sweep == 0)
 		RemoveTracesFromGraph(graphMag)
@@ -3041,12 +3036,8 @@ Function WBP_ShowFFTSpectrumIfReq(segmentWave, sweep)
 
 	SetAxesRanges(graphMag, axesRangesMag)
 	SetAxesRanges(graphPhase, axesRangesPhase)
-
-	RestoreCursor(graphMag, cursorInfoMagA)
-	RestoreCursor(graphMag, cursorInfoMagB)
-
-	RestoreCursor(graphPhase, cursorInfoPhaseA)
-	RestoreCursor(graphPhase, cursorInfoPhaseB)
+	RestoreCursors(graphMag, cursorInfosMag)
+	RestoreCursors(graphPhase, cursorInfosPhase)
 End
 
 /// @brief Return distinct colors the sweeps of the wavebuilder


### PR DESCRIPTION
Since forever we only restored the cursors A and B.

For a future application we want to use all cursors, so it is quite
inconvenient that only A and B are restored.

Introduce GetCursorInfos/RestoreCursors and remove RestoreCursor to
handle that.

Close #277.