### PR TITLE
DAEphys: Fix pressure device listing

### DIFF
--- a/Packages/MIES/MIES_PressureControl.ipf
+++ b/Packages/MIES/MIES_PressureControl.ipf
@@ -2228,7 +2228,7 @@ Function ButtonProc_Hrdwr_P_UpdtDAClist(ba) : ButtonControl
 	switch(ba.eventCode)
 		case 2: // mouse up
 			string filteredList = ""
-			string DeviceList = DAP_GetDACDeviceList()
+			string DeviceList = NONE + ";" + DAP_GetITCDeviceList() + HW_NI_ListDevices()
 			string lockedList = GetListOfLockedDevices()
 			string dev
 			variable nrDevs = ItemsInList(DeviceList)


### PR DESCRIPTION
In 66fca8ab (DAEphys: Rework device selection logic, 2019-10-08) we
replaced all calls of HW_ITC_ListDevices with a call to
DAP_GetITCDeviceList. And in this case here we wanted to be extra smart
and just use DAP_GetDACDeviceList.

But for the updating the list of pressure devices we don't need the list
of devices capable of DAQ but all unlocked devices.