### PR TITLE
Allow tp during daq with indexing

### DIFF
--- a/Packages/MIES/MIES_AnalysisFunctionManagement.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctionManagement.ipf
@@ -31,6 +31,7 @@ Function AFM_CallAnalysisFunctions(panelTitle, eventType)
 	NVAR stopCollectionPoint = $GetStopCollectionPoint(panelTitle)
 	NVAR fifoPosition = $GetFifoPosition(panelTitle)
 	WAVE statusHS = DAG_GetChannelState(panelTitle, CHANNEL_TYPE_HEADSTAGE)
+	WAVE/T allSetNames = DAG_GetChannelTextual(panelTitle, CHANNEL_TYPE_DAC, CHANNEL_CONTROL_WAVE)
 	WAVE setEventFlag = GetSetEventFlag(panelTitle)
 
 	WAVE/T analysisFunctions = GetAnalysisFunctionStorage(panelTitle)
@@ -47,6 +48,12 @@ Function AFM_CallAnalysisFunctions(panelTitle, eventType)
 			continue
 		endif
 
+		DAC = AFH_GetDACFromHeadstage(panelTitle, i)
+
+		if(!cmpstr(allSetNames[DAC], STIMSET_TP_WHILE_DAQ, 1))
+			continue
+		endif
+
 		// always prefer the generic event over the specialized ones
 		func = analysisFunctions[i][GENERIC_EVENT]
 
@@ -58,7 +65,6 @@ Function AFM_CallAnalysisFunctions(panelTitle, eventType)
 			continue
 		endif
 
-		DAC = AFH_GetDACFromHeadstage(panelTitle, i)
 
 		if((eventType == PRE_SET_EVENT && !setEventFlag[DAC][%PRE_SET_EVENT]) \
 		   || (eventType == POST_SET_EVENT && !setEventFlag[DAC][%POST_SET_EVENT]))

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -2631,7 +2631,7 @@ static Function DAP_CheckStimset(panelTitle, channelType, channel, headstage)
 		return 1
 	endif
 
-	if(DAG_GetNumericalValue(panelTitle, "Check_DataAcq_Indexing"))
+	if(DAG_GetNumericalValue(panelTitle, "Check_DataAcq_Indexing") && CmpStr(setName, STIMSET_TP_WHILE_DAQ))
 		setNameEnd = DAG_GetTextualValue(panelTitle, GetSpecialControlLabel(channelType, CHANNEL_CONTROL_INDEX_END), index = channel)
 		if(!CmpStr(setNameEnd, NONE))
 			printf "(%s) Please select a valid indexing end wave for %s channel %d referenced by headstage %g\r", panelTitle, channelTypeStr, channel, headStage

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -2151,10 +2151,10 @@ Function DAP_CheckSettings(panelTitle, mode)
 			endif
 
 			// check all selected TTLs
-			Wave statusTTL = DAG_GetChannelState(panelTitle, CHANNEL_TYPE_TTL)
-			numEntries = DimSize(statusTTL, ROWS)
+			WAVE statusTTLFiltered = DC_GetFilteredChannelState(panelTitle, mode, CHANNEL_TYPE_TTL)
+			numEntries = DimSize(statusTTLFiltered, ROWS)
 			for(i=0; i < numEntries; i+=1)
-				if(!DC_ChannelIsActive(panelTitle, mode, CHANNEL_TYPE_TTL, i, statusTTL, statusHS))
+				if(!statusTTLFiltered[i])
 					continue
 				endif
 
@@ -2179,9 +2179,10 @@ Function DAP_CheckSettings(panelTitle, mode)
 			// classic distributed acquisition requires that all stim sets are the same
 			// oodDAQ allows different stim sets
 			if(DAG_GetNumericalValue(panelTitle, "Check_DataAcq1_DistribDaq") || DAG_GetNumericalValue(panelTitle, "Check_DataAcq1_dDAQOptOv"))
-				numEntries = DimSize(statusDA, ROWS)
+				WAVE statusDAFiltered = DC_GetFilteredChannelState(panelTitle, mode, CHANNEL_TYPE_DAC)
+				numEntries = DimSize(statusDAFiltered, ROWS)
 				for(i=0; i < numEntries; i+=1)
