### PR TITLE
Hardware Tests: Fail hard without MCC app open

### DIFF
--- a/Packages/Testing-MIES/UTF_AnalysisFunctionManagement.ipf
+++ b/Packages/Testing-MIES/UTF_AnalysisFunctionManagement.ipf
@@ -279,8 +279,8 @@ static Function AcquireData(s, stimset, device, [numHeadstages, TTLStimset, post
 	WAVE ampMCC = GetAmplifierMultiClamps()
 	WAVE ampTel = GetAmplifierTelegraphServers()
 
-	CHECK_EQUAL_VAR(DimSize(ampMCC, ROWS), 2)
-	CHECK_EQUAL_VAR(DimSize(ampTel, ROWS), 2)
+	REQUIRE_EQUAL_VAR(DimSize(ampMCC, ROWS), 2)
+	REQUIRE_EQUAL_VAR(DimSize(ampTel, ROWS), 2)
 
 	PGC_SetAndActivateControl(device, "ADC", val=0)
 	DoUpdate/W=$device

--- a/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
+++ b/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
@@ -87,8 +87,8 @@ static Function AcquireData(s, devices, [postInitializeFunc, preAcquireFunc, set
 		WAVE ampMCC = GetAmplifierMultiClamps()
 		WAVE ampTel = GetAmplifierTelegraphServers()
 
-		CHECK_EQUAL_VAR(DimSize(ampMCC, ROWS), 2)
-		CHECK_EQUAL_VAR(DimSize(ampTel, ROWS), 2)
+		REQUIRE_EQUAL_VAR(DimSize(ampMCC, ROWS), 2)
+		REQUIRE_EQUAL_VAR(DimSize(ampTel, ROWS), 2)
 
 		// HS 0 with Amp
 		PGC_SetAndActivateControl(device, "Popup_Settings_HeadStage", val = 0)

--- a/Packages/Testing-MIES/UTF_Epochs.ipf
+++ b/Packages/Testing-MIES/UTF_Epochs.ipf
@@ -40,8 +40,8 @@ static Function AcquireData(s, devices, stimSetName1, stimSetName2[, dDAQ, oodDA
 		WAVE ampMCC = GetAmplifierMultiClamps()
 		WAVE ampTel = GetAmplifierTelegraphServers()
 
-		CHECK_EQUAL_VAR(DimSize(ampMCC, ROWS), 2)
-		CHECK_EQUAL_VAR(DimSize(ampTel, ROWS), 2)
+		REQUIRE_EQUAL_VAR(DimSize(ampMCC, ROWS), 2)
+		REQUIRE_EQUAL_VAR(DimSize(ampTel, ROWS), 2)
 
 		// HS 0 with Amp
 		PGC_SetAndActivateControl(device, "Popup_Settings_HeadStage", val = 0)

--- a/Packages/Testing-MIES/UTF_MultiPatchSeqDaScale.ipf
+++ b/Packages/Testing-MIES/UTF_MultiPatchSeqDaScale.ipf
@@ -25,8 +25,8 @@ static Function AcquireData(s, device, [postInitializeFunc, preAcquireFunc])
 	WAVE ampMCC = GetAmplifierMultiClamps()
 	WAVE ampTel = GetAmplifierTelegraphServers()
 
-	CHECK_EQUAL_VAR(DimSize(ampMCC, ROWS), 2)
-	CHECK_EQUAL_VAR(DimSize(ampTel, ROWS), 2)
+	REQUIRE_EQUAL_VAR(DimSize(ampMCC, ROWS), 2)
+	REQUIRE_EQUAL_VAR(DimSize(ampTel, ROWS), 2)
 
 	// HS 0 with Amp
 	PGC_SetAndActivateControl(device, "Popup_Settings_HeadStage", val = 0)

--- a/Packages/Testing-MIES/UTF_MultiPatchSeqFastRheoEstimate.ipf
+++ b/Packages/Testing-MIES/UTF_MultiPatchSeqFastRheoEstimate.ipf
@@ -25,8 +25,8 @@ static Function AcquireData(s, device, [postInitializeFunc, preAcquireFunc])
 	WAVE ampMCC = GetAmplifierMultiClamps()
 	WAVE ampTel = GetAmplifierTelegraphServers()
 
-	CHECK_EQUAL_VAR(DimSize(ampMCC, ROWS), 2)
-	CHECK_EQUAL_VAR(DimSize(ampTel, ROWS), 2)
+	REQUIRE_EQUAL_VAR(DimSize(ampMCC, ROWS), 2)
+	REQUIRE_EQUAL_VAR(DimSize(ampTel, ROWS), 2)
 
 	// HS 0 with Amp
 	PGC_SetAndActivateControl(device, "Popup_Settings_HeadStage", val = 0)

--- a/Packages/Testing-MIES/UTF_PatchSeqDAScale.ipf
+++ b/Packages/Testing-MIES/UTF_PatchSeqDAScale.ipf
@@ -30,8 +30,8 @@ static Function AcquireData(s, stimset, device, [postInitializeFunc, preAcquireF
 	WAVE ampMCC = GetAmplifierMultiClamps()
 	WAVE ampTel = GetAmplifierTelegraphServers()
 
-	CHECK_EQUAL_VAR(DimSize(ampMCC, ROWS), 2)
-	CHECK_EQUAL_VAR(DimSize(ampTel, ROWS), 2)
+	REQUIRE_EQUAL_VAR(DimSize(ampMCC, ROWS), 2)
+	REQUIRE_EQUAL_VAR(DimSize(ampTel, ROWS), 2)
 
 	// HS 0 with Amp
 	PGC_SetAndActivateControl(device, "Popup_Settings_HeadStage", val = HEADSTAGE)

--- a/Packages/Testing-MIES/UTF_PatchSeqRamp.ipf
+++ b/Packages/Testing-MIES/UTF_PatchSeqRamp.ipf
@@ -31,8 +31,8 @@ static Function AcquireData(s, device)
 	WAVE ampMCC = GetAmplifierMultiClamps()
 	WAVE ampTel = GetAmplifierTelegraphServers()
 
-	CHECK_EQUAL_VAR(DimSize(ampMCC, ROWS), 2)
-	CHECK_EQUAL_VAR(DimSize(ampTel, ROWS), 2)
+	REQUIRE_EQUAL_VAR(DimSize(ampMCC, ROWS), 2)
+	REQUIRE_EQUAL_VAR(DimSize(ampTel, ROWS), 2)
 
 	// HS 0 with Amp
 	PGC_SetAndActivateControl(device, "Popup_Settings_HeadStage", val = HEADSTAGE)

--- a/Packages/Testing-MIES/UTF_PatchSeqRheobase.ipf
+++ b/Packages/Testing-MIES/UTF_PatchSeqRheobase.ipf
@@ -26,8 +26,8 @@ static Function AcquireData(s, finalDAScaleFake, device)
 	WAVE ampMCC = GetAmplifierMultiClamps()
 	WAVE ampTel = GetAmplifierTelegraphServers()
 
-	CHECK_EQUAL_VAR(DimSize(ampMCC, ROWS), 2)
-	CHECK_EQUAL_VAR(DimSize(ampTel, ROWS), 2)
+	REQUIRE_EQUAL_VAR(DimSize(ampMCC, ROWS), 2)
+	REQUIRE_EQUAL_VAR(DimSize(ampTel, ROWS), 2)
 
 	// HS 0 with Amp
 	PGC_SetAndActivateControl(device, "Popup_Settings_HeadStage", val = HEADSTAGE)

--- a/Packages/Testing-MIES/UTF_PatchSeqSquarePulse.ipf
+++ b/Packages/Testing-MIES/UTF_PatchSeqSquarePulse.ipf
@@ -22,8 +22,8 @@ static Function AcquireData(s, device)
 	WAVE ampMCC = GetAmplifierMultiClamps()
 	WAVE ampTel = GetAmplifierTelegraphServers()
 
-	CHECK_EQUAL_VAR(DimSize(ampMCC, ROWS), 2)
-	CHECK_EQUAL_VAR(DimSize(ampTel, ROWS), 2)
+	REQUIRE_EQUAL_VAR(DimSize(ampMCC, ROWS), 2)
+	REQUIRE_EQUAL_VAR(DimSize(ampTel, ROWS), 2)
 
 	// HS 0 with Amp
 	PGC_SetAndActivateControl(device, "Popup_Settings_HeadStage", val = HEADSTAGE)


### PR DESCRIPTION
A common error when executing the tests is that the MCC application is
not open.

We already check that we got a two amplifiers, but only with a CHECK_*
and that made us continue.

Use a REQUIRE_* and fail immediately.