### PR TITLE
SWS_AfterSweepDataSaveHook: Continue with aborts from DB_UpdateToLast…

### DIFF
--- a/Packages/MIES/MIES_SweepSaving.ipf
+++ b/Packages/MIES/MIES_SweepSaving.ipf
@@ -81,7 +81,12 @@ static Function SWS_AfterSweepDataSaveHook(panelTitle)
 			scPanel = BSP_GetSweepControlsPanel(panel)
 
 			if(GetCheckBoxState(scPanel, "check_SweepControl_AutoUpdate"))
-				DB_UpdateToLastSweep(panel)
+				try
+					ClearRTError()
+					DB_UpdateToLastSweep(panel); AbortOnRTE
+				catch
+					ClearRTError()
+				endtry
 			endif
 		endif
 	endfor


### PR DESCRIPTION
…Sweep

Since forever we required the update call to the databrowser to succeed so that DAQ is continued.

But that is quite inconvienient since the introduction of sweep formula
support as this leaves quite some space for user errors which would stop
DAQ.

Let's just catch the error and continue.