-					if(!DC_ChannelIsActive(panelTitle, mode, CHANNEL_TYPE_DAC, i, statusDA, statusHS))
+					if(!statusDAFiltered[i])
 						continue
 					endif
 
@@ -2336,10 +2337,11 @@ Function DAP_CheckSettings(panelTitle, mode)
 
 		if(mode == DATA_ACQUISITION_MODE)
 			WAVE/T allSetNames = DAG_GetChannelTextual(panelTitle, CHANNEL_TYPE_DAC, CHANNEL_CONTROL_WAVE)
-			numEntries = DimSize(statusDA, ROWS)
+			WAVE statusDAFiltered = DC_GetFilteredChannelState(panelTitle, DATA_ACQUISITION_MODE, CHANNEL_TYPE_DAC)
+			numEntries = DimSize(statusDAFiltered, ROWS)
 			for(i = 0; i < numEntries; i += 1)
 
-				if(!DC_ChannelIsActive(panelTitle, mode, CHANNEL_TYPE_DAC, i, statusDA, statusHS))
+				if(!statusDAFiltered[i])
 					continue
 				endif
 

--- a/Packages/MIES/MIES_Indexing.ipf
+++ b/Packages/MIES/MIES_Indexing.ipf
@@ -226,22 +226,22 @@ Function IDX_MaxNoOfSweeps(panelTitle, IndexOverRide)
 	variable i, numFollower
 	string followerPanelTitle
 
-	WAVE statusDA = DAG_GetChannelState(panelTitle, CHANNEL_TYPE_DAC)
+	WAVE statusDAFiltered = DC_GetFilteredChannelState(panelTitle, DATA_ACQUISITION_MODE, CHANNEL_TYPE_DAC)
  
 	for(i = 0; i < NUM_DA_TTL_CHANNELS; i += 1)
 
-		if(!statusDA[i])
+		if(!statusDAFiltered[i])
 			continue
 		endif
 
 		MaxNoOfSweeps = max(MaxNoOfSweeps, IDX_NumberOfSweepsAcrossSets(panelTitle, i, 0, IndexOverRide))
 	endfor
 
-	WAVE statusTTL = DAG_GetChannelState(panelTitle, CHANNEL_TYPE_TTL)
+	WAVE statusTTLFiltered = DC_GetFilteredChannelState(panelTitle, DATA_ACQUISITION_MODE, CHANNEL_TYPE_TTL)
 
 	for(i = 0; i < NUM_DA_TTL_CHANNELS; i += 1)
 
-		if(!statusTTL[i])
+		if(!statusTTLFiltered[i])
 			continue
 		endif
 
@@ -270,22 +270,22 @@ Function IDX_MinNoOfSweeps(panelTitle)
 	variable MinNoOfSweeps = inf
 	variable i
 
-	WAVE statusDA = DAG_GetChannelState(panelTitle, CHANNEL_TYPE_DAC)
+	WAVE statusDAFiltered = DC_GetFilteredChannelState(panelTitle, DATA_ACQUISITION_MODE, CHANNEL_TYPE_DAC)
 
 	for(i = 0; i < NUM_DA_TTL_CHANNELS; i += 1)
 
-		if(!statusDA[i])
+		if(!statusDAFiltered[i])
 			continue
 		endif
 
 		MinNoOfSweeps = min(MinNoOfSweeps, IDX_NumberOfSweepsAcrossSets(panelTitle, i, CHANNEL_TYPE_DAC, 1))
 	endfor
 
-	WAVE statusTTL = DAG_GetChannelState(panelTitle, CHANNEL_TYPE_TTL)
+	WAVE statusTTLFiltered = DC_GetFilteredChannelState(panelTitle, DATA_ACQUISITION_MODE, CHANNEL_TYPE_TTL)
 
 	for(i = 0; i < NUM_DA_TTL_CHANNELS; i += 1)
 
-		if(!statusTTL[i])
+		if(!statusTTLFiltered[i])
 			continue
 		endif
 
@@ -385,12 +385,12 @@ Function IDX_ApplyUnLockedIndexing(panelTitle, count)
 
 	variable i, update
 
-	WAVE statusDA = DAG_GetChannelState(panelTitle, CHANNEL_TYPE_DAC)
-	WAVE statusTTL = DAG_GetChannelState(panelTitle, CHANNEL_TYPE_TTL)
+	WAVE statusDAFiltered = DC_GetFilteredChannelState(panelTitle, DATA_ACQUISITION_MODE, CHANNEL_TYPE_DAC)
+	WAVE statusTTLFiltered = DC_GetFilteredChannelState(panelTitle, DATA_ACQUISITION_MODE, CHANNEL_TYPE_TTL)
 
 	for(i = 0; i < NUM_DA_TTL_CHANNELS; i += 1)
 
-		if(!statusDA[i])
+		if(!statusDAFiltered[i])
 			continue
 		endif
 
@@ -402,7 +402,7 @@ Function IDX_ApplyUnLockedIndexing(panelTitle, count)
 
 	for(i = 0; i < NUM_DA_TTL_CHANNELS; i += 1)
 
-		if(!statusTTL[i])
+		if(!statusTTLFiltered[i])
 			continue
 		endif
 

--- a/Packages/MIES/MIES_Indexing.ipf
+++ b/Packages/MIES/MIES_Indexing.ipf
@@ -226,7 +226,7 @@ Function IDX_MaxNoOfSweeps(panelTitle, IndexOverRide)
 	variable i, numFollower
 	string followerPanelTitle
 
-	WAVE statusDAFiltered = DC_GetFilteredChannelState(panelTitle, DATA_ACQUISITION_MODE, CHANNEL_TYPE_DAC)
+	WAVE statusDAFiltered = DC_GetFilteredChannelState(panelTitle, DATA_ACQUISITION_MODE, CHANNEL_TYPE_DAC, DAQChannelType = DAQ_CHANNEL_TYPE_DAQ)
  
 	for(i = 0; i < NUM_DA_TTL_CHANNELS; i += 1)
 
@@ -237,7 +237,7 @@ Function IDX_MaxNoOfSweeps(panelTitle, IndexOverRide)
 		MaxNoOfSweeps = max(MaxNoOfSweeps, IDX_NumberOfSweepsAcrossSets(panelTitle, i, 0, IndexOverRide))
 	endfor
 
-	WAVE statusTTLFiltered = DC_GetFilteredChannelState(panelTitle, DATA_ACQUISITION_MODE, CHANNEL_TYPE_TTL)
+	WAVE statusTTLFiltered = DC_GetFilteredChannelState(panelTitle, DATA_ACQUISITION_MODE, CHANNEL_TYPE_TTL, DAQChannelType = DAQ_CHANNEL_TYPE_DAQ)
 
 	for(i = 0; i < NUM_DA_TTL_CHANNELS; i += 1)
 
@@ -270,7 +270,7 @@ Function IDX_MinNoOfSweeps(panelTitle)
 	variable MinNoOfSweeps = inf
 	variable i
 
-	WAVE statusDAFiltered = DC_GetFilteredChannelState(panelTitle, DATA_ACQUISITION_MODE, CHANNEL_TYPE_DAC)
+	WAVE statusDAFiltered = DC_GetFilteredChannelState(panelTitle, DATA_ACQUISITION_MODE, CHANNEL_TYPE_DAC, DAQChannelType = DAQ_CHANNEL_TYPE_DAQ)
 
 	for(i = 0; i < NUM_DA_TTL_CHANNELS; i += 1)
 
@@ -281,7 +281,7 @@ Function IDX_MinNoOfSweeps(panelTitle)
 		MinNoOfSweeps = min(MinNoOfSweeps, IDX_NumberOfSweepsAcrossSets(panelTitle, i, CHANNEL_TYPE_DAC, 1))
 	endfor
 
-	WAVE statusTTLFiltered = DC_GetFilteredChannelState(panelTitle, DATA_ACQUISITION_MODE, CHANNEL_TYPE_TTL)
+	WAVE statusTTLFiltered = DC_GetFilteredChannelState(panelTitle, DATA_ACQUISITION_MODE, CHANNEL_TYPE_TTL, DAQChannelType = DAQ_CHANNEL_TYPE_DAQ)
 
 	for(i = 0; i < NUM_DA_TTL_CHANNELS; i += 1)
 
@@ -385,8 +385,8 @@ Function IDX_ApplyUnLockedIndexing(panelTitle, count)
 
 	variable i, update
 
-	WAVE statusDAFiltered = DC_GetFilteredChannelState(panelTitle, DATA_ACQUISITION_MODE, CHANNEL_TYPE_DAC)
-	WAVE statusTTLFiltered = DC_GetFilteredChannelState(panelTitle, DATA_ACQUISITION_MODE, CHANNEL_TYPE_TTL)
+	WAVE statusDAFiltered = DC_GetFilteredChannelState(panelTitle, DATA_ACQUISITION_MODE, CHANNEL_TYPE_DAC, DAQChannelType = DAQ_CHANNEL_TYPE_DAQ)
+	WAVE statusTTLFiltered = DC_GetFilteredChannelState(panelTitle, DATA_ACQUISITION_MODE, CHANNEL_TYPE_TTL, DAQChannelType = DAQ_CHANNEL_TYPE_DAQ)
 
 	for(i = 0; i < NUM_DA_TTL_CHANNELS; i += 1)
 

--- a/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
+++ b/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
@@ -1546,6 +1546,96 @@ Function RepeatSets_7_REENTRY([str])
 	AllTests(t, str)
 End
 
+Function RepeatSets_8_IGNORE(device)
+	string device
+
+	PGC_SetAndActivateControl(device, GetPanelControl(1, CHANNEL_TYPE_DAC, CHANNEL_CONTROL_WAVE), str = "TestPulse")
+	PGC_SetAndActivateControl(device, GetPanelControl(1, CHANNEL_TYPE_DAC, CHANNEL_CONTROL_INDEX_END), str = NONE)
+End
+
+// Locked Indexing with TP during DAQ
+//
+// UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
+Function RepeatSets_8([str])
+	string str
+
+	STRUCT DAQSettings s
+	InitDAQSettingsFromString(s, "MD1_RA1_I1_L1_BKG_1_RES_1")
+	AcquireData(s, str, preAcquireFunc = RepeatSets_8_IGNORE)
+End
+
+Function RepeatSets_8_REENTRY([str])
+	string str
+
+	STRUCT TestSettings t
+
+	t.numSweeps     = 4
+	t.sweepWaveType = FLOAT_WAVE
+
+	InitTestStructure(t)
+
+	t.acquiredStimSets_HS0[0,2] = "StimulusSetA_DA_0"
+	t.acquiredStimSets_HS0[3]   = "StimulusSetB_DA_0"
+	t.sweepCount_HS0            = {0, 1, 2, 0}
+	t.setCycleCount_HS0         = {0, 0, 0, 0}
+	t.stimsetCycleID_HS0[]      = {0, 0, 0, 1}
+
+	t.acquiredStimSets_HS1      = "Testpulse"
+	t.sweepCount_HS1            = {0, 0, 0, 0}
+	t.setCycleCount_HS1         = {0, 0, 0, 0}
+	WAVEClear t.stimsetCycleID_HS1
+
+	t.DAQChannelTypeDA = {DAQ_CHANNEL_TYPE_DAQ, DAQ_CHANNEL_TYPE_TP, NaN, NaN, NaN, NaN, NaN, NaN, NaN}
+	t.DAQChannelTypeAD = {DAQ_CHANNEL_TYPE_DAQ, DAQ_CHANNEL_TYPE_TP, NaN, NaN, NaN, NaN, NaN, NaN, NaN}
+
+	AllTests(t, str)
+End
+
+Function RepeatSets_9_IGNORE(device)
+	string device
+
+	PGC_SetAndActivateControl(device, GetPanelControl(1, CHANNEL_TYPE_DAC, CHANNEL_CONTROL_WAVE), str = "TestPulse")
+	PGC_SetAndActivateControl(device, GetPanelControl(1, CHANNEL_TYPE_DAC, CHANNEL_CONTROL_INDEX_END), str = NONE)
+End
+
+// Unlocked Indexing with TP during DAQ
+//
+// UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
+Function RepeatSets_9([str])
+	string str
+
+	STRUCT DAQSettings s
+	InitDAQSettingsFromString(s, "MD1_RA1_I1_L0_BKG_1_RES_1")
+	AcquireData(s, str, preAcquireFunc = RepeatSets_9_IGNORE)
+End
+
+Function RepeatSets_9_REENTRY([str])
+	string str
+
+	STRUCT TestSettings t
+
+	t.numSweeps     = 4
+	t.sweepWaveType = FLOAT_WAVE
+
+	InitTestStructure(t)
+
+	t.acquiredStimSets_HS0[0,2] = "StimulusSetA_DA_0"
+	t.acquiredStimSets_HS0[3]   = "StimulusSetB_DA_0"
+	t.sweepCount_HS0            = {0, 1, 2, 0}
+	t.setCycleCount_HS0         = {0, 0, 0, 0}
+	t.stimsetCycleID_HS0[]      = {0, 0, 0, 1}
+
+	t.acquiredStimSets_HS1      = "Testpulse"
+	t.sweepCount_HS1            = {0, 0, 0, 0}
+	t.setCycleCount_HS1         = {0, 0, 0, 0}
+	WAVEClear t.stimsetCycleID_HS1
+
+	t.DAQChannelTypeDA = {DAQ_CHANNEL_TYPE_DAQ, DAQ_CHANNEL_TYPE_TP, NaN, NaN, NaN, NaN, NaN, NaN, NaN}
+	t.DAQChannelTypeAD = {DAQ_CHANNEL_TYPE_DAQ, DAQ_CHANNEL_TYPE_TP, NaN, NaN, NaN, NaN, NaN, NaN, NaN}
+
+	AllTests(t, str)
+End
+
 Function SkipSweepsStimsetsP_IGNORE(device)
 	string device
 

--- a/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
+++ b/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
@@ -141,6 +141,7 @@ static Structure TestSettings
 	WAVE stimsetCycleID_HS0, stimsetCycleID_HS1
 	// store the sweep count where a event was fired
 	WAVE events_HS0, events_HS1
+	WAVE DAQChannelTypeAD, DAQChannelTypeDA
 EndStructure
 
 static Function InitTestStructure(t)
@@ -152,6 +153,8 @@ static Function InitTestStructure(t)
 	Make/FREE/N=(t.numSweeps) t.setCycleCount_HS0, t.setCycleCount_HS1
 	Make/FREE/N=(t.numSweeps) t.stimsetCycleID_HS0, t.stimsetCycleID_HS1
 	Make/FREE/N=(t.numSweeps, TOTAL_NUM_EVENTS) t.events_HS0 = NaN, t.events_HS1 = NaN
+	Make/FREE t.DAQChannelTypeAD = {DAQ_CHANNEL_TYPE_DAQ, DAQ_CHANNEL_TYPE_DAQ, NaN, NaN, NaN, NaN, NaN, NaN, NaN}
+	Make/FREE t.DAQChannelTypeDA = {DAQ_CHANNEL_TYPE_DAQ, DAQ_CHANNEL_TYPE_DAQ, NaN, NaN, NaN, NaN, NaN, NaN, NaN}
 End
 
 static Function AllTests(t, devices)
@@ -266,10 +269,10 @@ static Function AllTests(t, devices)
 			CHECK_EQUAL_WAVES(refEvents_HS1, actualEvents_HS1, mode = WAVE_DATA)
 
 			WAVE DAChannelTypes = GetLastSetting(numericalValues, sweepNo, "DA ChannelType", DATA_ACQUISITION_MODE)
-			CHECK_EQUAL_WAVES(DAChannelTypes, {DAQ_CHANNEL_TYPE_DAQ, DAQ_CHANNEL_TYPE_DAQ, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode = WAVE_DATA)
+			CHECK_EQUAL_WAVES(DAChannelTypes, t.DAQChannelTypeDA, mode = WAVE_DATA)
 
 			WAVE ADChannelTypes = GetLastSetting(numericalValues, sweepNo, "AD ChannelType", DATA_ACQUISITION_MODE)
-			CHECK_EQUAL_WAVES(ADChannelTypes, {DAQ_CHANNEL_TYPE_DAQ, DAQ_CHANNEL_TYPE_DAQ, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode = WAVE_DATA)
+			CHECK_EQUAL_WAVES(ADChannelTypes, t.DAQChannelTypeAD, mode = WAVE_DATA)
 		endfor
 	endfor
 

--- a/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
+++ b/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
@@ -248,13 +248,21 @@ static Function AllTests(t, devices)
 			CHECK_EQUAL_VAR(setCycleCounts[0], t.setCycleCount_HS0[j])
 			CHECK_EQUAL_VAR(setCycleCounts[1], t.setCycleCount_HS1[j])
 
-			WAVE sciSweeps = AFH_GetSweepsFromSameSCI(numericalValues, j, 0)
-			Extract/FREE/INDX t.stimsetCycleID_HS0, indizes, t.stimsetCycleID_HS0 == t.stimsetCycleID_HS0[j]
-			CHECK_EQUAL_WAVES(sciSweeps, indizes, mode = WAVE_DATA)
+			WAVE/Z sciSweeps = AFH_GetSweepsFromSameSCI(numericalValues, j, 0)
+			if(WaveExists(sciSweeps))
+				Extract/FREE/INDX t.stimsetCycleID_HS0, indizes, t.stimsetCycleID_HS0 == t.stimsetCycleID_HS0[j]
+				CHECK_EQUAL_WAVES(sciSweeps, indizes, mode = WAVE_DATA)
+			else
+				CHECK_WAVE(t.stimsetCycleID_HS0, NULL_WAVE)
+			endif
 
-			WAVE sciSweeps = AFH_GetSweepsFromSameSCI(numericalValues, j, 1)
-			Extract/FREE/INDX t.stimsetCycleID_HS1, indizes, t.stimsetCycleID_HS1 == t.stimsetCycleID_HS1[j]
-			CHECK_EQUAL_WAVES(sciSweeps, indizes, mode = WAVE_DATA)
+			WAVE/Z sciSweeps = AFH_GetSweepsFromSameSCI(numericalValues, j, 1)
+			if(WaveExists(sciSweeps))
+				Extract/FREE/INDX t.stimsetCycleID_HS1, indizes, t.stimsetCycleID_HS1 == t.stimsetCycleID_HS1[j]
+				CHECK_EQUAL_WAVES(sciSweeps, indizes, mode = WAVE_DATA)
+			else
+				CHECK_WAVE(t.stimsetCycleID_HS1, NULL_WAVE)
+			endif
 
 			Duplicate/FREE/RMD=[j][][0] anaFuncSweepTracker, actualEvents_HS0
 			Duplicate/FREE/RMD=[j][] t.events_HS0, refEvents_HS0

--- a/Packages/Testing-MIES/UTF_TestNWBExportV1.ipf
+++ b/Packages/Testing-MIES/UTF_TestNWBExportV1.ipf
@@ -111,6 +111,10 @@ Function TestStimsetParamWaves(fileID, device, sweeps)
 				break
 			endif
 
+			if(!cmpstr(stimset, STIMSET_TP_WHILE_DAQ))
+				continue
+			endif
+
 			WAVE/Z WP  = WB_GetWaveParamForSet(stimset)
 			WAVE/Z WPT = WB_GetWaveTextParamForSet(stimset)
 			WAVE/Z SegWvType = WB_GetSegWvTypeForSet(stimset)


### PR DESCRIPTION
- [x] Find all places where we now have to use `DC_ChannelIsActive` with the new DAQChannelType parameter
- [x] Add tests with locked/unlocked indexing and TP During DAQ channels
- [x] Teach DAP_CheckSettings to not enfore indexing requirements for TP during DAQ channels

Close #217.