### PR TITLE
Generic GUI Load/Save and DA_Ephys Experiment Config Load/Save using customized generic way

### DIFF
--- a/Packages/MIES/MIES_AmplifierInteraction.ipf
+++ b/Packages/MIES/MIES_AmplifierInteraction.ipf
@@ -799,7 +799,7 @@ End
 /// @brief Opens Multi-clamp commander software
 ///
 /// @param ampSerialNumList A text list of amplifier serial numbers without leading zeroes
-/// Ex. "834001;435003;836059"
+/// Ex. "834001;435003;836059", "0;" starts the MCC in Demo mode
 /// @param ampTitleList [optional, defaults to blank] MCC gui window title
 /// @param maxAttempts [optional, defaults to inf] Maximum number of attempts made to open specified MCCs
 /// @return 1 if all MCCs specified in ampSerialNumList were opened, 0 if one or more MCCs specified in ampSerialNumList were not able to be opened
@@ -828,7 +828,11 @@ Function AI_OpenMCCs(ampSerialNumList, [ampTitleList, maxAttempts])
 			title = stringfromlist(i, AmpTitleList)
 			findvalue/I=(serialNum) OpenMCCList
 			if( V_value == -1)
-				sprintf cmd, "\"%s\" /S00%g /T%s(%s)", AI_GetMCCWinFilePath(), SerialNum, title, SerialStr
+				if(!serialNum)
+					sprintf cmd, "\"%s\" /T%s(%s)", AI_GetMCCWinFilePath(), title, SerialStr
+				else
+					sprintf cmd, "\"%s\" /S00%g /T%s(%s)", AI_GetMCCWinFilePath(), SerialNum, title, SerialStr
+				endif
 				executeScriptText cmd
 			endif
 		endfor

--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -122,7 +122,6 @@ static StrConstant EXPCONFIG_UDATA_WINHANDLE = "Config_WindowHandle"
 static StrConstant EXPCONFIG_UDATA_RADIOCOUPLING = "Config_RadioCouplingFunc"
 static StrConstant EXPCONFIG_UDATA_CTRLARRAY = "ControlArray"
 static StrConstant EXPCONFIG_UDATA_CTRLARRAYINDEX = "ControlArrayIndex"
-static StrConstant EXPCONFIG_UDATA_SOURCEFILE = "Config_FileName"
 
 static Constant EXPCONFIG_UDATA_MAXCTRLARRAYINDEX = 100
 static Constant EXPCONFIG_JSON_INDENT = 4
@@ -301,7 +300,7 @@ Function CONF_RestoreWindow(fName[, usePanelTypeFromFile])
 				wName = GetMainWindow(GetCurrentWindow())
 				SetWindow $wName, userData($EXPCONFIG_UDATA_SOURCEFILE)=""
 				wName = CONF_JSONToWindow(wName, restoreMask, jsonID)
-				SetWindow $wName, userData($EXPCONFIG_UDATA_SOURCEFILE)=fullFilePath
+				CONF_AddConfigFileUserData(wName, fullFilePath)
 				print "Configuration restored for " + wName
 			else
 				ASSERT(0, "Configuration file entry for panel type has an unknown panel tag (" + panelType + ").")
@@ -324,7 +323,7 @@ Function CONF_RestoreWindow(fName[, usePanelTypeFromFile])
 				jsonID = CONF_ParseJSON(input)
 				SetWindow $wName, userData($EXPCONFIG_UDATA_SOURCEFILE)=""
 				wName = CONF_JSONToWindow(wName, restoreMask, jsonID)
-				SetWindow $wName, userData($EXPCONFIG_UDATA_SOURCEFILE)=fullFilePath
+				CONF_AddConfigFileUserData(wName, fullFilePath)
 				print "Configuration restored for " + wName
 			endif
 		endif
@@ -471,8 +470,7 @@ Function CONF_RestoreDAEphys(jsonID, fullFilePath, [middleOfExperiment, forceNew
 
 		CONF_RestoreHeadstageAssociation(panelTitle, jsonID, middleOfExperiment)
 		CONF_RestoreUserPressure(panelTitle, jsonID)
-
-		SetWindow $panelTitle, userData($EXPCONFIG_UDATA_SOURCEFILE)=fullFilePath
+		CONF_AddConfigFileUserData(panelTitle, fullFilePath)
 
 		filename = GetTimeStamp() + PACKED_FILE_EXPERIMENT_SUFFIX
 		path = CONF_GetStringFromSettings(jsonID, SAVE_PATH)
@@ -510,6 +508,13 @@ Function CONF_RestoreDAEphys(jsonID, fullFilePath, [middleOfExperiment, forceNew
 			Abort
 		endif
 	endtry
+End
+
+/// @brief Add the config file path to the panel as user data
+static Function CONF_AddConfigFileUserData(win, fullFilePath)
+	string win, fullFilePath
+
+	SetWindow $win, userData($EXPCONFIG_UDATA_SOURCEFILE)=fullFilePath
 End
 
 /// @brief Parses a json formatted string to a json object. This function shows a helpful error message if the parse fails

--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -1,0 +1,2071 @@
+#pragma TextEncoding = "UTF-8"
+#pragma rtGlobals=3 // Use modern global access method and strict wave access.
+#pragma rtFunctionErrors=1
+
+#ifdef AUTOMATED_TESTING
+#pragma ModuleName=MIES_CONF
+#endif
+
+/// @file MIES_Configuration.ipf
+///
+/// @brief __CONF__ Import user settings to configure paramters for Ephys experiments
+///
+/// @anchor Configuration Module brief description
+///******************************************************************************************************************************
+///
+/// The Configuration module allows to save and load the GUI state of complete windows including its subwindows
+///
+/// The main functions are CONF_SaveWindow and CONF_RestoreWindow. CONF_SaveWindow automatically detects if the current window is
+/// a DA_Ephys panel and uses the DA_Ephys GUI state savig configuration settings and saves additional information.
+/// CONF_RestoreWindow also detects if the current window is of DA_Ephys type and handles that specific for this case.
+/// CONF_RestoreDAEphys can be called directly as well if there is no panel open. It will open a new DA_Ephys panel automatically
+/// if no other viable candidate panel was found.
+///
+/// The GUI state is saved in a text file in json format. In the basic structure of the file the main blocks
+/// are the windows and subwindows and within are the control blocks.
+/// A bitmask parameter allows to configure which control information is saved. See WindowControlSavingMask
+/// Currently supported is Value, Position/Size, Userdata, Disabled state and Type of a control.
+/// Not implemented is e.g. Color/Background Color
+/// As Value only the V_Value and/or S_Value and/or S_DataFolder is saved. Special control properties for e.g.
+/// ListBox like V_SelCol are currently not implemented.
+///
+/// How GUI controls are handled can be controlled through userdata settings of each control. The following
+/// userdata settings are supported:
+/// - Config_NiceName: sets a human readable name of the control used in the configuration file
+///                    This name may not be a duplicate of another controls name or ControlArray name.
+///                    Also suffixing with " ControlGroup" is not allowed.
+/// - Config_GroupPath: Sets a group path in which the control appears in the configuration file.
+///                     If not set then "Generic" is used. The group path elements can not contain the '/' character.
+///                     Several levels can be separated by ";", e.g. "level1;level2;".
+///                     In the configuration file the group path elements are suffixed by " ControlGroup" which identifies them
+///                     as path compared to actual control names.
+/// - Config_DontSave: When set to 1 the control is ignored on saving the window.
+/// - Config_DontRestore: When set to 1 the control is ignored on restoring the window.
+/// - Config_PushButtonOnRestore: Only valid with Button controls. When the button is restored a button press
+///                               is issued.
+/// - Config_RestorePriority: Sets a double precision number that defines the order in which controls get restored.
+///                           Lower numbers correspond to earlier restore. If not set a priority of Inf is used.
+///                           If multiple controls have the same priority the order of restore is not defined.
+/// - Config_RadioCouplingFunc: A function name of a function that returns a text wave with lists of coupled
+///                             CheckBoxes (aka RadioButtons). It is assumed that only one CheckBox of the group
+///                             is in enabled state at the same time. See DAP_GetRadioButtonCoupling for example.
+/// - ControlArray: Stores a name of a group of controls. All controls with the same ControlArray name are saved
+///                 as group with that name in the configuration file. ControlArrays save only values and nothing
+///                 is saved if the configured WindowControlSavingMask does not include values.
+/// - ControlArrayIndex: Only valid if also ControlArray is set. Stores the index number of the control in its
+///                      ControlArray. All member of the same ControlArray must have different indices.
+///                      Currently not more than 100 controls are allowed for each ControlArray.
+///
+/// The function WindowtoJSON allows to give optional a list of control types that should be excluded.
+///
+/// If the type of the control was saved, it is checked against the GUI controls type on restore.
+///
+/// CheckBoxes are saved with true/false values.
+///
+/// For the DA_Ephys panel: The function CONF_DefaultSettings sets default values for parameters not present in the GUI.
+///
+/// Special mask flags:
+/// - EXPCONFIG_SAVE_ONLY_RELEVANT: Saves only most relevant value data of a control. It is configured in EXPCONFIG_GUI_PREFERRED
+/// - EXPCONFIG_SAVE_POPUPMENU_AS_STRING_ONLY: Saves value for PopupMenu only as string
+/// - EXPCONFIG_SAVE_POPUPMENU_AS_INDEX_ONLY: Saves value for PopupMenu only as index value
+/// - EXPCONFIG_MINIMIZE_ON_RESTORE: Minimize window while restoring it.
+/// - EXPCONFIG_SAVE_BUTTONS_ONLY_PRESSED: Saves Buttons only when its userdata Config_PushButtonOnRestore is "1"
+///
+/// Handling of window names on restore:
+/// The currently selected windows main window is used as reference. The main window name in the configuration file is
+/// internally replaced with the current main window. This allows to save from "DataBrowser" and load to "DataBrowser2".
+///
+/// Handling of errors in input data:
+/// If input data is of unexpected format an ASSERTion or RTE is issued. The wrapping function converts the RTE to an ASSERT.
+/// The panel restore is aborted and the panel stays in its state. It gets unhided.
+///
+/// Default configuration for generic windows:
+/// By default only the Value property is saved and controls from EXPCONFIG_EXCLUDE_CTRLTYPES excluded.
+///
+/// Default configuration for DA_Ephys panel:
+/// - By default only the Value property is saved
+/// - Controls from DAEPHYS_EXCLUDE_CTRLTYPES are excluded.
+/// - The window is minimized while restoring
+/// - PopupMenu values are saved as string only
+/// - Buttons are only saved if its userdata Config_PushButtonOnRestore is "1"
+/// - Only most relevant data of a control is saved.
+///******************************************************************************************************************************
+
+#if exists("MCC_GetMode") && exists("AxonTelegraphGetDataStruct")
+#define AMPLIFIER_XOPS_PRESENT
+#endif
+
+static StrConstant EXPCONFIG_FIELD_CTRLTYPE = "Type"
+static StrConstant EXPCONFIG_FIELD_CTRLVVALUE = "NumValue"
+static StrConstant EXPCONFIG_FIELD_CTRLSVALUE = "StrValue"
+static StrConstant EXPCONFIG_FIELD_CTRLSDF = "DataSource"
+static StrConstant EXPCONFIG_FIELD_CTRLDISABLED = "Disabled"
+static StrConstant EXPCONFIG_FIELD_CTRLPOSHEIGHT = "Height"
+static StrConstant EXPCONFIG_FIELD_CTRLPOSWIDTH = "Width"
+static StrConstant EXPCONFIG_FIELD_CTRLPOSTOP = "Top"
+static StrConstant EXPCONFIG_FIELD_CTRLPOSLEFT = "Left"
+static StrConstant EXPCONFIG_FIELD_CTRLPOSRIGHT = "Right"
+static StrConstant EXPCONFIG_FIELD_CTRLPOSPOS = "Pos"
+static StrConstant EXPCONFIG_FIELD_CTRLPOSALIGN = "Align"
+static StrConstant EXPCONFIG_FIELD_CTRLUSERDATA = "Userdata"
+static StrConstant EXPCONFIG_FIELD_BASE64PREFIX = "Base64 "
+static StrConstant EXPCONFIG_FIELD_CTRLARRAYVALUES = "Values"
+
+static StrConstant EXPCONFIG_UDATA_NICENAME = "Config_NiceName"
+static StrConstant EXPCONFIG_UDATA_JSONPATH = "Config_GroupPath"
+static StrConstant EXPCONFIG_UDATA_EXCLUDE_SAVE = "Config_DontSave"
+static StrConstant EXPCONFIG_UDATA_EXCLUDE_RESTORE = "Config_DontRestore"
+static StrConstant EXPCONFIG_UDATA_BUTTONPRESS = "Config_PushButtonOnRestore"
+// Lower means higher priority
+static StrConstant EXPCONFIG_UDATA_RESTORE_PRIORITY = "Config_RestorePriority"
+static StrConstant EXPCONFIG_UDATA_WINHANDLE = "Config_WindowHandle"
+static StrConstant EXPCONFIG_UDATA_RADIOCOUPLING = "Config_RadioCouplingFunc"
+static StrConstant EXPCONFIG_UDATA_CTRLARRAY = "ControlArray"
+static StrConstant EXPCONFIG_UDATA_CTRLARRAYINDEX = "ControlArrayIndex"
+static StrConstant EXPCONFIG_UDATA_SOURCEFILE = "Config_FileName"
+
+static Constant EXPCONFIG_UDATA_MAXCTRLARRAYINDEX = 100
+static Constant EXPCONFIG_JSON_INDENT = 4
+static StrConstant EXPCONFIG_FILEFILTER = "Configuration Files (*.json):.json;All Files:.*;"
+static StrConstant EXPCONFIG_CTRLGROUP_SUFFIX = " ControlGroup"
+static StrConstant EXPCONFIG_SETTINGS_FOLDER = "Settings"
+
+// DA_Ephys specific constants
+static StrConstant DAEPHYS_UDATA_WINHANDLE = "DAEphys_WindowHandle"
+// Headstage checkboxes ctrl niceName prefix
+static StrConstant DAEPHYS_HEADSTAGECTRLARRAYPREFIX = "Check_DataAcqHS"
+static StrConstant DAEPHYS_EXCLUDE_CTRLTYPES = "12;9;10;4;"
+
+static StrConstant EXPCONFIG_DEFAULT_CTRL_JSONPATH = "Generic"
+static StrConstant EXPCONFIG_RESERVED_DATABLOCK = "Common configuration data"
+static StrConstant EXPCONFIG_RESERVED_TAGENTRY = "Target Window Type"
+
+static StrConstant EXPCONFIG_EXCLUDE_USERDATA = "ResizeControlsInfo;"
+static StrConstant EXPCONFIG_EXCLUDE_CTRLTYPES = "12;9;10;"
+
+static StrConstant EXPCONFIG_SETTINGS_AMPTITLE = "0,1;2,3;4,5;6,7"
+
+
+static StrConstant EXPCONFIG_JSON_HSASSOCBLOCK = "Headstage Association"
+static StrConstant EXPCONFIG_JSON_AMPSERIAL = "Amplifier Serial"
+static StrConstant EXPCONFIG_JSON_AMPTITLE = "Amplifier Title"
+static StrConstant EXPCONFIG_JSON_AMPVCDA = "VC DA"
+static StrConstant EXPCONFIG_JSON_AMPVCAD = "VC AD"
+static StrConstant EXPCONFIG_JSON_AMPICDA = "IC DA"
+static StrConstant EXPCONFIG_JSON_AMPICAD = "IC AD"
+static StrConstant EXPCONFIG_JSON_PRESSDEV = "Pressure Device"
+static StrConstant EXPCONFIG_JSON_PRESSDA = "Pressure DA"
+static StrConstant EXPCONFIG_JSON_PRESSAD = "Pressure AD"
+static StrConstant EXPCONFIG_JSON_PRESSDAGAIN = "Pressure DA Gain"
+static StrConstant EXPCONFIG_JSON_PRESSADGAIN = "Pressure AD Gain"
+static StrConstant EXPCONFIG_JSON_PRESSDAUNIT = "Pressure DA Unit"
+static StrConstant EXPCONFIG_JSON_PRESSADUNIT = "Pressure AD Unit"
+static StrConstant EXPCONFIG_JSON_PRESSTTLA = "Pressure TTLA"
+static StrConstant EXPCONFIG_JSON_PRESSTTLB = "Pressure TTLB"
+static StrConstant EXPCONFIG_JSON_PRESSCONSTNEG = "Pressure Constant Negative"
+static StrConstant EXPCONFIG_JSON_PRESSCONSTPOS = "Pressure Constant Positive"
+
+static StrConstant EXPCONFIG_JSON_USERPRESSBLOCK = "User Pressure Devices"
+static StrConstant EXPCONFIG_JSON_USERPRESSDEV = "DAC Device"
+static StrConstant EXPCONFIG_JSON_USERPRESSDA = "Pressure DA"
+
+static Constant EXPCONFIG_MIDDLEEXP_OFF = 0
+static Constant EXPCONFIG_MIDDLEEXP_ON = 1
+
+/// @brief Creates a json with default experiment configuration block
+///
+/// @returns json with default experiment configuration
+static Function CONF_DefaultSettings()
+
+	variable jsonID
+
+	jsonID = JSON_New()
+
+	JSON_AddString(jsonID, POSITION_MCC, NONE)
+	JSON_AddString(jsonID, STIMSET_NAME, "")
+	JSON_AddString(jsonID, SAVE_PATH, "C:MiesSave")
+
+	return jsonID
+End
+
+/// @brief Automatically loads all *.json files from MIES Settings folder and opens and restores the corresponding windows
+///        Files are restored in case-insensitive alphanumeric order.
+Function CONF_AutoLoader()
+
+	variable i, numFiles
+	string fileList, fullFilePath
+	string settingsPath = CONF_GetSettingsPath()
+
+	ASSERT(!IsEmpty(settingsPath), "Unable to resolve MIES Settings folder path. Is it present and readable in Packages\\Settings ?")
+	NewPath/O/Q PathSettings, settingsPath
+	fileList = GetAllFilesRecursivelyFromPath("PathSettings", extension = ".json")
+	fileList = SortList(fileList, "|", 4)
+	numFiles = ItemsInList(fileList, "|")
+	for(i = 0; i < numFiles; i += 1)
+		fullFilePath = StringFromList(i, fileList, "|")
+		CONF_RestoreWindow(fullFilePath, usePanelTypeFromFile = 1)
+	endfor
+End
+
+/// @brief Returns the path to the settings folder
+///
+/// @returns string with full path to MIES Settings folder
+static Function/S CONF_GetSettingsPath()
+
+	variable numItems
+	string reflectedProcpath = FunctionPath("CONF_GetSettingsPath")
+
+	numItems = ItemsInList(reflectedProcpath, ":")
+	if(numItems < 2)
+		return ""
+	endif
+	reflectedProcpath = RemoveListItem(numItems - 1, reflectedProcpath, ":")
+	reflectedProcpath = RemoveListItem(numItems - 2, reflectedProcpath, ":") + EXPCONFIG_SETTINGS_FOLDER + ":"
+	GetFileFolderInfo/Q/Z reflectedProcpath
+	if(!V_Flag && V_isFolder)
+		return reflectedProcpath
+	endif
+
+	return ""
+End
+
+/// @brief Saves the GUI state of a window and all of its subwindows to a configuration file
+///
+/// @param fName file name of configuration file to save configuration
+Function CONF_SaveWindow(fName)
+	string fName
+
+	variable i, jsonID, saveMask, saveResult
+	string out, wName, errMsg
+
+	try
+		wName = GetMainWindow(GetCurrentWindow())
+		if(!CmpStr(wName, "HistoryCarbonCopy"))
+			printf "Please select a window.\r"
+			ControlWindowToFront()
+			return NaN
+		endif
+		if(PanelIsType(wName, PANELTAG_DAEPHYS))
+			CONF_SaveDAEphys(fName)
+		else
+			saveMask = EXPCONFIG_SAVE_VALUE
+			jsonID = CONF_AllWindowsToJSON(wName, saveMask, excCtrlTypes = EXPCONFIG_EXCLUDE_CTRLTYPES)
+			out = JSON_Dump(jsonID, indent = EXPCONFIG_JSON_INDENT)
+			JSON_Release(jsonID)
+
+			saveResult = SaveTextFile(out, fName, fileFilter = EXPCONFIG_FILEFILTER, message = "Save configuration file for window")
+			if(!IsNaN(saveResult))
+				print "Configuration saved."
+			else
+				print "Save FAILED!"
+			endif
+		endif
+	catch
+		errMsg = getRTErrMessage()
+		if(getRTError(1))
+			ASSERT(0, errMsg)
+		else
+			Abort
+		endif
+	endtry
+End
+
+/// @brief Restores the GUI state of window and all of its subwindows from a configuration file
+///
+/// @param fName file name of configuration file to read configuration
+/// @param usePanelTypeFromFile [optional, default = 0] if set to 1 then the panel type from the json is interpreted and a new panel of that type is opened
+Function CONF_RestoreWindow(fName[, usePanelTypeFromFile])
+	string fName
+	variable usePanelTypeFromFile
+
+	variable jsonID, restoreMask
+	string input, wName, errMsg, fullFilePath, panelType
+
+	usePanelTypeFromFile = ParamIsDefault(usePanelTypeFromFile) ? 0 : !!usePanelTypeFromFile
+
+	jsonID = NaN
+	restoreMask = EXPCONFIG_SAVE_VALUE | EXPCONFIG_SAVE_USERDATA | EXPCONFIG_SAVE_DISABLED
+	try
+		if(usePanelTypeFromFile)
+			[input, fullFilePath] = LoadTextFile(fName, fileFilter = EXPCONFIG_FILEFILTER, message = "Open configuration file")
+			if(IsEmpty(input))
+				return 0
+			endif
+			jsonID = CONF_ParseJSON(input)
+			panelType = JSON_GetString(jsonID, "/" + EXPCONFIG_RESERVED_TAGENTRY)
+			ASSERT(!IsEmpty(panelType), "Configuration file entry for panel type (" + EXPCONFIG_RESERVED_TAGENTRY + ") is empty.")
+			if(!CmpStr(panelType, PANELTAG_DAEPHYS))
+				CONF_RestoreDAEphys(jsonID, fullFilePath, forceNewPanel = 1)
+			elseif(!CmpStr(panelType, PANELTAG_DATABROWSER))
+				DB_OpenDataBrowser()
+				wName = GetMainWindow(GetCurrentWindow())
+				SetWindow $wName, userData($EXPCONFIG_UDATA_SOURCEFILE)=""
+				wName = CONF_JSONToWindow(wName, restoreMask, jsonID)
+				SetWindow $wName, userData($EXPCONFIG_UDATA_SOURCEFILE)=fullFilePath
+				print "Configuration restored for " + wName
+			else
+				ASSERT(0, "Configuration file entry for panel type has an unknown panel tag (" + panelType + ").")
+			endif
+
+		else
+			wName = GetMainWindow(GetCurrentWindow())
+			if(PanelIsType(wName, PANELTAG_DAEPHYS))
+				[input, fullFilePath] = LoadTextFile(fName, fileFilter = EXPCONFIG_FILEFILTER, message = "Open configuration file for DA_Ephys panel")
+				if(IsEmpty(input))
+					return 0
+				endif
+				jsonID = CONF_ParseJSON(input)
+				CONF_RestoreDAEphys(jsonID, fullFilePath)
+			else
+				[input, fullFilePath] = LoadTextFile(fName, fileFilter = EXPCONFIG_FILEFILTER, message = "Open configuration file for frontmost window")
+				if(IsEmpty(input))
+					return 0
+				endif
+				jsonID = CONF_ParseJSON(input)
+				SetWindow $wName, userData($EXPCONFIG_UDATA_SOURCEFILE)=""
+				wName = CONF_JSONToWindow(wName, restoreMask, jsonID)
+				SetWindow $wName, userData($EXPCONFIG_UDATA_SOURCEFILE)=fullFilePath
+				print "Configuration restored for " + wName
+			endif
+		endif
+	catch
+		errMsg = getRTErrMessage()
+		if(!IsNaN(jsonID))
+			JSON_Release(jsonID)
+		endif
+		if(getRTError(1))
+			ASSERT(0, errMsg)
+		else
+			Abort
+		endif
+	endtry
+	JSON_Release(jsonID)
+End
+
+/// @brief Saves the GUI state of a DA_Ephys panel to a configuration file
+///
+/// @param fName file name of configuration file to store DA_Ephys configuration
+static Function CONF_SaveDAEphys(fName)
+	string fName
+
+	variable i, jsonID, saveMask, saveResult
+	string out, wName, errMsg
+
+	try
+		wName = GetMainWindow(GetCurrentWindow())
+		ASSERT(PanelIsType(wName, PANELTAG_DAEPHYS), "Current window is no DA_Ephys panel")
+
+		saveMask = EXPCONFIG_SAVE_VALUE | EXPCONFIG_SAVE_POPUPMENU_AS_STRING_ONLY | EXPCONFIG_SAVE_BUTTONS_ONLY_PRESSED | EXPCONFIG_SAVE_ONLY_RELEVANT
+		jsonID = CONF_AllWindowsToJSON(wName, saveMask, excCtrlTypes = DAEPHYS_EXCLUDE_CTRLTYPES)
+
+		JSON_SetJSON(jsonID, EXPCONFIG_RESERVED_DATABLOCK, CONF_DefaultSettings())
+		JSON_SetJSON(jsonID, EXPCONFIG_RESERVED_DATABLOCK + "/" + EXPCONFIG_JSON_HSASSOCBLOCK, CONF_GetHeadstageAssociation(wName))
+		JSON_SetJSON(jsonID, EXPCONFIG_RESERVED_DATABLOCK + "/" + EXPCONFIG_JSON_USERPRESSBLOCK, CONF_GetUserPressure(wName))
+
+		out = JSON_Dump(jsonID, indent = EXPCONFIG_JSON_INDENT)
+		JSON_Release(jsonID)
+
+		saveResult = SaveTextFile(out, fName, fileFilter = EXPCONFIG_FILEFILTER, message = "Save configuration file for DA_Ephys panel")
+		if(!IsNaN(saveResult))
+			print "Configuration saved."
+		endif
+	catch
+		errMsg = getRTErrMessage()
+		if(getRTError(1))
+			ASSERT(0, errMsg)
+		else
+			Abort
+		endif
+	endtry
+End
+
+/// @brief Restores the GUI state of a DA_Ephys panel from a configuration file
+///
+/// @param jsonID json ID of json object to restore DA_Ephys panel from
+/// @param fullFilePath full file path of the file where the json object was parsed from
+/// @param middleOfExperiment [optional, default = 0] Allows MIES config in the middle of experiment. Instead of setting MCC parameters they are pulled from actively recording MCCs to configure MIES]
+/// @param forceNewPanel [optional, default = 0] When set opens always a fresh DA_Ephys panel, otherwise follows this priority order:
+///                      - Reuses locked DA_Ephys panel with same device as saved in configuration
+///                      - Uses open unlocked DA_Ephys panel
+///                      - Opens new DA_Ephys panel
+Function CONF_RestoreDAEphys(jsonID, fullFilePath, [middleOfExperiment, forceNewPanel])
+	variable jsonID
+	string fullFilePath
+	variable middleOfExperiment, forceNewPanel
+
+	variable i, fnum, restoreMask, numPotentialUnlocked, err, winConfigChanged, isTagged
+	string panelTitle, getWName, jsonPath, potentialUnlockedList, winHandle, errMsg
+	string AmpSerialLocal, AmpTitleLocal, device, StimSetPath, path, filename, rStateSync
+	string input = ""
+
+	try
+		middleOfExperiment = ParamIsDefault(middleOfExperiment) ? 0 : !!middleOfExperiment
+		forceNewPanel = ParamIsDefault(forceNewPanel) ? 0 : !!forceNewPanel
+
+		if(forceNewPanel)
+			panelTitle = DAP_CreateDAEphysPanel()
+		else
+			device = CONF_GetStringFromSavedControl(jsonID, "popup_MoreSettings_Devices")
+			panelTitle = ""
+			if(WindowExists(device))
+				panelTitle = device
+				if(PanelIsType(panelTitle, PANELTAG_DAEPHYS))
+					winHandle = num2istr(GetUniqueInteger())
+					SetWindow $panelTitle, userdata($EXPCONFIG_UDATA_WINHANDLE) = winHandle
+					PGC_SetAndActivateControl(panelTitle, "button_SettingsPlus_unLockDevic")
+					panelTitle = CONF_FindWindow(winHandle)
+					ASSERT(!IsEmpty(panelTitle), "Could not find unlocked window, did it close?")
+				endif
+			endif
+			if(IsEmpty(panelTitle))
+				potentialUnlockedList = GetListOfUnlockedDevices()
+				if(!IsEmpty(potentialUnlockedList))
+					numPotentialUnlocked = ItemsInList(potentialUnlockedList)
+					for(i = 0; i < numPotentialUnlocked; i += 1)
+						panelTitle = StringFromList(i, potentialUnlockedList)
+						if(PanelIsType(panelTitle, PANELTAG_DAEPHYS))
+							break
+						endif
+					endfor
+				endif
+			endif
+			if(IsEmpty(panelTitle))
+				panelTitle = DAP_CreateDAEphysPanel()
+			endif
+		endif
+
+		SetWindow $panelTitle, userData($EXPCONFIG_UDATA_SOURCEFILE)=""
+
+		if(middleOfExperiment)
+			PGC_SetAndActivateControl(panelTitle, "check_Settings_SyncMiesToMCC", val = CHECKBOX_UNSELECTED)
+			rStateSync = GetUserData(panelTitle, "check_Settings_SyncMiesToMCC", EXPCONFIG_UDATA_EXCLUDE_RESTORE)
+			ModifyControl $"check_Settings_SyncMiesToMCC" win=$panelTitle, userdata($EXPCONFIG_UDATA_EXCLUDE_RESTORE)="1"
+			winConfigChanged = 1
+		endif
+
+		StimSetPath = CONF_GetStringFromSettings(jsonID, STIMSET_NAME)
+		if(IsEmpty(StimSetPath))
+			err = NWB_LoadAllStimSets(overwrite = 1)
+		else
+			err = NWB_LoadAllStimSets(overwrite = 1, fileName = StimSetPath)
+		endif
+		if(err)
+			print "Stim set failed to load, check file path"
+			ControlWindowToFront()
+		endif
+
+		restoreMask = EXPCONFIG_SAVE_VALUE | EXPCONFIG_SAVE_POPUPMENU_AS_STRING_ONLY | EXPCONFIG_SAVE_DISABLED | EXPCONFIG_SAVE_ONLY_RELEVANT | EXPCONFIG_MINIMIZE_ON_RESTORE
+		winHandle = num2istr(GetUniqueInteger())
+		SetWindow $panelTitle, userdata($DAEPHYS_UDATA_WINHANDLE) = winHandle
+		isTagged = 1
+		panelTitle = CONF_JSONToWindow(panelTitle, restoreMask, jsonID)
+		isTagged = 0
+		SetWindow $panelTitle, userdata($DAEPHYS_UDATA_WINHANDLE) = ""
+		if(restoreMask & EXPCONFIG_MINIMIZE_ON_RESTORE)
+			SetWindow $panelTitle, hide=1
+		endif
+
+		if(middleOfExperiment)
+			ModifyControl $"check_Settings_SyncMiesToMCC" win=$panelTitle, userdata($EXPCONFIG_UDATA_EXCLUDE_RESTORE)=rStateSync
+		endif
+
+		CONF_RestoreHeadstageAssociation(panelTitle, jsonID, middleOfExperiment)
+		CONF_RestoreUserPressure(panelTitle, jsonID)
+
+		SetWindow $panelTitle, userData($EXPCONFIG_UDATA_SOURCEFILE)=fullFilePath
+
+		filename = GetTimeStamp() + PACKED_FILE_EXPERIMENT_SUFFIX
+		path = CONF_GetStringFromSettings(jsonID, SAVE_PATH)
+
+		if(IsDriveValid(path))
+			CreateFolderOnDisk(path)
+		endif
+
+		NewPath/C/O SavePath, path
+
+		SaveExperiment /P=SavePath as filename
+
+		KillPath/Z SavePath
+
+		PGC_SetAndActivateControl(panelTitle, "StartTestPulseButton", switchTab = 1)
+
+		print "Start Sciencing"
+		SetWindow $panelTitle, hide=0, needUpdate=1
+
+	catch
+		if(isTagged)
+			panelTitle = CONF_FindWindow(winHandle, uKey = DAEPHYS_UDATA_WINHANDLE)
+		endif
+		if(!IsEmpty(panelTitle) && WindowExists(panelTitle))
+			SetWindow $panelTitle, userdata($DAEPHYS_UDATA_WINHANDLE) = ""
+			if(middleOfExperiment & winConfigChanged)
+				ModifyControl $"check_Settings_SyncMiesToMCC" win=$panelTitle, userdata($EXPCONFIG_UDATA_EXCLUDE_RESTORE)=rStateSync
+			endif
+			SetWindow $panelTitle, hide=0, needUpdate=1
+		endif
+		errMsg = getRTErrMessage()
+		if(getRTError(1))
+			ASSERT(0, errMsg)
+		else
+			Abort
+		endif
+	endtry
+End
+
+/// @brief Parses a json formatted string to a json object. This function shows a helpful error message if the parse fails
+///
+/// @param[in] str string in json format
+/// @returns jsonID of the json object
+static Function CONF_ParseJSON(str)
+	string str
+
+	variable err
+
+	try
+		JSONXOP_Parse/Z=0/Q=0 str; AbortOnRTE
+		return V_Value
+	catch
+		err = getRTError(1)
+		ASSERT(0, "The text from the configuration file could not be parsed.\rThe above information helps to find the problematic location.\r")
+	endtry
+
+	return NaN
+End
+
+/// @brief Retrieves list of active headstages saved in a DA_Ephys configuration file
+///
+/// @param jsonID  ID of existing json
+/// @returns List of active head stages
+static Function/S CONF_GetDAEphysActiveHeadstages(jsonID)
+	variable jsonID
+
+	WAVE hsStates = CONF_GetWaveFromSavedControlArray(jsonID, DAEPHYS_HEADSTAGECTRLARRAYPREFIX)
+	return NumericWaveToList(hsStates, ";")
+end
+
+/// @brief Checks if EXPCONFIG_RESERVED_DATABLOCK exists in json; ASSERTion is thrown if not found.
+///
+/// @param jsonID  ID of existing json
+static Function CONF_RequireConfigBlockExists(jsonID)
+	variable jsonID
+
+	WAVE/T ctrlGroups = JSON_GetKeys(jsonID, "")
+	FindValue/TXOP=4/TEXT=EXPCONFIG_RESERVED_DATABLOCK ctrlGroups
+	ASSERT(V_Value >= 0, "\"" + EXPCONFIG_RESERVED_DATABLOCK + "\" block in config file not found.")
+End
+
+/// @brief Retrieves a string value from a setting
+///
+/// @param jsonID  ID of existing json
+/// @param keyName key name of setting
+/// @returns string from member with keyname in the EXPCONFIG_RESERVED_DATABLOCK
+static Function/S CONF_GetStringFromSettings(jsonID, keyName)
+	variable jsonID
+	string keyName
+
+	CONF_RequireConfigBlockExists(jsonID)
+	return JSON_GetString(jsonID, EXPCONFIG_RESERVED_DATABLOCK + "/" + keyName)
+End
+
+/// @brief Retrieves a variable value from a setting
+///
+/// @param jsonID  ID of existing json
+/// @param keyName key name of setting
+/// @returns value of member with keyname in the EXPCONFIG_RESERVED_DATABLOCK
+static Function CONF_GetVariableFromSettings(jsonID, keyName)
+	variable jsonID
+	string keyName
+
+	CONF_RequireConfigBlockExists(jsonID)
+	return JSON_GetVariable(jsonID, EXPCONFIG_RESERVED_DATABLOCK + "/" + keyName)
+End
+
+/// @brief Retrieves a boolean value from a saved control
+///        note: boolean control property values are also saved in the EXPCONFIG_FIELD_CTRLVVALUE field
+///
+/// @param jsonID  ID of existing json
+/// @param keyName key name of setting
+/// @returns value of the EXPCONFIG_FIELD_CTRLVVALUE field of the control
+static Function CONF_GetBooleanFromSettings(jsonID, keyName)
+	variable jsonID
+	string keyName
+
+	return CONF_GetVariableFromSettings(jsonID, keyName)
+End
+
+/// @brief Returns the path to the first control named nicename found in the json in all saved windows
+///        This might as well be a ControlArray.
+///
+/// @param jsonID   ID of existing json
+/// @param niceName nice name of control
+/// @returns Path to control in json, empty string if not found
+static Function/S CONF_FindControl(jsonID, niceName)
+	variable jsonID
+	string niceName
+
+	variable i, numWindows
+	string result
+
+	WAVE/T winNames = CONF_GetWindowNames(jsonID)
+	numWindows = DimSize(winNames, ROWS)
+	for(i = 0; i < numWindows; i += 1)
+		result = CONF_TraversalFinder(jsonID, winNames[i], niceName)
+		if(!IsEmpty(result))
+			return result
+		endif
+	endfor
+
+	return ""
+End
+
+/// @brief Returns the path to the first control named nicename found traversing the json starting at basePath
+///        This might as well be a ControlArray. This function runs recursively.
+///
+/// @param jsonID   ID of existing json
+/// @param basePath root of traversal start
+/// @param niceName nice name of control
+/// @returns Path to control in json, empty string if not found
+static Function/S CONF_TraversalFinder(jsonID, basePath, niceName)
+	variable jsonID
+	string basePath, niceName
+
+
+	variable i, numElems
+	string result
+
+	WAVE/T ctrlGroups = JSON_GetKeys(jsonID, basePath)
+
+	WAVE/T/Z ctrlSubGroups
+	WAVE/T/Z niceNames
+	[ctrlSubGroups, niceNames] = SplitTextWaveBySuffix(ctrlGroups, EXPCONFIG_CTRLGROUP_SUFFIX)
+	FindValue/TXOP=4/TEXT=niceName niceNames
+	if(V_Value >= 0)
+		return basePath + "/" + niceName
+	endif
+
+	numElems = DimSize(ctrlSubGroups, ROWS)
+	for(i = 0; i < numElems; i += 1)
+		result = CONF_TraversalFinder(jsonID, basePath + "/" + ctrlSubGroups[i], niceName)
+		if(!IsEmpty(result))
+			return result
+		endif
+	endfor
+
+	return ""
+End
+
+/// @brief Retrieves a wave from a saved ControlArray
+///        It is REQUIRED that ALL ELEMENTS of the ControlArray are of NUMERIC type
+///
+/// @param jsonID    ID of existing json
+/// @param arrayName name of ControlArray
+/// @returns text wave with data from ControlArray
+static Function/WAVE CONF_GetWaveFromSavedControlArray(jsonID, arrayName)
+	variable jsonID
+	string arrayName
+
+	string arrayPath = CONF_FindControl(jsonID, arrayName)
+	ASSERT(!IsEmpty(arrayPath), "Can not find ControlArray " + arrayName + " in config file.")
+	return JSON_GetWave(jsonID, arrayPath + "/" + EXPCONFIG_FIELD_CTRLARRAYVALUES)
+End
+
+/// @brief Retrieves a string value from a saved control
+///
+/// @param jsonID   ID of existing json
+/// @param niceName nice name of control
+/// @returns value of the EXPCONFIG_FIELD_CTRLSVALUE field of the control
+static Function/S CONF_GetStringFromSavedControl(jsonID, niceName)
+	variable jsonID
+	string niceName
+
+	string ctrlPath = CONF_FindControl(jsonID, niceName)
+	ASSERT(!IsEmpty(ctrlPath), "Can not find control " + niceName + " in config file.")
+	return JSON_GetString(jsonID, ctrlPath + "/" + EXPCONFIG_FIELD_CTRLSVALUE)
+End
+
+/// @brief Retrieves a variable value from a saved control
+///
+/// @param jsonID   ID of existing json
+/// @param niceName nice name of control
+/// @returns value of the EXPCONFIG_FIELD_CTRLVVALUE field of the control
+static Function CONF_GetVariableFromSavedControl(jsonID, niceName)
+	variable jsonID
+	string niceName
+
+	string ctrlPath = CONF_FindControl(jsonID, niceName)
+	ASSERT(!IsEmpty(ctrlPath), "Can not find control " + niceName + " in config file.")
+	return JSON_GetVariable(jsonID, ctrlPath + "/" + EXPCONFIG_FIELD_CTRLVVALUE)
+End
+
+/// @brief Returns a wave with all configuration sections ( aka control groups).
+///        This equals the top level keys without the EXPCONFIG_RESERVED_DATABLOCK key.
+///
+/// @param[in] jsonID ID of existing json
+/// @returns Text wave with all named configuration sections
+static Function/WAVE CONF_GetWindowNames(jsonID)
+	variable jsonID
+
+	WAVE/T ctrlGroups = JSON_GetKeys(jsonID, "")
+	RemoveTextWaveEntry1D(ctrlGroups, EXPCONFIG_RESERVED_DATABLOCK)
+	RemoveTextWaveEntry1D(ctrlGroups, EXPCONFIG_RESERVED_TAGENTRY)
+
+	return ctrlGroups
+End
+
+/// @brief Returns a two column free wave with ControlArrayName and associated control list from a window
+///
+/// @param[in] wName Name of window
+/// @returns Text wave with two columns and in each row ControlArray name (column ARRAYNAME) and control list (column CTRLNAMELIST)
+static Function/WAVE CONF_GetControlArrayList(wName)
+	string wName
+
+	string ctrlList, ctrlName, arrayName
+	variable i, numWinCtrl, col1, numCtrlArrays
+
+	ctrlList = ControlNameList(wName, ";", "*")
+	numWinCtrl = ItemsInList(ctrlList)
+
+	Make/FREE/T/N=(MINIMUM_WAVE_SIZE, 2) ctrlArrays
+	SetDimLabel COLS, 0, ARRAYNAME, ctrlArrays
+	SetDimLabel COLS, 1, CTRLNAMELIST, ctrlArrays
+
+	col1 = FindDimLabel(ctrlArrays, COLS, "ARRAYNAME")
+	for(i = 0; i < numWinCtrl; i += 1)
+		ctrlName = StringFromList(i, ctrlList)
+		arrayName = GetUserData(wName, ctrlName, EXPCONFIG_UDATA_CTRLARRAY)
+		if(!IsEmpty(arrayName))
+			FindValue/RMD=[][col1]/TXOP=4/TEXT=arrayName ctrlArrays
+			if(V_Value >= 0)
+				ctrlArrays[V_Row][%CTRLNAMELIST] = AddListItem(ctrlName, ctrlArrays[V_Row][%CTRLNAMELIST])
+			else
+				EnsureLargeEnoughWave(ctrlArrays, dimension = ROWS, minimumSize = numCtrlArrays)
+				ctrlArrays[numCtrlArrays][%ARRAYNAME] = arrayName
+				ctrlArrays[numCtrlArrays][%CTRLNAMELIST] = ctrlName
+				numCtrlArrays += 1
+			endif
+		endif
+	endfor
+
+	return ctrlArrays
+End
+
+/// @brief Gathers recursively all control nice names and control paths from a configuration json by traversing all sub objects.
+///
+/// @param[in] ctrlData ctrlData wave, 2d four column text wave as created in CONF_JSONToWindow(). This wave is updated by this function.
+/// @param[in] jsonID json object to traverse
+/// @param[in] basePath root path for traversal
+static Function CONF_GatherControlsFromJSON(ctrlData, jsonID, basePath)
+	WAVE/T ctrlData
+	variable jsonID
+	string basePath
+
+	variable i, numElems, offset
+
+	WAVE/T ctrlGroups = JSON_GetKeys(jsonID, basePath)
+	if(!DimSize(ctrlGroups, ROWS))
+		return 0
+	endif
+
+	WAVE/T/Z ctrlSubGroups
+	WAVE/T/Z niceNames
+	[ctrlSubGroups, niceNames] = SplitTextWaveBySuffix(ctrlGroups, EXPCONFIG_CTRLGROUP_SUFFIX)
+
+	numElems = DimSize(ctrlSubGroups, ROWS)
+	for(i = 0; i < numElems; i += 1)
+		CONF_GatherControlsFromJSON(ctrlData, jsonID, basePath + "/" + ctrlSubGroups[i])
+	endfor
+
+	numElems = DimSize(niceNames, ROWS)
+	if(!numElems)
+		return 0
+	endif
+	offset = DimSize(ctrlData, ROWS)
+	Redimension/N=(numElems + offset, 4) ctrlData
+	ctrlData[offset, offset + numElems - 1][%JSONPATH] = basePath + "/" + niceNames[p - offset]
+	ctrlData[offset, offset + numElems - 1][%NICENAME] = niceNames[p - offset]
+End
+
+/// @brief Restores GUI state of a window from a json
+///        The following userdata properties are considered: EXPCONFIG_UDATA_EXCLUDE_RESTORE, EXPCONFIG_UDATA_RESTORE_PRIORITY
+///        It is supported that the current main reference window in the GUI changes its name. It is not supported
+///        that a not yet restored subwindow of it changes its name.
+///
+/// @param wName       main reference window name in GUI
+/// @param restoreMask Bit mask which properties are restored from WindowControlSavingMask constants
+/// @param jsonID      ID of existing json
+/// @returns name of main window after restore
+Function/S CONF_JSONToWindow(wName, restoreMask, jsonID)
+	string wName
+	variable restoreMask, jsonID
+	string excludeList
+
+	variable i, colNiceName, colArrayName, colCtrlName, winNum, numCtrl, numWinCtrl, numGroups, numNice, offset, numWindows, numCtrlArrays, numArrayElem, isTagged
+	variable arrayNameIndex
+	string ctrlName, niceName, arrayName, ctrlList, wList, uData, winHandle, jsonCtrlGroupPath, subWinTarget, str, errMsg
+
+	try
+
+		ASSERT(WinType(wName), "Window " + wName + " does not exist!")
+		ASSERT(restoreMask & (EXPCONFIG_SAVE_VALUE | EXPCONFIG_SAVE_POSITION | EXPCONFIG_SAVE_USERDATA | EXPCONFIG_SAVE_DISABLED | EXPCONFIG_SAVE_CTRLTYPE), "No property class enabled to restore in restoreMask.")
+
+		if(restoreMask & EXPCONFIG_MINIMIZE_ON_RESTORE)
+			SetWindow $wName, hide=1
+		endif
+		WAVE/T srcWinNames = CONF_GetWindowNames(jsonID)
+		Duplicate/FREE/T srcWinNames tgtWinNames
+		tgtWinNames[] = RemoveListItem(0, srcWinNames[p], "#")
+
+		numWindows = DimSize(srcWinNames, ROWS)
+		for(winNum = 0; winNum < numWindows; winNum += 1)
+			str = tgtWinNames[winNum]
+			subWinTarget = SelectString(IsEmpty(str), wName + "#" + str, wName)
+			ASSERT(WinType(subWinTarget), "Window " + subWinTarget + " does not exist!")
+
+			Make/FREE/T/N=(0, 4) ctrlData
+			SetDimLabel COLS, 0, NICENAME, ctrlData
+			SetDimLabel COLS, 1, CTRLNAME, ctrlData
+			SetDimLabel COLS, 2, JSONPATH, ctrlData
+			SetDimLabel COLS, 3, PRIORITY, ctrlData
+
+			CONF_GatherControlsFromJSON(ctrlData, jsonID, srcWinNames[winNum])
+
+			colNiceName = FindDimLabel(ctrlData, COLS, "NICENAME")
+			numCtrl = DimSize(ctrlData, ROWS)
+			if(numCtrl > 1)
+				Duplicate/FREE/RMD=[][colNiceName] ctrlData ctrlNiceNames
+				Redimension/N=(numCtrl) ctrlNiceNames
+				FindDuplicates/DT=dupWave ctrlNiceNames
+				ASSERT(DimSize(dupWave, ROWS) == 0, "Found duplicates in control names in configuration file for window " + subWinTarget)
+			endif
+
+			WAVE/T ctrlArrays = CONF_GetControlArrayList(subWinTarget)
+			Make/FREE/B/U/N=(DimSize(ctrlArrays, ROWS)) ctrlArrayAdded
+			ctrlList = ControlNameList(subWinTarget, ";", "*")
+			numWinCtrl = ItemsInList(ctrlList)
+			colArrayName = FindDimLabel(ctrlArrays, COLS, "ARRAYNAME")
+			for(i = 0; i < numWinCtrl; i += 1)
+				ctrlName = StringFromList(i, ctrlList)
+				arrayName = GetUserData(subWinTarget, ctrlName, EXPCONFIG_UDATA_CTRLARRAY)
+				if(!IsEmpty(arrayName))
+					FindValue/RMD=[][colArrayName]/TXOP=4/TEXT=arrayName ctrlArrays
+					if(V_Value >= 0)
+						if(!ctrlArrayAdded[V_Row])
+							arrayNameIndex = V_Row
+							FindValue/RMD=[][colNiceName]/TXOP=4/TEXT=arrayName ctrlData
+							if(V_Value >= 0)
+								jsonCtrlGroupPath = ctrlData[V_Row][%JSONPATH]
+								DeletePoints V_Row, 1, ctrlData
+								numArrayElem = ItemsInList(ctrlArrays[arrayNameIndex][%CTRLNAMELIST])
+								numCtrl = DimSize(ctrlData, ROWS)
+								Redimension/N=(numCtrl + numArrayElem, 4) ctrlData
+								ctrlData[numCtrl, numCtrl + numArrayElem - 1][%NICENAME] = arrayName
+								ctrlData[numCtrl, numCtrl + numArrayElem - 1][%CTRLNAME] = StringFromList(p - numCtrl, ctrlArrays[arrayNameIndex][%CTRLNAMELIST])
+								ctrlData[numCtrl, numCtrl + numArrayElem - 1][%JSONPATH] = jsonCtrlGroupPath
+								ctrlData[numCtrl, numCtrl + numArrayElem - 1][%PRIORITY] = GetUserData(subWinTarget, ctrlData[p][%CTRLNAME], EXPCONFIG_UDATA_RESTORE_PRIORITY)
+								ctrlData[numCtrl, numCtrl + numArrayElem - 1][%PRIORITY] = SelectString(strlen(ctrlData[p][%PRIORITY]), "Inf", ctrlData[p][%PRIORITY])
+								ctrlArrayAdded[arrayNameIndex] = 1
+							endif
+						endif
+					else
+						printf "ControlArray %s from config file does not exist in window %s.\r", arrayName, subWinTarget
+					endif
+				else
+					niceName = GetUserData(subWinTarget, ctrlName, EXPCONFIG_UDATA_NICENAME)
+					niceName = SelectString(IsEmpty(niceName), niceName, ctrlName)
+					FindValue/RMD=[][colNiceName]/TXOP=4/TEXT=niceName ctrlData
+					if(V_Value >= 0)
+						ctrlData[V_Row][%CTRLNAME] = ctrlName
+						uData = GetUserData(subWinTarget, ctrlName, EXPCONFIG_UDATA_RESTORE_PRIORITY)
+						ctrlData[V_Row][%PRIORITY] = SelectString(IsEmpty(uData), uData, "Inf")
+					endif
+				endif
+			endfor
+
+			numCtrl = DimSize(ctrlData, ROWS)
+			for(i = numCtrl - 1; i >= 0; i -= 1)
+				if(!CmpStr(GetUserData(subWinTarget, ctrlData[i][%CTRLNAME], EXPCONFIG_UDATA_EXCLUDE_RESTORE), "1"))
+					DeletePoints i, 1, ctrlData
+				endif
+			endfor
+
+			colCtrlName = FindDimLabel(ctrlData, COLS, "CTRLNAME")
+			do
+				FindValue/RMD=[][colCtrlName]/TXOP=4/TEXT="" ctrlData
+				if(V_Value >= 0)
+					printf "Control %s from config file does not exist in window %s.\r", ctrlData[V_Row][%NICENAME], subWinTarget
+					DeletePoints V_Row, 1, ctrlData
+				endif
+			while(V_Value >= 0)
+
+			numCtrl = DimSize(ctrlData, ROWS)
+			if(!numCtrl)
+				return wName
+			endif
+			Make/FREE/N=(numCtrl) prioritySort
+			prioritySort[] = str2num(ctrlData[p][%PRIORITY])
+			SortColumns keyWaves={prioritySort}, sortWaves={ctrlData}
+
+			winHandle = num2istr(GetUniqueInteger())
+			SetWindow $subWinTarget, userdata($EXPCONFIG_UDATA_WINHANDLE) = winHandle
+			isTagged = 1
+			for(i = 0; i < numCtrl; i += 1)
+				CONF_RestoreControl(subWinTarget, restoreMask, jsonID, ctrlData[i][%CTRLNAME], jsonPath = ctrlData[i][%JSONPATH])
+				subWinTarget = CONF_FindWindow(winHandle)
+				ASSERT(!IsEmpty(subWinTarget), "Could not find window, did it close?")
+			endfor
+			wName = GetMainWindow(subWinTarget)
+			isTagged = 0
+			SetWindow $subWinTarget, userdata($EXPCONFIG_UDATA_WINHANDLE) = ""
+		endfor
+		if(restoreMask & EXPCONFIG_MINIMIZE_ON_RESTORE)
+			SetWindow $wName, hide=0, needUpdate=1
+		endif
+
+	catch
+		if(isTagged)
+			wName = CONF_FindWindow(winHandle, uKey = EXPCONFIG_UDATA_WINHANDLE)
+		endif
+		if(!IsEmpty(wName) && WindowExists(wName))
+			SetWindow $wName, hide=0, needUpdate=1
+		endif
+		errMsg = getRTErrMessage()
+		if(getRTError(1))
+			ASSERT(0, errMsg)
+		else
+			Abort
+		endif
+	endtry
+
+	return wName
+End
+
+/// @brief Returns the window with the set window handle
+///
+/// @param winHandle window handle
+/// @param uKey      [optional, default = EXPCONFIG_UDATA_WINHANDLE] userdata key that stores the handle value
+/// @returns Window name of the window with the given handle; empty string if not found.
+static Function/S CONF_FindWindow(winHandle[, uKey])
+	string winHandle, uKey
+
+	variable i, j, numWin, numSubWin
+	string wList, wName, wSubList
+
+	uKey = SelectString(ParamIsDefault(uKey), uKey, EXPCONFIG_UDATA_WINHANDLE)
+	wList = WinList("*", ";", "WIN:87")
+	numWin = ItemsInList(wList)
+	for(i = 0; i < numWin; i += 1)
+		wName = StringFromList(i, wList)
+		wSubList = ""
+		GetAllWindows(wName, wSubList)
+		numSubWin = ItemsInList(wSubList)
+		for(j = 0; j < numSubWin; j += 1)
+			wName = StringFromList(j, wSubList)
+			if(!CmpStr(winHandle, GetUserData(wName, "", uKey)))
+				return wName
+			endif
+		endfor
+	endfor
+
+	return ""
+End
+
+/// @brief Restores properties of a control from a json
+///        The following control userdata properties are considered: EXPCONFIG_UDATA_EXCLUDE_RESTORE; EXPCONFIG_UDATA_BUTTONPRESS (for Buttons)
+///
+/// @param wName       Window name
+/// @param restoreMask Bit mask which properties are restored from WindowControlSavingMask constants
+/// @param jsonID      ID of existing json
+/// @param ctrlName    Control name
+/// @param jsonPath    [optional, default = n/a] When given: the control is expected to be a named json object (with the control nice name)
+///                    If not given: the jsons second level (assuming default format) is searched for the associated object. This is slower.
+static Function CONF_RestoreControl(wName, restoreMask, jsonID, ctrlName[, jsonPath])
+	string wName
+	variable restoreMask, jsonID
+	string ctrlName, jsonPath
+
+	string ctrlTypeName, uData, uKey, base64Key, str, wList, niceName, arrayName, arrayElemPath
+	variable i, base64Entries, ctrlType, setVarType, varTypeGlobal, val, numGroups, arrayElemType
+	variable VHeight, VWidth, VTop, VLeft, VRight, VPos, VAlign
+	variable VDisabled
+	variable numUdataKeys, arrayIndex, arraySize
+
+	ASSERT((restoreMask & (EXPCONFIG_SAVE_POPUPMENU_AS_STRING_ONLY | EXPCONFIG_SAVE_POPUPMENU_AS_INDEX_ONLY)) != (EXPCONFIG_SAVE_POPUPMENU_AS_STRING_ONLY | EXPCONFIG_SAVE_POPUPMENU_AS_INDEX_ONLY), "Invalid popup menu restore selection. String only and Index only can not be set at the same time.")
+	ASSERT(WinType(wName), "Window " + wName + " does not exist!")
+
+	if(!CmpStr(GetUserData(wName, ctrlName, EXPCONFIG_UDATA_EXCLUDE_RESTORE), "1"))
+		return NaN
+	endif
+
+	arrayName = GetUserData(wName, ctrlName, EXPCONFIG_UDATA_CTRLARRAY)
+	if(ParamIsDefault(jsonPath))
+		niceName = GetUserData(wName, ctrlName, EXPCONFIG_UDATA_NICENAME)
+		niceName = SelectString(IsEmpty(niceName), niceName, ctrlName)
+		niceName = SelectString(IsEmpty(arrayName), arrayName, niceName)
+		jsonPath = CONF_FindControl(jsonID, niceName)
+		ASSERT(!IsEmpty(jsonPath), "Control " + nicename + " not found in file.")
+	endif
+
+	WAVE/T ctrlPropList = JSON_GetKeys(jsonID, jsonPath)
+	jsonPath = jsonPath + "/"
+
+	if(IsEmpty(arrayName))
+
+		FindValue/TXOP=4/TEXT=EXPCONFIG_FIELD_CTRLTYPE ctrlPropList
+		if(V_Value >= 0)
+			ctrlTypeName = JSON_GetString(jsonID, jsonPath + EXPCONFIG_FIELD_CTRLTYPE)
+			i = WhichListItem(ctrlTypeName, EXPCONFIG_GUI_CTRLLIST)
+			ASSERT(i != -1, "Read unknown control type: " + ctrlTypeName)
+			ctrlType = str2num(StringFromList(i, EXPCONFIG_GUI_CTRLTYPES))
+			ControlInfo/W=$wName $ctrlName
+			ASSERT(abs(V_Flag) == ctrlType, "Expected control of type " + ctrlTypeName + " in window " + wName)
+		else
+			ControlInfo/W=$wName $ctrlName
+			ctrlType = abs(V_Flag)
+		endif
+
+		if(restoreMask & EXPCONFIG_SAVE_POSITION)
+			VHeight = JSON_GetVariable(jsonID, jsonPath + EXPCONFIG_FIELD_CTRLPOSHEIGHT)
+			VWidth = JSON_GetVariable(jsonID, jsonPath + EXPCONFIG_FIELD_CTRLPOSWIDTH)
+			VTop = JSON_GetVariable(jsonID, jsonPath + EXPCONFIG_FIELD_CTRLPOSTOP)
+			VPos = JSON_GetVariable(jsonID, jsonPath + EXPCONFIG_FIELD_CTRLPOSPOS)
+			VAlign = JSON_GetVariable(jsonID, jsonPath + EXPCONFIG_FIELD_CTRLPOSALIGN)
+			ModifyControl $ctrlName win=$wName, align=VAlign, size={VWidth, VHeight}, pos={VPos, VTop}
+		endif
+		if(restoreMask & EXPCONFIG_SAVE_DISABLED)
+			FindValue/TXOP=4/TEXT=EXPCONFIG_FIELD_CTRLDISABLED ctrlPropList
+			if(V_Value >= 0)
+				VDisabled = JSON_GetVariable(jsonID, jsonPath + EXPCONFIG_FIELD_CTRLDISABLED)
+				if(VDisabled & HIDDEN_CONTROL_BIT)
+					HideControl(wName, ctrlName)
+				elseif(VDisabled & DISABLE_CONTROL_BIT)
+					DisableControl(wName, ctrlName)
+				else
+					ShowControl(wName, ctrlName)
+					EnableControl(wName, ctrlName)
+				endif
+			endif
+		endif
+		if(restoreMask & EXPCONFIG_SAVE_USERDATA)
+			FindValue/TXOP=4/TEXT=EXPCONFIG_FIELD_CTRLUSERDATA ctrlPropList
+			if(V_Value >= 0)
+				WAVE/T udataKeys = JSON_GetKeys(jsonID, jsonPath + EXPCONFIG_FIELD_CTRLUSERDATA)
+
+				Duplicate/T/FREE udataKeys, udataBase64
+				numUdataKeys = DimSize(udataKeys, ROWS)
+				for(i = numUdataKeys - 1; i >= 0; i -= 1)
+					uKey = udataKeys[i]
+					if(strsearch(uKey, EXPCONFIG_FIELD_BASE64PREFIX, 0) >= 0)
+						base64Key = uKey[strlen(EXPCONFIG_FIELD_BASE64PREFIX), Inf]
+						udataBase64[base64Entries] = base64Key
+						base64Entries += 1
+						DeletePoints i, 1, udataKeys
+						i -= 1
+					endif
+				endfor
+				Redimension/N=(base64Entries) udataBase64
+
+				numUdataKeys = DimSize(udataKeys, ROWS)
+				for(i = 0; i < numUdataKeys; i += 1)
+					uKey = udataKeys[i]
+					uData = JSON_GetString(jsonID, jsonPath + EXPCONFIG_FIELD_CTRLUSERDATA + "/" + uKey)
+					FindValue/TXOP=4/TEXT=uKey udataBase64
+					if(V_Value >= 0)
+						uData = Base64Decode(uData)
+					endif
+					if(IsEmpty(uKey))
+						ModifyControl $ctrlName win=$wName, userdata=uData
+					else
+						ModifyControl $ctrlName win=$wName, userdata($uKey)=uData
+					endif
+				endfor
+			endif
+		endif
+		if(restoreMask & EXPCONFIG_SAVE_VALUE)
+			if(ctrlType == CONTROL_TYPE_CHECKBOX || ctrlType == CONTROL_TYPE_SLIDER || ctrlType == CONTROL_TYPE_TAB || ctrlType == CONTROL_TYPE_VALDISPLAY)
+				val = JSON_GetVariable(jsonID, jsonPath + EXPCONFIG_FIELD_CTRLVVALUE)
+				PGC_SetAndActivateControl(wName, ctrlName, val = val)
+			elseif(ctrlType == CONTROL_TYPE_SETVARIABLE)
+				setVarType = GetInternalSetVariableType(S_recreation)
+				if(setVarType == SET_VARIABLE_BUILTIN_NUM)
+					val = JSON_GetVariable(jsonID, jsonPath + EXPCONFIG_FIELD_CTRLVVALUE)
+					PGC_SetAndActivateControl(wName, ctrlName, val = val)
+				elseif(setVarType == SET_VARIABLE_BUILTIN_STR)
+					str = JSON_GetString(jsonID, jsonPath + EXPCONFIG_FIELD_CTRLSVALUE)
+					PGC_SetAndActivateControl(wName, ctrlName, str = str)
+				else
+					str = JSON_GetString(jsonID, jsonPath + EXPCONFIG_FIELD_CTRLSDF)
+					if(IsEmpty(str))
+						SetVariable $ctrlName win=$wName, value=$""
+					else
+						varTypeGlobal = exists(str)
+						if(varTypeGlobal == EXISTS_AS_WAVE || varTypeGlobal == EXISTS_AS_VAR_OR_STR)
+							SetVariable $ctrlName win=$wName, value=$str
+						endif
+					endif
+				endif
+			elseif(ctrlType == CONTROL_TYPE_POPUPMENU)
+				if(restoreMask & EXPCONFIG_SAVE_POPUPMENU_AS_INDEX_ONLY && !(restoreMask & EXPCONFIG_SAVE_ONLY_RELEVANT))
+					val = JSON_GetVariable(jsonID, jsonPath + EXPCONFIG_FIELD_CTRLVVALUE)
+					PGC_SetAndActivateControl(wName, ctrlName, val = val)
+				else
+					str = JSON_GetString(jsonID, jsonPath + EXPCONFIG_FIELD_CTRLSVALUE)
+					PGC_SetAndActivateControl(wName, ctrlName, str = str)
+				endif
+			elseif(ctrlType == CONTROL_TYPE_BUTTON)
+				if(!CmpStr(GetUserData(wName, ctrlName, EXPCONFIG_UDATA_BUTTONPRESS), "1"))
+					PGC_SetAndActivateControl(wName, ctrlName)
+				endif
+			elseif(ctrlType == CONTROL_TYPE_CHART)
+			elseif(ctrlType == CONTROL_TYPE_CUSTOMCONTROL)
+			elseif(ctrlType == CONTROL_TYPE_GROUPBOX)
+			elseif(ctrlType == CONTROL_TYPE_LISTBOX)
+			elseif(ctrlType == CONTROL_TYPE_TITLEBOX)
+			else
+				ASSERT(0, "Unknown control type to restore value")
+			endif
+
+		endif
+	elseif(restoreMask & EXPCONFIG_SAVE_VALUE)
+		arrayIndex = str2num(GetUserData(wName, ctrlName, EXPCONFIG_UDATA_CTRLARRAYINDEX))
+		ASSERT(!IsNaN(arrayIndex) && arrayIndex >= 0, "Read invalid ControlArrayIndex from userdata of control " + ctrlName)
+		ASSERT(arrayIndex < EXPCONFIG_UDATA_MAXCTRLARRAYINDEX, "ControlArrayIndex is greater than " + num2istr(EXPCONFIG_UDATA_MAXCTRLARRAYINDEX) + ".")
+		arraySize = JSON_GetArraySize(jsonID, jsonPath + EXPCONFIG_FIELD_CTRLARRAYVALUES)
+		ASSERT(arrayIndex < arraySize, "The ControlArray of control " + ctrlName + " has less data elements saved than the GUI control requests from its ControlArrayIndex.")
+		arrayElemPath = jsonPath + EXPCONFIG_FIELD_CTRLARRAYVALUES + "/" + num2istr(arrayIndex)
+		arrayElemType = JSON_GetType(jsonID, arrayElemPath)
+		ASSERT(arrayElemType != JSON_NULL , "Value for element " + num2istr(arrayIndex) + " in ControlArray of control " + ctrlName + " was not saved.")
+
+		ControlInfo/W=$wName $ctrlName
+		ctrlType = abs(V_Flag)
+		if(ctrlType == CONTROL_TYPE_TAB || ctrlType == CONTROL_TYPE_SLIDER || ctrlType == CONTROL_TYPE_VALDISPLAY)
+			ASSERT(arrayElemType == JSON_NUMERIC, "Expected numeric value for ControlArray of control " + ctrlName + " at " + num2istr(arrayIndex))
+			val = JSON_GetVariable(jsonID, arrayElemPath)
+			PGC_SetAndActivateControl(wName, ctrlName, val = val)
+		elseif(ctrlType == CONTROL_TYPE_SETVARIABLE)
+			setVarType = GetInternalSetVariableType(S_recreation)
+			if(setVarType == SET_VARIABLE_BUILTIN_NUM)
+				ASSERT(arrayElemType == JSON_NUMERIC, "Expected numeric value for ControlArray of control " + ctrlName + " at " + num2istr(arrayIndex))
+				val = JSON_GetVariable(jsonID, arrayElemPath)
+				PGC_SetAndActivateControl(wName, ctrlName, val = val)
+			else
+				ASSERT(arrayElemType == JSON_STRING, "Expected string value for ControlArray of control " + ctrlName + " at " + num2istr(arrayIndex))
+				str = JSON_GetString(jsonID, arrayElemPath)
+				if(setVarType == SET_VARIABLE_BUILTIN_STR)
+					PGC_SetAndActivateControl(wName, ctrlName, str = str)
+				elseif(IsEmpty(str))
+					SetVariable $ctrlName win=$wName, value=$""
+				else
+					varTypeGlobal = exists(str)
+					if(varTypeGlobal == EXISTS_AS_WAVE || varTypeGlobal == EXISTS_AS_VAR_OR_STR)
+						SetVariable $ctrlName win=$wName, value=$str
+					endif
+				endif
+			endif
+		elseif(ctrlType == CONTROL_TYPE_POPUPMENU)
+			if(restoreMask & EXPCONFIG_SAVE_POPUPMENU_AS_INDEX_ONLY)
+				ASSERT(arrayElemType == JSON_NUMERIC, "Expected numeric value for ControlArray of control " + ctrlName + " at " + num2istr(arrayIndex))
+				val = JSON_GetVariable(jsonID, arrayElemPath)
+				PGC_SetAndActivateControl(wName, ctrlName, val = val)
+			else
+				ASSERT(arrayElemType == JSON_STRING, "Expected string value for ControlArray of control " + ctrlName + " at " + num2istr(arrayIndex))
+				str = JSON_GetString(jsonID, arrayElemPath)
+				PGC_SetAndActivateControl(wName, ctrlName, str = str)
+			endif
+		elseif(ctrlType == CONTROL_TYPE_BUTTON)
+			if(!CmpStr(GetUserData(wName, ctrlName, EXPCONFIG_UDATA_BUTTONPRESS), "1"))
+				PGC_SetAndActivateControl(wName, ctrlName)
+			endif
+		elseif(ctrlType == CONTROL_TYPE_CHECKBOX)
+			ASSERT(arrayElemType == JSON_BOOL, "Expected boolean value for ControlArray of control " + ctrlName + " at " + num2istr(arrayIndex))
+			val = JSON_GetVariable(jsonID, arrayElemPath)
+			PGC_SetAndActivateControl(wName, ctrlName, val = val)
+		elseif(ctrlType == CONTROL_TYPE_CHART)
+		elseif(ctrlType == CONTROL_TYPE_CUSTOMCONTROL)
+		elseif(ctrlType == CONTROL_TYPE_GROUPBOX)
+		elseif(ctrlType == CONTROL_TYPE_LISTBOX)
+		elseif(ctrlType == CONTROL_TYPE_TITLEBOX)
+		else
+			ASSERT(0, "Unknown control type to restore value")
+		endif
+
+	endif
+End
+
+/// @brief Serializes all controls of a window and its subwindows into a json object
+///
+/// @param[in] wName name of main window
+/// @param[in] saveMask bit pattern based configuration setting for saving @sa WindowControlSavingMask
+/// @param[in] excCtrlTypes [optional, default = ""], list of control type codes for excluded control types for saving e.g. "1;6;" to exclude all buttons and charts
+/// @returns json ID of object where all controls where serialized into
+Function CONF_AllWindowsToJSON(wName, saveMask[, excCtrlTypes])
+	string wName
+	variable saveMask
+	string excCtrlTypes
+
+	string wList = "", curWinName, errMsg
+	variable i, numWins, jsonID, jsonIDWin
+
+	try
+		excCtrlTypes = SelectString(ParamIsDefault(excCtrlTypes), excCtrlTypes, "")
+
+		ASSERT(!CmpStr(wName, GetMainWindow(wName)), "Windows name is not a main window, use function CONF_WindowToJSON instead.")
+
+		GetAllWindows(wName, wList)
+
+		jsonID = JSON_New()
+
+		JSON_AddString(jsonID, "/" + EXPCONFIG_RESERVED_TAGENTRY, GetUserData(wName, "", EXPCONFIG_UDATA_PANELTYPE))
+
+		numWins = ItemsInList(wList)
+		for(i = 0; i < numWins; i += 1)
+			curWinName = StringFromList(i, wList)
+			jsonIDWin = CONF_WindowToJSON(curWinName, saveMask, excCtrlTypes = excCtrlTypes)
+			WAVE/T ctrlList = JSON_GetKeys(jsonIDWin, "")
+			if(DimSize(ctrlList, ROWS))
+				JSON_SetJSON(jsonID, curWinName, jsonIDWin)
+			endif
+			JSON_Release(jsonIDWin)
+		endfor
+
+		return jsoNID
+
+	catch
+		errMsg = getRTErrMessage()
+		if(getRTError(1))
+			ASSERT(0, errMsg)
+		else
+			Abort
+		endif
+	endtry
+End
+
+Function/WAVE CONF_GetRadioButtonCouplingProtoFunc()
+End
+
+/// @brief Saves complete GUI state of a window in a json
+///        For coupled CheckBoxes aka (radio buttons) the enabled radio button is saved, the disabled is not saved.
+///        For three or more coupled CheckBoxes the first enabled radio button is saved, the disabled are not saved.
+///        For three or more coupled CheckBoxes an assertion is thrown if no CheckBox is set.
+///
+/// @param wName               Window name
+/// @param saveMask            Bit mask which properties are saved from WindowControlSavingMask constants
+/// @param excCtrlTypes        [optional, default = ""] List of excluded control types that are ignored
+/// @returns jsonID            ID of json containing the serialized GUI data
+Function CONF_WindowToJSON(wName, saveMask[, excCtrlTypes])
+	string wName
+	variable saveMask
+	string excCtrlTypes
+
+	string ctrlList, ctrlName, radioList, tmpList, wList, cbCtrlName, coupledIndexKeys = "", excUserKeys, radioFunc, str, errMsg
+	variable numCtrl, i, j, jsonID, numCoupled, setRadioPos, ctrlType, coupledCnt, numUniqueCtrlArray, numDupCheck
+	variable rbcIndex
+
+	try
+		excCtrlTypes = SelectString(ParamIsDefault(excCtrlTypes), excCtrlTypes, "")
+		ASSERT(WinType(wName), "Window " + wName + " does not exist!")
+		jsonID = JSON_New()
+
+		ctrlList = ControlNameList(wName, ";", "*")
+		numCtrl = ItemsInList(ctrlList)
+		if(!numCtrl)
+			JSON_AddTreeObject(jsonID, "")
+			return jsonID
+		endif
+		WAVE/T ctrlNames = ListToTextWave(ctrlList, ";")
+		Redimension/N=(numCtrl, 2) ctrlNames
+		SetDimLabel COLS, 0, CTRLNAME, ctrlNames
+		SetDimLabel COLS, 1, NICENAME, ctrlNames
+
+		ctrlNames[][%NICENAME] = GetUserData(wName, ctrlNames[p][%CTRLNAME], EXPCONFIG_UDATA_NICENAME)
+
+		Make/FREE/T/N=(numCtrl) arrayNames
+		arrayNames[] = GetUserData(wName, ctrlNames[p][%CTRLNAME], EXPCONFIG_UDATA_CTRLARRAY)
+		if(numCtrl > 1)
+			FindDuplicates/FREE/RT=arrayNamesRedux arrayNames
+			arrayNamesRedux[] = LowerStr(arrayNamesRedux[p])
+			FindValue/TXOP=4/TEXT="" arrayNamesRedux
+			if(V_Value >= 0)
+				DeletePoints V_Value, 1, arrayNamesRedux
+			endif
+		else
+			Make/FREE/T/N=0 arrayNamesRedux
+		endif
+
+		Make/FREE/N=(numCtrl)/T duplicateCheck
+		duplicateCheck[] = SelectString(strlen(ctrlNames[p][%NICENAME]), LowerStr(ctrlNames[p][%CTRLNAME]), LowerStr(ctrlNames[p][%NICENAME]))
+		numUniqueCtrlArray = DimSize(arrayNamesRedux, ROWS)
+		if(numUniqueCtrlArray)
+			Redimension/N=(numCtrl + numUniqueCtrlArray) duplicateCheck
+			duplicateCheck[numCtrl, numCtrl + numUniqueCtrlArray - 1] = arrayNamesRedux[p - numCtrl]
+		endif
+
+		numDupCheck = DimSize(duplicateCheck, ROWS)
+		if(numDupCheck > 1)
+			FindDuplicates/FREE/DT=duplicates duplicateCheck
+			ASSERT(!DimSize(duplicates, ROWS), "Human readable control names combined with internal control names have duplicates: " + TextWaveToList(duplicates, ";"))
+		endif
+		Make/FREE/I/N=(numDupCheck) groupEndingCheck
+		groupEndingCheck[] = StringEndsWith(duplicateCheck[p], LowerStr(EXPCONFIG_CTRLGROUP_SUFFIX))
+		FindValue/I=1 groupEndingCheck
+		if(V_Value >= 0)
+			ASSERT(0, "Control with [nice] name " + duplicateCheck[V_Value] + " uses a reserved suffix for control groups. Please change it to avoid conflicts.")
+		endif
+
+		radioFunc = GetUserData(wName, "", EXPCONFIG_UDATA_RADIOCOUPLING)
+		if(!IsEmpty(radioFunc))
+			FUNCREF CONF_GetRadioButtonCouplingProtoFunc rCoupleFunc = $radioFunc
+			WAVE/T radioButtonCoupling = rCoupleFunc()
+			coupledCnt = DimSize(radioButtonCoupling, ROWS)
+			for(i = 0; i < coupledCnt; i += 1)
+				radioList = radioButtonCoupling[i]
+				numCtrl = ItemsInList(radioList)
+				for(j = 0; j < numCtrl; j += 1)
+					coupledIndexKeys = ReplaceNumberByKey(StringFromList(j, radioList), coupledIndexKeys, i)
+				endfor
+			endfor
+
+			numCtrl = ItemsInList(ctrlList)
+			for(i = 0; i < numCtrl; i += 1)
+				ctrlName = StringFromList(i, ctrlList)
+				rbcIndex = NumberByKey(ctrlName, coupledIndexKeys)
+				if(IsNaN(rbcIndex))
+					continue
+				endif
+				radioList = radioButtonCoupling[rbcIndex]
+				if(IsEmpty(radioList))
+					continue
+				endif
+				radioButtonCoupling[rbcIndex] = ""
+
+				numCoupled = ItemsInList(radioList)
+				ASSERT(numCoupled >= 2, "At least two CheckBoxes must be coupled for Radio Buttons")
+				if(numCoupled == 2)
+					FindValue/TXOP=4/TEXT=StringFromList(1, radioList) ctrlNames
+					ASSERT(V_Value >= 0, "Specified coupled CheckBox is not present as control in " + wName)
+					DeletePoints V_Row, 1, ctrlNames
+				else
+					for(j = 0; j < numCoupled; j += 1)
+						cbCtrlName = StringFromList(j, radioList)
+						ControlInfo/W=$wName $cbCtrlName
+						ctrlType = abs(V_Flag)
+						ASSERT(ctrlType == 2, "Control is not present or not a CheckBox")
+						if(V_Value)
+							break
+						endif
+					endfor
+
+					if(j < numCoupled)
+						DEBUGPRINT("Ecountered >2 coupled CheckBoxes (RadioButtons) where all are in off state")
+					endif
+
+					setRadioPos = j
+					for(j = 0; j < numCoupled; j += 1)
+						cbCtrlName = StringFromList(j, radioList)
+						if(setRadioPos != j)
+							FindValue/TXOP=4/TEXT=cbCtrlName ctrlNames
+							ASSERT(V_Value >= 0, "Specified coupled CheckBox " + cbCtrlName + " is not present as control in " + wName)
+							DeletePoints V_Row, 1, ctrlNames
+						endif
+					endfor
+				endif
+			endfor
+		endif
+
+		excUserKeys = EXPCONFIG_EXCLUDE_USERDATA
+		excUserKeys = AddListItem(EXPCONFIG_UDATA_NICENAME, excUserKeys)
+		excUserKeys = AddListItem(EXPCONFIG_UDATA_JSONPATH, excUserKeys)
+		excUserKeys = AddListItem(EXPCONFIG_UDATA_EXCLUDE_SAVE, excUserKeys)
+		excUserKeys = AddListItem(EXPCONFIG_UDATA_EXCLUDE_RESTORE, excUserKeys)
+		excUserKeys = AddListItem(EXPCONFIG_UDATA_BUTTONPRESS, excUserKeys)
+		excUserKeys = AddListItem(EXPCONFIG_UDATA_RESTORE_PRIORITY, excUserKeys)
+		excUserKeys = AddListItem(EXPCONFIG_UDATA_WINHANDLE, excUserKeys)
+
+		numCtrl = DimSize(ctrlNames, ROWS)
+		for(i = 0; i < numCtrl; i += 1)
+			CONF_ControlToJSON(wName, ctrlNames[i][%CTRLNAME], saveMask, jsonID, excCtrlTypes, excUserKeys)
+		endfor
+
+		return jsonID
+
+	catch
+		errMsg = getRTErrMessage()
+		if(getRTError(1))
+			ASSERT(0, errMsg)
+		else
+			Abort
+		endif
+	endtry
+End
+
+static Function/S CONF_GetCompleteJSONCtrlPath(path)
+	string path
+
+	variable i, numElems
+	string completePath = ""
+
+	numElems = ItemsInList(path)
+	for(i = 0; i < numElems; i += 1)
+		completePath = AddListItem(StringFromList(i, path) + EXPCONFIG_CTRLGROUP_SUFFIX, completePath, "/", Inf)
+	endfor
+
+	return completePath
+End
+
+/// @brief Adds properties of a control to a json
+///
+/// @param wName        Window name
+/// @param ctrlName     Control name
+/// @param saveMask     Bit mask which properties are saved from WindowControlSavingMask constants
+/// @param jsonID       ID of existing json
+/// @param excCtrlTypes List of excluded control types that are ignored
+/// @param excUserKeys  List of excluded keys of userdata fields that are ignored
+static Function CONF_ControlToJSON(wName, ctrlName, saveMask, jsonID, excCtrlTypes, excUserKeys)
+	string wName, ctrlName
+	variable saveMask
+	variable jsonID
+	string excCtrlTypes, excUserKeys
+
+	variable ctrlType, pos, i, numUdataKeys, setVarType, err, arrayIndex, oldSize, preferCode, arrayElemType
+	string wList, ctrlPath, controlPath, niceName, jsonPath, udataPath, udataKeys, uDataKey, uData, s, arrayName, arrayElemPath
+
+
+	ASSERT((saveMask & (EXPCONFIG_SAVE_POPUPMENU_AS_STRING_ONLY | EXPCONFIG_SAVE_POPUPMENU_AS_INDEX_ONLY)) != (EXPCONFIG_SAVE_POPUPMENU_AS_STRING_ONLY | EXPCONFIG_SAVE_POPUPMENU_AS_INDEX_ONLY), "Invalid popup menu save selection. String only and Index only can not be set at the same time.")
+	ASSERT(WinType(wName), "Window " + wName + " does not exist!")
+
+	ControlInfo/W=$wName $ctrlName
+	ctrlType = abs(V_Flag)
+	ASSERT(ctrlType != 0, "Control does not exist")
+
+	if(WhichListItem(num2str(ctrlType), excCtrlTypes) >= 0)
+		return NaN
+	endif
+	if(!CmpStr(GetUserData(wName, ctrlName, EXPCONFIG_UDATA_EXCLUDE_SAVE), "1"))
+		return NaN
+	endif
+
+	niceName = GetUserData(wName, ctrlName, EXPCONFIG_UDATA_NICENAME)
+	niceName = SelectString(IsEmpty(niceName), niceName, ctrlName)
+	jsonPath = GetUserData(wName, ctrlName, EXPCONFIG_UDATA_JSONPATH)
+	jsonPath = SelectString(IsEmpty(jsonPath), jsonPath, EXPCONFIG_DEFAULT_CTRL_JSONPATH)
+	ASSERT(strsearch(jsonPath, "/", 0) == -1, "Control " + ctrlName + " has an invalid GroupPath configured in userdata containing a / character.")
+	jsonPath = CONF_GetCompleteJSONCtrlPath(jsonPath)
+	if(!CmpStr(jsonPath, EXPCONFIG_RESERVED_DATABLOCK))
+		printf "Control %s has a reserved jsonPath configured in userdata, replacing with default path.\r", ctrlName
+		jsonPath = EXPCONFIG_DEFAULT_CTRL_JSONPATH
+	endif
+
+	arrayName = GetUserData(wName, ctrlName, EXPCONFIG_UDATA_CTRLARRAY)
+	niceName = SelectString(IsEmpty(arrayName), arrayName, niceName)
+	controlPath = jsonPath + niceName
+	JSON_AddTreeObject(jsonID, controlPath)
+	ctrlPath = controlPath + "/"
+
+	pos = WhichListItem(num2str(ctrlType), EXPCONFIG_GUI_CTRLTYPES)
+	ASSERT(pos >= 0, "Unknown Control Type")
+
+	if(IsEmpty(arrayName))
+
+		if(IsNull(S_DataFolder))
+			S_DataFolder = ""
+		endif
+		if(IsNull(S_Value))
+			S_Value = ""
+		endif
+
+		if(saveMask & EXPCONFIG_SAVE_CTRLTYPE)
+			JSON_AddString(jsonID, ctrlPath + EXPCONFIG_FIELD_CTRLTYPE, ControlTypeToName(ctrlType))
+		endif
+
+		if(saveMask & EXPCONFIG_SAVE_VALUE)
+			if(ctrlType == CONTROL_TYPE_SETVARIABLE)
+				setVarType = GetInternalSetVariableType(S_recreation)
+				if(setVarType == SET_VARIABLE_BUILTIN_NUM)
+					JSON_AddVariable(jsonID, ctrlPath + EXPCONFIG_FIELD_CTRLVVALUE, V_Value)
+				elseif(setVarType == SET_VARIABLE_BUILTIN_STR)
+					JSON_AddString(jsonID, ctrlPath + EXPCONFIG_FIELD_CTRLSVALUE, S_Value)
+				else
+					JSON_AddString(jsonID, ctrlPath + EXPCONFIG_FIELD_CTRLSDF, S_DataFolder)
+				endif
+			elseif(ctrlType == CONTROL_TYPE_POPUPMENU)
+				if(saveMask & EXPCONFIG_SAVE_POPUPMENU_AS_STRING_ONLY || saveMask & EXPCONFIG_SAVE_ONLY_RELEVANT)
+					JSON_AddString(jsonID, ctrlPath + EXPCONFIG_FIELD_CTRLSVALUE, S_Value)
+				elseif(saveMask & EXPCONFIG_SAVE_POPUPMENU_AS_INDEX_ONLY)
+					JSON_AddVariable(jsonID, ctrlPath + EXPCONFIG_FIELD_CTRLVVALUE, V_Value)
+				else
+					JSON_AddString(jsonID, ctrlPath + EXPCONFIG_FIELD_CTRLSVALUE, S_Value)
+					JSON_AddVariable(jsonID, ctrlPath + EXPCONFIG_FIELD_CTRLVVALUE, V_Value)
+				endif
+			elseif(ctrlType == CONTROL_TYPE_BUTTON)
+				if(saveMask & EXPCONFIG_SAVE_ONLY_RELEVANT)
+					V_Value = 1
+				endif
+				if(saveMask & EXPCONFIG_SAVE_BUTTONS_ONLY_PRESSED)
+					if(!CmpStr(GetUserData(wName, ctrlName, EXPCONFIG_UDATA_BUTTONPRESS), "1"))
+						JSON_AddVariable(jsonID, ctrlPath + EXPCONFIG_FIELD_CTRLVVALUE, V_Value)
+					endif
+				else
+					JSON_AddVariable(jsonID, ctrlPath + EXPCONFIG_FIELD_CTRLVVALUE, V_Value)
+				endif
+			elseif(ctrlType == CONTROL_TYPE_CHECKBOX)
+				JSON_AddBoolean(jsonID, ctrlPath + EXPCONFIG_FIELD_CTRLVVALUE, V_Value)
+			else
+				if(saveMask & EXPCONFIG_SAVE_ONLY_RELEVANT)
+					preferCode = str2num(StringFromList(pos, EXPCONFIG_GUI_PREFERRED))
+				endif
+				if(preferCode == 0)
+					if(str2num(StringFromList(pos, EXPCONFIG_GUI_VVALUE)))
+						JSON_AddVariable(jsonID, ctrlPath + EXPCONFIG_FIELD_CTRLVVALUE, V_Value)
+					endif
+					if(str2num(StringFromList(pos, EXPCONFIG_GUI_SVALUE)))
+						JSON_AddString(jsonID, ctrlPath + EXPCONFIG_FIELD_CTRLSVALUE, S_Value)
+					endif
+					if(str2num(StringFromList(pos, EXPCONFIG_GUI_SDATAFOLDER)))
+						JSON_AddString(jsonID, ctrlPath + EXPCONFIG_FIELD_CTRLSDF, S_DataFolder)
+					endif
+				elseif(preferCode == 1)
+					JSON_AddVariable(jsonID, ctrlPath + EXPCONFIG_FIELD_CTRLVVALUE, V_Value)
+				elseif(preferCode == 2)
+					JSON_AddString(jsonID, ctrlPath + EXPCONFIG_FIELD_CTRLSVALUE, S_Value)
+				elseif(preferCode == 3)
+					JSON_AddString(jsonID, ctrlPath + EXPCONFIG_FIELD_CTRLSDF, S_DataFolder)
+				else
+					ASSERT(0, "Unknown code for preference in EXPCONFIG_SAVE_ONLY_RELEVANT mode.")
+				endif
+			endif
+		endif
+		if(saveMask & EXPCONFIG_SAVE_DISABLED)
+			JSON_AddVariable(jsonID, ctrlPath + EXPCONFIG_FIELD_CTRLDISABLED, V_disable)
+		endif
+		if(saveMask & EXPCONFIG_SAVE_POSITION)
+			JSON_AddVariable(jsonID, ctrlPath + EXPCONFIG_FIELD_CTRLPOSHEIGHT, V_Height)
+			JSON_AddVariable(jsonID, ctrlPath + EXPCONFIG_FIELD_CTRLPOSWIDTH, V_Width)
+			JSON_AddVariable(jsonID, ctrlPath + EXPCONFIG_FIELD_CTRLPOSTOP, V_Top)
+			JSON_AddVariable(jsonID, ctrlPath + EXPCONFIG_FIELD_CTRLPOSPOS, V_Pos)
+			JSON_AddVariable(jsonID, ctrlPath + EXPCONFIG_FIELD_CTRLPOSALIGN, V_Align)
+		endif
+		if(saveMask & EXPCONFIG_SAVE_USERDATA)
+			udataPath = ctrlPath + EXPCONFIG_FIELD_CTRLUSERDATA
+			JSON_AddTreeObject(jsonID, udataPath)
+			udataPath = udataPath + "/"
+			if(!IsEmpty(S_Userdata) && str2num(StringFromList(pos, EXPCONFIG_GUI_SUSERDATA)))
+				JSON_AddString(jsonID, udataPath, S_Userdata)
+			endif
+			udataKeys = GetUserdataKeys(S_recreation)
+			if(!IsEmpty(udataKeys))
+				numUdataKeys = ItemsInList(udataKeys)
+				for(i = 0; i < numUdataKeys; i +=1)
+					uDataKey = StringFromList(i, udataKeys)
+					if(WhichListItem(uDataKey, excUserKeys) >= 0)
+						continue
+					endif
+					uData = GetUserData(wName, ctrlName, uDataKey)
+					try
+						s = ConvertTextEncoding(uData, TextEncodingCode("UTF-8"), TextEncodingCode("UTF-8"), 1, 0); AbortOnRTE
+					catch
+						err = GetRTError(1)
+						uData = Base64Encode(udata)
+						JSON_AddString(jsonID, udataPath + EXPCONFIG_FIELD_BASE64PREFIX + uDataKey, "1")
+					endtry
+					JSON_AddString(jsonID, udataPath + uDataKey, uData)
+				endfor
+			endif
+		endif
+	elseif(saveMask & EXPCONFIG_SAVE_VALUE)
+		arrayIndex = str2num(GetUserData(wName, ctrlName, EXPCONFIG_UDATA_CTRLARRAYINDEX))
+		ASSERT(!IsNaN(arrayIndex) && arrayIndex >= 0, "Read invalid ControlArrayIndex from userdata of control " + ctrlName)
+		ASSERT(arrayIndex < EXPCONFIG_UDATA_MAXCTRLARRAYINDEX, "ControlArrayIndex is greater than " + num2str(EXPCONFIG_UDATA_MAXCTRLARRAYINDEX) + ".")
+		WAVE/T ctrlProps = JSON_GetKeys(jsonID, controlPath)
+		FindValue/TXOP=4/TEXT=EXPCONFIG_FIELD_CTRLARRAYVALUES ctrlProps
+		if(V_Value >= 0)
+			oldSize = JSON_GetArraySize(jsonID, ctrlPath + EXPCONFIG_FIELD_CTRLARRAYVALUES)
+		else
+			JSON_AddTreeArray(jsonID, ctrlPath + EXPCONFIG_FIELD_CTRLARRAYVALUES)
+			oldSize = 0
+		endif
+		for(i = oldSize; i < arrayIndex + 1; i += 1)
+			JSON_AddNull(jsonID, ctrlPath + EXPCONFIG_FIELD_CTRLARRAYVALUES)
+		endfor
+		arrayElemPath = ctrlPath + EXPCONFIG_FIELD_CTRLARRAYVALUES + "/" + num2istr(arrayIndex)
+		arrayElemType = JSON_GetType(jsonID, arrayElemPath)
+		ASSERT(arrayElemType == JSON_NULL, "Control of ControlArray with the same ControlArrayIndex was already encountered. Check control: " + ctrlName)
+		ControlInfo/W=$wName $ctrlName
+		ctrlType = abs(V_Flag)
+		if(IsNull(S_DataFolder))
+			S_DataFolder = ""
+		endif
+		if(IsNull(S_Value))
+			S_Value = ""
+		endif
+		if(ctrlType == CONTROL_TYPE_SETVARIABLE)
+			setVarType = GetInternalSetVariableType(S_recreation)
+			if(setVarType == SET_VARIABLE_BUILTIN_NUM)
+				JSON_SetVariable(jsonID, arrayElemPath, V_Value)
+			elseif(setVarType == SET_VARIABLE_BUILTIN_STR)
+				JSON_SetString(jsonID, arrayElemPath, S_Value)
+			else
+				JSON_SetString(jsonID, arrayElemPath, S_DataFolder)
+			endif
+		elseif(ctrlType == CONTROL_TYPE_POPUPMENU)
+			if(saveMask & EXPCONFIG_SAVE_POPUPMENU_AS_INDEX_ONLY)
+				JSON_SetVariable(jsonID, arrayElemPath, V_Value)
+			else
+				JSON_SetString(jsonID, arrayElemPath, S_Value)
+			endif
+		elseif(ctrlType == CONTROL_TYPE_BUTTON)
+			if(saveMask & EXPCONFIG_SAVE_ONLY_RELEVANT)
+				V_Value = 1
+			endif
+			if(saveMask & EXPCONFIG_SAVE_BUTTONS_ONLY_PRESSED)
+				if(!CmpStr(GetUserData(wName, ctrlName, EXPCONFIG_UDATA_BUTTONPRESS), "1"))
+					JSON_SetVariable(jsonID, arrayElemPath, V_Value)
+				endif
+			else
+				JSON_SetVariable(jsonID, arrayElemPath, V_Value)
+			endif
+		elseif(ctrlType == CONTROL_TYPE_CHART || ctrlType == CONTROL_TYPE_GROUPBOX)
+			JSON_SetString(jsonID, arrayElemPath, S_Value)
+		elseif(ctrlType == CONTROL_TYPE_CHECKBOX)
+			JSON_SetBoolean(jsonID, arrayElemPath, V_Value)
+		elseif(ctrlType == CONTROL_TYPE_CUSTOMCONTROL || ctrlType == CONTROL_TYPE_TAB || ctrlType == CONTROL_TYPE_SLIDER || ctrlType == CONTROL_TYPE_VALDISPLAY)
+			JSON_SetVariable(jsonID, arrayElemPath, V_Value)
+		elseif(ctrlType == CONTROL_TYPE_LISTBOX || ctrlType == CONTROL_TYPE_TITLEBOX)
+			JSON_SetString(jsonID, arrayElemPath, S_DataFolder)
+		endif
+	endif
+
+	WAVE/T ctrlProps = JSON_GetKeys(jsonID, controlPath)
+	if(!DimSize(ctrlProps, ROWS))
+		JSONXOP_Remove/Q=1 jsonID, controlPath; AbortOnRTE
+	endif
+End
+
+/// @brief Retrieves current Headstage Association settings (amplifiers, pressure) )to json
+/// @param[in] panelTitle panel title of DA_Ephys panel
+/// @returns jsonID ID of json object with Headstage Association configuration data
+static Function CONF_GetHeadstageAssociation(panelTitle)
+	string panelTitle
+
+	variable i, jsonID, ampSerial, ampChannelID, index
+	string ctrl, amplifierDef, jsonPath, popupStr
+
+	jsonID = JSON_New()
+
+	for(i = 0; i < NUM_HEADSTAGES; i += 1)
+		jsonPath = num2istr(i)
+		ctrl = GetPanelControl(i, CHANNEL_TYPE_HEADSTAGE, CHANNEL_CONTROL_CHECK)
+		if(GetCheckBoxState(panelTitle, ctrl))
+
+			JSON_AddTreeObject(jsonID, jsonPath)
+			jsonPath = jsonPath + "/"
+			PGC_SetAndActivateControl(panelTitle,"Popup_Settings_HeadStage", val = i)
+
+			amplifierDef = GetPopupMenuString(panelTitle, "popup_Settings_Amplifier")
+			DAP_ParseAmplifierDef(amplifierDef, ampSerial, ampChannelID)
+			if(IsFinite(ampSerial) && IsFinite(ampChannelID))
+				JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_AMPSERIAL, ampSerial)
+			else
+				JSON_AddNull(jsonID, jsonPath + EXPCONFIG_JSON_AMPSERIAL)
+			endif
+			JSON_AddString(jsonID, jsonPath + EXPCONFIG_JSON_AMPTITLE, StringFromList(trunc(i / 2), EXPCONFIG_SETTINGS_AMPTITLE))
+
+			JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_AMPVCDA, str2num(GetPopupMenuString(panelTitle, "Popup_Settings_VC_DA")))
+			JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_AMPVCAD, str2num(GetPopupMenuString(panelTitle, "Popup_Settings_VC_AD")))
+			JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_AMPICDA, str2num(GetPopupMenuString(panelTitle, "Popup_Settings_IC_DA")))
+			JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_AMPICAD, str2num(GetPopupMenuString(panelTitle, "Popup_Settings_IC_AD")))
+
+			JSON_AddString(jsonID, jsonPath + EXPCONFIG_JSON_PRESSDEV, GetPopupMenuString(panelTitle, "popup_Settings_Pressure_dev"))
+			JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_PRESSDA, str2num(GetPopupMenuString(panelTitle, "Popup_Settings_Pressure_DA")))
+			JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_PRESSAD, str2num(GetPopupMenuString(panelTitle, "Popup_Settings_Pressure_AD")))
+			JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_PRESSDAGAIN, GetSetVariable(panelTitle, "setvar_Settings_Pressure_DAgain"))
+			JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_PRESSADGAIN, GetSetVariable(panelTitle, "setvar_Settings_Pressure_ADgain"))
+			JSON_AddString(jsonID, jsonPath + EXPCONFIG_JSON_PRESSDAUNIT, GetSetVariableString(panelTitle, "SetVar_Hardware_Pressur_DA_Unit"))
+			JSON_AddString(jsonID, jsonPath + EXPCONFIG_JSON_PRESSADUNIT, GetSetVariableString(panelTitle, "SetVar_Hardware_Pressur_AD_Unit"))
+			JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_PRESSTTLA, str2numsafe(GetPopupMenuString(panelTitle, "Popup_Settings_Pressure_TTLA")))
+			JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_PRESSTTLB, str2numsafe(GetPopupMenuString(panelTitle, "Popup_Settings_Pressure_TTLB")))
+			WAVE pressureDataWv = P_GetPressureDataWaveRef(panelTitle)
+			index = FindDimLabel(pressureDataWv, ROWS, "headStage_" + num2str(i))
+			JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_PRESSCONSTNEG, pressureDataWv[index][%NegCalConst])
+			JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_PRESSCONSTPOS, pressureDataWv[index][%PosCalConst])
+
+		else
+			JSON_AddNull(jsonID, jsonPath)
+		endif
+	endfor
+
+	return jsonID
+End
+
+/// @brief Opens MCCs and restores Headstage Association from configuration data to DA_Ephys panel
+/// @param[in] panelTitle panel title of DA_Ephys panel
+/// @param[in] jsonID ID of json object with configuration data
+/// @param[in] midExp middle of experiment - uploads MCC relevant settings from panel to MCC instead
+static Function CONF_RestoreHeadstageAssociation(panelTitle, jsonID, midExp)
+	string panelTitle
+	variable jsonID, midExp
+
+	variable i, type, numRows, ampSerial, ampIndex, index, value
+	string jsonPath, jsonHSPath, winPositionMCC
+	string ampSerialList = ""
+	string ampTitleList = ""
+
+	CONF_RequireConfigBlockExists(jsonID)
+	WAVE/T keys = JSON_GetKeys(jsonID, EXPCONFIG_RESERVED_DATABLOCK)
+	FindValue/TXOP=4/TEXT=EXPCONFIG_JSON_HSASSOCBLOCK keys
+	ASSERT(V_Value >= 0, "Headstage Association block not found in configuration.")
+	jsonPath = EXPCONFIG_RESERVED_DATABLOCK + "/" + EXPCONFIG_JSON_HSASSOCBLOCK + "/"
+	for(i = 0; i < NUM_HEADSTAGES; i += 1)
+		jsonHSPath = jsonPath + num2istr(i)
+		type = JSON_GetType(jsonID, jsonHSPath)
+		if(type == JSON_NULL)
+			continue
+		elseif(type == JSON_OBJECT)
+			ampSerialList = AddListItem(num2istr(JSON_GetVariable(jsonID, jsonHSPath + "/" + EXPCONFIG_JSON_AMPSERIAL)), ampSerialList)
+			ampTitleList = AddListItem(JSON_GetString(jsonID, jsonHSPath + "/" + EXPCONFIG_JSON_AMPTITLE), ampTitleList)
+		else
+			ASSERT(0, "Unexpected entry for headstage data in Headstage Association block")
+		endif
+	endfor
+
+	WAVE telegraphServers = GetAmplifierTelegraphServers()
+	numRows = DimSize(telegraphServers, ROWS)
+	if(!numRows)
+		Assert(AI_OpenMCCs(ampSerialList, ampTitleList = ampTitleList, maxAttempts = ATTEMPTS), "Evil kittens prevented MultiClamp from opening - FULL STOP" )
+	endif
+
+	winPositionMCC = CONF_GetStringFromSettings(jsonID, POSITION_MCC)
+	if(!CmpStr(NONE, winPositionMCC))
+		CONF_Position_MCC_Win(ampSerialList, ampTitleList, winPositionMCC)
+	endif
+
+	PGC_SetAndActivateControl(panelTitle, "button_Settings_UpdateAmpStatus")
+	PGC_SetAndActivateControl(panelTitle, "button_Settings_UpdateDACList")
+
+	Make/FREE/U/I/N=(ItemsInList(ampSerialList)) ampIDTracker = 1
+
+	for(i = 0; i < NUM_HEADSTAGES; i += 1)
+		jsonHSPath = jsonPath + num2istr(i)
+		PGC_SetAndActivateControl(panelTitle, "Popup_Settings_HeadStage", val = i)
+
+		type = JSON_GetType(jsonID, jsonHSPath)
+		jsonHSPath = jsonHSPath + "/"
+		if(type == JSON_NULL)
+			PGC_SetAndActivateControl(panelTitle, "popup_Settings_Amplifier", str = NONE)
+			PGC_SetAndActivateControl(panelTitle, "popup_Settings_Pressure_dev", str = NONE)
+		elseif(type == JSON_OBJECT)
+			ampSerial = JSON_GetVariable(jsonID, jsonHSPath + EXPCONFIG_JSON_AMPSERIAL)
+			ampIndex = WhichListItem(num2istr(ampSerial), ampSerialList)
+			ASSERT(ampIDTracker[ampIndex] <= 2, "More than two headstages are configured for the same amplifier serial.")
+			PGC_SetAndActivateControl(panelTitle, "popup_Settings_Amplifier", val = CONF_FindAmpInList(ampSerial, ampIDTracker[ampIndex]))
+			ampIDTracker[ampIndex] += 1
+			PGC_SetAndActivateControl(panelTitle, "Popup_Settings_VC_DA", val = JSON_GetVariable(jsonID, jsonHSPath + EXPCONFIG_JSON_AMPVCDA))
+			PGC_SetAndActivateControl(panelTitle, "Popup_Settings_VC_AD", val = JSON_GetVariable(jsonID, jsonHSPath + EXPCONFIG_JSON_AMPVCAD))
+			PGC_SetAndActivateControl(panelTitle, "Popup_Settings_IC_DA", val = JSON_GetVariable(jsonID, jsonHSPath + EXPCONFIG_JSON_AMPICDA))
+			PGC_SetAndActivateControl(panelTitle, "Popup_Settings_IC_AD", val = JSON_GetVariable(jsonID, jsonHSPath + EXPCONFIG_JSON_AMPICAD))
+			PGC_SetAndActivateControl(panelTitle,"button_Hardware_AutoGainAndUnit")
+
+			PGC_SetAndActivateControl(panelTitle, "popup_Settings_Pressure_dev", str = JSON_GetString(jsonID, jsonHSPath + EXPCONFIG_JSON_PRESSDEV))
+			PGC_SetAndActivateControl(panelTitle, "Popup_Settings_Pressure_DA", val = JSON_GetVariable(jsonID, jsonHSPath + EXPCONFIG_JSON_PRESSDA))
+			PGC_SetAndActivateControl(panelTitle, "Popup_Settings_Pressure_AD", val = JSON_GetVariable(jsonID, jsonHSPath + EXPCONFIG_JSON_PRESSAD))
+			PGC_SetAndActivateControl(panelTitle, "setvar_Settings_Pressure_DAgain", val = JSON_GetVariable(jsonID, jsonHSPath + EXPCONFIG_JSON_PRESSDAGAIN))
+			PGC_SetAndActivateControl(panelTitle, "setvar_Settings_Pressure_ADgain", val = JSON_GetVariable(jsonID, jsonHSPath + EXPCONFIG_JSON_PRESSADGAIN))
+			PGC_SetAndActivateControl(panelTitle, "SetVar_Hardware_Pressur_DA_Unit", str = JSON_GetString(jsonID, jsonHSPath + EXPCONFIG_JSON_PRESSDAUNIT))
+			PGC_SetAndActivateControl(panelTitle, "SetVar_Hardware_Pressur_AD_Unit", str = JSON_GetString(jsonID, jsonHSPath + EXPCONFIG_JSON_PRESSADUNIT))
+			value = JSON_GetVariable(jsonID, jsonHSPath + EXPCONFIG_JSON_PRESSTTLA)
+			if(IsNaN(value))
+				PGC_SetAndActivateControl(panelTitle, "Popup_Settings_Pressure_TTLA", str = NONE)
+			else
+				PGC_SetAndActivateControl(panelTitle, "Popup_Settings_Pressure_TTLA", str = num2istr(value))
+			endif
+			value = JSON_GetVariable(jsonID, jsonHSPath + EXPCONFIG_JSON_PRESSTTLB)
+			if(IsNaN(value))
+				PGC_SetAndActivateControl(panelTitle, "Popup_Settings_Pressure_TTLB", str = NONE)
+			else
+				PGC_SetAndActivateControl(panelTitle, "Popup_Settings_Pressure_TTLB", str = num2istr(value))
+			endif
+			WAVE pressureDataWv = P_GetPressureDataWaveRef(panelTitle)
+			index = FindDimLabel(pressureDataWv, ROWS, "headStage_" + num2str(i))
+			pressureDataWv[index][%NegCalConst] = JSON_GetVariable(jsonID, jsonHSPath + EXPCONFIG_JSON_PRESSCONSTNEG)
+			pressureDataWv[index][%PosCalConst] = JSON_GetVariable(jsonID, jsonHSPath + EXPCONFIG_JSON_PRESSCONSTPOS)
+
+			if(!midExp)
+				CONF_MCC_InitParams(panelTitle, i)
+			else
+				CONF_MCC_MidExp(panelTitle, i, jsonID)
+			endif
+		endif
+	endfor
+	PGC_SetAndActivateControl(panelTitle, "button_Hardware_P_Enable")
+
+End
+
+/// @brief Retrieves current User Pressure settings to json
+/// @param[in] panelTitle panel title of DA_Ephys panel
+/// @returns jsonID ID of json object with user pressure configuration data
+static Function CONF_GetUserPressure(panelTitle)
+	string panelTitle
+
+	variable jsonID
+
+	jsonID = JSON_New()
+
+	JSON_AddString(jsonID, EXPCONFIG_JSON_USERPRESSDEV, GetPopupMenuString(panelTitle, "popup_Settings_UserPressure"))
+	JSON_AddVariable(jsonID, EXPCONFIG_JSON_USERPRESSDA, str2num(GetPopupMenuString(panelTitle, "Popup_Settings_UserPressure_ADC")))
+
+	return jsonID
+End
+
+/// @brief Restore User Pressure settings
+/// @param[in] panelTitle panel title of DA_Ephys panel
+/// @param[in] jsonID ID of json object with configuration data
+static Function CONF_RestoreUserPressure(panelTitle, jsonID)
+	string panelTitle
+	variable jsonID
+
+	string jsonPath
+
+	CONF_RequireConfigBlockExists(jsonID)
+	WAVE/T keys = JSON_GetKeys(jsonID, EXPCONFIG_RESERVED_DATABLOCK)
+	FindValue/TXOP=4/TEXT=EXPCONFIG_JSON_USERPRESSBLOCK keys
+	ASSERT(V_Value >= 0, "User Pressure block not found in configuration.")
+	jsonPath = EXPCONFIG_RESERVED_DATABLOCK + "/" + EXPCONFIG_JSON_USERPRESSBLOCK + "/"
+	PGC_SetAndActivateControl(panelTitle, "popup_Settings_UserPressure", str = JSON_GetString(jsonID, jsonPath + EXPCONFIG_JSON_USERPRESSDEV))
+	PGC_SetAndActivateControl(panelTitle, "Popup_Settings_UserPressure_ADC", val = JSON_GetVariable(jsonID, jsonPath + EXPCONFIG_JSON_USERPRESSDA))
+	PGC_SetAndActivateControl(panelTitle, "button_Hardware_PUser_Enable")
+End
+
+
+#ifdef AMPLIFIER_XOPS_PRESENT
+
+/// @brief Intiate MCC parameters for active headstages
+///
+/// @param panelTitle ITC device panel
+/// @param headStage  MIES headstage number, must be in the range [0, NUM_HEADSTAGES]
+static Function CONF_MCC_InitParams(panelTitle, headStage)
+	string panelTitle
+	variable headStage
+
+	variable clampMode
+
+	WAVE GuiState = GetDA_EphysGuiStateNum(panelTitle)
+	clampMode = GuiState[headStage][%HSmode]
+
+	// Set initial parameters within MCC itself.
+	AI_SelectMultiClamp(panelTitle, headStage)
+
+	//Set V-clamp parameters
+	DAP_ChangeHeadStageMode(panelTitle, V_CLAMP_MODE, headStage, DO_MCC_MIES_SYNCING)
+
+	MCC_SetHoldingEnable(0)
+	MCC_SetOscKillerEnable(0)
+	MCC_SetFastCompTau(1.8e-6)
+	MCC_SetSlowCompTau(1e-5)
+	MCC_SetSlowCompTauX20Enable(0)
+	MCC_SetRsCompBandwidth(1.02e3)
+	MCC_SetRSCompCorrection(0)
+	MCC_SetPrimarySignalGain(1)
+	MCC_SetPrimarySignalLPF(10e3)
+	MCC_SetPrimarySignalHPF(0)
+	MCC_SetSecondarySignalGain(1)
+	MCC_SetSecondarySignalLPF(10e3)
+
+	//Set I-Clamp Parameters
+	DAP_ChangeHeadStageMode(panelTitle, I_CLAMP_MODE, headStage, DO_MCC_MIES_SYNCING)
+
+	MCC_SetHoldingEnable(0)
+	MCC_SetSlowCurrentInjEnable(0)
+	MCC_SetNeutralizationEnable(0)
+	MCC_SetOscKillerEnable(0)
+	MCC_SetPrimarySignalGain(5)
+	MCC_SetPrimarySignalLPF(10e3)
+	MCC_SetPrimarySignalHPF(0)
+	MCC_SetSecondarySignalGain(1)
+	MCC_SetSecondarySignalLPF(10e3)
+
+	if(clampMode != I_CLAMP_MODE)
+		DAP_ChangeHeadStageMode(panelTitle, clampMode, headStage, DO_MCC_MIES_SYNCING)
+	endif
+End
+
+#else
+
+static Function CONF_MCC_InitParams(panelTitle, headStage)
+	string panelTitle
+	variable headStage
+
+	DEBUGPRINT("Unimplemented")
+
+	return NaN
+End
+
+#endif
+
+/// @brief Find the list index of a connected amplifier serial number
+///
+/// @param ampSerialRef    Amplifier Serial Number to search for
+/// @param ampChannelIDRef Headstage reference number
+static Function CONF_FindAmpInList(ampSerialRef, ampChannelIDRef)
+	variable ampSerialRef, ampChannelIDRef
+
+	string listOfAmps, ampDef
+	variable numAmps, i, ampSerial, ampChannelID
+
+	listOfAmps = DAP_GetNiceAmplifierChannelList()
+	numAmps = ItemsInList(listOfAmps)
+
+	for(i = 0; i < numAmps; i += 1)
+		ampDef = StringFromList(i, listOfAmps)
+		DAP_ParseAmplifierDef(ampDef, ampSerial, ampChannelID)
+		if(ampSerial == ampSerialRef && ampChannelID == ampChannelIDRef)
+			return i
+		endif
+	endfor
+
+	ASSERT(0, "Could not find amplifier")
+End
+
+static Function CONF_MCC_MidExp(panelTitle, headStage, jsonID)
+	string panelTitle
+	variable headStage, jsonID
+
+	variable settingValue, clampMode
+
+	PGC_SetAndActivateControl(panelTitle,"slider_DataAcq_ActiveHeadstage", val = headStage)
+
+	clampMode = AI_GetMode(panelTitle, headstage)
+
+	if(clampMode == V_CLAMP_MODE)
+
+		settingValue = AI_SendToAmp(panelTitle, headStage, V_CLAMP_MODE, MCC_GETPIPETTEOFFSET_FUNC, NaN, checkBeforeWrite = 1)
+		PGC_SetAndActivateControl(panelTitle, "setvar_DataAcq_PipetteOffset_VC", val = settingValue)
+		PGC_SetAndActivateControl(panelTitle, "setvar_DataAcq_PipetteOffset_IC", val = settingValue)
+		settingValue = AI_SendToAmp(panelTitle, headStage, V_CLAMP_MODE, MCC_GETHOLDING_FUNC, NaN, checkBeforeWrite = 1)
+		PGC_SetAndActivateControl(panelTitle, "setvar_DataAcq_Hold_VC", val = settingValue)
+		settingValue = AI_SendToAmp(panelTitle, headStage, V_CLAMP_MODE, MCC_GETHOLDINGENABLE_FUNC, NaN, checkBeforeWrite = 1)
+		PGC_SetAndActivateControl(panelTitle, "check_DatAcq_HoldEnableVC", val = settingValue)
+		PGC_SetAndActivateControl(panelTitle,"check_DataAcq_AutoBias", val = CHECKBOX_SELECTED)
+		printf "HeadStage %d is in V-Clamp mode and has been configured from the MCC. I-Clamp settings were reset to initial values, check before switching!\r", headStage
+	elseif(clampMode == I_CLAMP_MODE)
+		settingValue = AI_SendToAmp(panelTitle, headStage, I_CLAMP_MODE, MCC_GETPIPETTEOFFSET_FUNC, NaN, checkBeforeWrite = 1)
+		PGC_SetAndActivateControl(panelTitle, "setvar_DataAcq_PipetteOffset_VC", val = settingValue)
+		PGC_SetAndActivateControl(panelTitle, "setvar_DataAcq_PipetteOffset_IC", val = settingValue)
+		settingValue = AI_SendToAmp(panelTitle, headStage, I_CLAMP_MODE, MCC_GETHOLDING_FUNC, NaN, checkBeforeWrite = 1)
+		PGC_SetAndActivateControl(panelTitle, "setvar_DataAcq_Hold_IC", val = settingValue)
+		settingValue = AI_SendToAmp(panelTitle, headStage, I_CLAMP_MODE, MCC_GETHOLDINGENABLE_FUNC, NaN, checkBeforeWrite = 1)
+		PGC_SetAndActivateControl(panelTitle, "check_DatAcq_HoldEnable", val = settingValue)
+		settingValue = AI_SendToAmp(panelTitle, headStage, I_CLAMP_MODE, MCC_GETBRIDGEBALRESIST_FUNC, NaN, checkBeforeWrite = 1)
+		PGC_SetAndActivateControl(panelTitle, "setvar_DataAcq_BB", val = settingValue)
+		settingValue = AI_SendToAmp(panelTitle, headStage, I_CLAMP_MODE, MCC_GETBRIDGEBALENABLE_FUNC, NaN, checkBeforeWrite = 1)
+		PGC_SetAndActivateControl(panelTitle, "check_DatAcq_BBEnable", val = settingValue)
+		settingValue = AI_SendToAmp(panelTitle, headStage, I_CLAMP_MODE, MCC_GETNEUTRALIZATIONCAP_FUNC, NaN, checkBeforeWrite = 1)
+		PGC_SetAndActivateControl(panelTitle, "setvar_DataAcq_CN", val = settingValue)
+		settingValue = AI_SendToAmp(panelTitle, headStage, I_CLAMP_MODE, MCC_GETNEUTRALIZATIONENABL_FUNC, NaN, checkBeforeWrite = 1)
+		PGC_SetAndActivateControl(panelTitle, "check_DatAcq_CNEnable", val = settingValue)
+		PGC_SetAndActivateControl(panelTitle,"check_DataAcq_AutoBias", val = CHECKBOX_UNSELECTED)
+		PGC_SetAndActivateControl(panelTitle,"check_DatAcq_HoldEnableVC", val = CHECKBOX_UNSELECTED)
+		printf "HeadStage %d is in I-Clamp mode and has been configured from the MCC. V-Clamp settings were reset to initial values, check before switching!\r", headStage
+	elseif(clampMode == I_EQUAL_ZERO_MODE)
+		// do nothing
+	endif
+End
+
+/// @brief Position MCC windows to upper right monitor using nircmd.exe
+///
+/// @param serialNum   Serial number of MCC
+/// @param winTitle    Name of MCC window
+/// @param winPosition One of 4 monitors to position MCCs in
+Function CONF_Position_MCC_Win(serialNum, winTitle, winPosition)
+	string serialNum, winTitle, winPosition
+	Make /T /FREE winNm
+	string cmd, fullPath, cmdPath
+	variable w
+
+	if(cmpstr(winPosition, NONE) == 0)
+		return 0
+	endif
+
+	fullPath = GetFolder(FunctionPath("")) + "..:..:tools:nircmd:nircmd.exe"
+	GetFileFolderInfo /Q/Z fullPath
+	cmdPath = S_Creator
+	if(V_flag != 0)
+		printf "nircmd.exe is not installed, please download it here: %s", "http://www.nirsoft.net/utils/nircmd.html"
+	endif
+
+	for(w = 0; w<NUM_HEADSTAGES/2; w+=1)
+
+		winNm[w] = {stringfromlist(w,winTitle) + "(" + stringfromlist(w,serialNum) + ")"}
+		sprintf cmd, "\"%s\" nircmd.exe win center title \"%s\"", cmdPath, winNm[w]
+		ExecuteScriptText cmd
+	endfor
+
+	if(cmpstr(winPosition, "Upper Right") == 0)
+		sprintf cmd, "\"%s\" nircmd.exe win move title \"%s\" 2300 -1250 0 0", cmdPath, winNm[0]
+		ExecuteScriptText cmd
+		sprintf cmd, "\"%s\" nircmd.exe win activate title \"%s\"", cmdPath, winNm[0]
+		ExecuteScriptText cmd
+		sprintf cmd, "\"%s\" nircmd.exe win move title \"%s\" 2675 -1250 0 0", cmdPath, winNm[1]
+		ExecuteScriptText cmd
+		sprintf cmd, "\"%s\" nircmd.exe win activate title \"%s\"", cmdPath, winNm[1]
+		ExecuteScriptText cmd
+		sprintf cmd, "\"%s\" nircmd.exe win move title \"%s\" 2300 -900 0 0", cmdPath, winNm[2]
+		ExecuteScriptText cmd
+		sprintf cmd, "\"%s\" nircmd.exe win activate title \"%s\"", cmdPath, winNm[2]
+		ExecuteScriptText cmd
+		sprintf cmd, "\"%s\"nircmd.exe win move title \"%s\" 2675 -900 0 0", cmdPath, winNm[3]
+		ExecuteScriptText cmd
+		sprintf cmd, "\"%s\" nircmd.exe win activate title \"%s\"", cmdPath, winNm[3]
+		ExecuteScriptText cmd
+	elseif(cmpstr(winPosition, "Lower Right") == 0)
+		sprintf cmd, "\"%s\" nircmd.exe win move title \"%s\" 2300 -200 0 0", cmdPath, winNm[0]
+		ExecuteScriptText cmd
+		sprintf cmd, "\"%s\" nircmd.exe win activate title \"%s\"", cmdPath, winNm[0]
+		ExecuteScriptText cmd
+		sprintf cmd, "\"%s\" nircmd.exe win move title \"%s\" 2675 -200 0 0", cmdPath, winNm[1]
+		ExecuteScriptText cmd
+		sprintf cmd, "\"%s\" nircmd.exe win activate title \"%s\"", cmdPath, winNm[1]
+		ExecuteScriptText cmd
+		sprintf cmd, "\"%s\" nircmd.exe win move title \"%s\" 2300 100 0 0", cmdPath, winNm[2]
+		ExecuteScriptText cmd
+		sprintf cmd, "\"%s\" nircmd.exe win activate title \"%s\"", cmdPath, winNm[2]
+		ExecuteScriptText cmd
+		sprintf cmd, "\"%s\"nircmd.exe win move title \"%s\" 2675 100 0 0", cmdPath, winNm[3]
+		ExecuteScriptText cmd
+		sprintf cmd, "\"%s\" nircmd.exe win activate title \"%s\"", cmdPath, winNm[3]
+		ExecuteScriptText cmd
+	elseif(cmpstr(winPosition, "Lower Left") == 0)
+		sprintf cmd, "\"%s\" nircmd.exe win move title \"%s\" 300 -200 0 0", cmdPath, winNm[0]
+		ExecuteScriptText cmd
+		sprintf cmd, "\"%s\" nircmd.exe win activate title \"%s\"", cmdPath, winNm[0]
+		ExecuteScriptText cmd
+		sprintf cmd, "\"%s\" nircmd.exe win move title \"%s\" 700 -200 0 0", cmdPath, winNm[1]
+		ExecuteScriptText cmd
+		sprintf cmd, "\"%s\" nircmd.exe win activate title \"%s\"", cmdPath, winNm[1]
+		ExecuteScriptText cmd
+		sprintf cmd, "\"%s\" nircmd.exe win move title \"%s\" 300 100 0 0", cmdPath, winNm[2]
+		ExecuteScriptText cmd
+		sprintf cmd, "\"%s\" nircmd.exe win activate title \"%s\"", cmdPath, winNm[2]
+		ExecuteScriptText cmd
+		sprintf cmd, "\"%s\"nircmd.exe win move title \"%s\" 700 100 0 0", cmdPath, winNm[3]
+		ExecuteScriptText cmd
+		sprintf cmd, "\"%s\" nircmd.exe win activate title \"%s\"", cmdPath, winNm[3]
+		ExecuteScriptText cmd
+	elseif(cmpstr(winPosition, "Upper Left") == 0)
+		sprintf cmd, "\"%s\" nircmd.exe win move title \"%s\" 300 -1250 0 0", cmdPath, winNm[0]
+		ExecuteScriptText cmd
+		sprintf cmd, "\"%s\" nircmd.exe win activate title \"%s\"", cmdPath, winNm[0]
+		ExecuteScriptText cmd
+		sprintf cmd, "\"%s\" nircmd.exe win move title \"%s\" 700 -1250 0 0", cmdPath, winNm[1]
+		ExecuteScriptText cmd
+		sprintf cmd, "\"%s\" nircmd.exe win activate title \"%s\"", cmdPath, winNm[1]
+		ExecuteScriptText cmd
+		sprintf cmd, "\"%s\" nircmd.exe win move title \"%s\" 300 -900 0 0", cmdPath, winNm[2]
+		ExecuteScriptText cmd
+		sprintf cmd, "\"%s\" nircmd.exe win activate title \"%s\"", cmdPath, winNm[2]
+		ExecuteScriptText cmd
+		sprintf cmd, "\"%s\"nircmd.exe win move title \"%s\" 700 -900 0 0", cmdPath, winNm[3]
+		ExecuteScriptText cmd
+		sprintf cmd, "\"%s\" nircmd.exe win activate title \"%s\"", cmdPath, winNm[3]
+		ExecuteScriptText cmd
+	else
+		printf "Message: If you would like to position the MCC windows please select a monitor in the Configuration text file"
+	endif
+End

--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -298,7 +298,8 @@ Function CONF_RestoreWindow(fName[, usePanelTypeFromFile])
 			elseif(!CmpStr(panelType, PANELTAG_DATABROWSER))
 				DB_OpenDataBrowser()
 				wName = GetMainWindow(GetCurrentWindow())
-				SetWindow $wName, userData($EXPCONFIG_UDATA_SOURCEFILE)=""
+				SetWindow $wName, userData($EXPCONFIG_UDATA_SOURCEFILE_PATH)=""
+				SetWindow $wName, userData($EXPCONFIG_UDATA_SOURCEFILE_HASH)=""
 				wName = CONF_JSONToWindow(wName, restoreMask, jsonID)
 				CONF_AddConfigFileUserData(wName, fullFilePath)
 				print "Configuration restored for " + wName
@@ -321,7 +322,8 @@ Function CONF_RestoreWindow(fName[, usePanelTypeFromFile])
 					return 0
 				endif
 				jsonID = CONF_ParseJSON(input)
-				SetWindow $wName, userData($EXPCONFIG_UDATA_SOURCEFILE)=""
+				SetWindow $wName, userData($EXPCONFIG_UDATA_SOURCEFILE_PATH)=""
+				SetWindow $wName, userData($EXPCONFIG_UDATA_SOURCEFILE_HASH)=""
 				wName = CONF_JSONToWindow(wName, restoreMask, jsonID)
 				CONF_AddConfigFileUserData(wName, fullFilePath)
 				print "Configuration restored for " + wName
@@ -433,7 +435,8 @@ Function CONF_RestoreDAEphys(jsonID, fullFilePath, [middleOfExperiment, forceNew
 			endif
 		endif
 
-		SetWindow $panelTitle, userData($EXPCONFIG_UDATA_SOURCEFILE)=""
+		SetWindow $panelTitle, userData($EXPCONFIG_UDATA_SOURCEFILE_PATH)=""
+		SetWindow $panelTitle, userData($EXPCONFIG_UDATA_SOURCEFILE_HASH)=""
 
 		if(middleOfExperiment)
 			PGC_SetAndActivateControl(panelTitle, "check_Settings_SyncMiesToMCC", val = CHECKBOX_UNSELECTED)
@@ -510,11 +513,12 @@ Function CONF_RestoreDAEphys(jsonID, fullFilePath, [middleOfExperiment, forceNew
 	endtry
 End
 
-/// @brief Add the config file path to the panel as user data
+/// @brief Add the config file path and SHA-256 hash to the panel as user data
 static Function CONF_AddConfigFileUserData(win, fullFilePath)
 	string win, fullFilePath
 
-	SetWindow $win, userData($EXPCONFIG_UDATA_SOURCEFILE)=fullFilePath
+	SetWindow $win, userData($EXPCONFIG_UDATA_SOURCEFILE_PATH)=fullFilePath
+	SetWindow $win, userData($EXPCONFIG_UDATA_SOURCEFILE_HASH)=CalcHashForFile(fullFilePath)
 End
 
 /// @brief Parses a json formatted string to a json object. This function shows a helpful error message if the parse fails

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -595,7 +595,7 @@ Constant WAVEBUILDER_PANEL_VERSION  = 8
 /// - Changed names of entries
 /// - Changed units or meaning of entries
 /// - New/Changed layers of entries
-Constant LABNOTEBOOK_VERSION = 34
+Constant LABNOTEBOOK_VERSION = 35
 
 /// Version of the stimset wave note
 Constant STIMSET_NOTE_VERSION = 6
@@ -1232,7 +1232,8 @@ StrConstant PANELTAG_DAEPHYS = "DA_Ephys"
 StrConstant PANELTAG_DATABROWSER = "DataBrowser"
 /// @}
 
-StrConstant EXPCONFIG_UDATA_SOURCEFILE = "Config_FileName"
+StrConstant EXPCONFIG_UDATA_SOURCEFILE_PATH = "Config_FileName"
+StrConstant EXPCONFIG_UDATA_SOURCEFILE_HASH = "Config_FileHash"
 
 /// @name Bit mask constants for properties for window control saving/restore
 /// @anchor WindowControlSavingMask

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -1232,6 +1232,8 @@ StrConstant PANELTAG_DAEPHYS = "DA_Ephys"
 StrConstant PANELTAG_DATABROWSER = "DataBrowser"
 /// @}
 
+StrConstant EXPCONFIG_UDATA_SOURCEFILE = "Config_FileName"
+
 /// @name Bit mask constants for properties for window control saving/restore
 /// @anchor WindowControlSavingMask
 /// @{

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -158,6 +158,7 @@ Constant CONTROL_TYPE_CHECKBOX      = 2
 Constant CONTROL_TYPE_POPUPMENU     = 3
 Constant CONTROL_TYPE_VALDISPLAY    = 4
 Constant CONTROL_TYPE_SETVARIABLE   = 5
+Constant CONTROL_TYPE_CHART         = 6
 Constant CONTROL_TYPE_SLIDER        = 7
 Constant CONTROL_TYPE_TAB           = 8
 Constant CONTROL_TYPE_GROUPBOX      = 9
@@ -582,7 +583,7 @@ Constant HARDWARE_DAC_EXTERNAL_TRIGGER = 0x1
 /// @}
 
 /// Used to upgrade the GuiStateWave as well as the DA Ephys panel
-Constant DA_EPHYS_PANEL_VERSION     = 44
+Constant DA_EPHYS_PANEL_VERSION     = 45
 Constant DATABROWSER_PANEL_VERSION  = 12
 Constant SWEEPBROWSER_PANEL_VERSION = 3
 Constant WAVEBUILDER_PANEL_VERSION  = 8
@@ -1194,4 +1195,68 @@ Constant FINDLEVEL_EDGE_BOTH       = 0
 /// @{
 Constant FINDLEVEL_MODE_SINGLE = 1
 Constant FINDLEVEL_MODE_MULTI  = 2
+/// @}
+
+/// @name Return codes of the Igor exists function
+/// @anchor existsReturnCodes
+/// @{
+Constant EXISTS_NAME_NOT_USED = 0
+Constant EXISTS_AS_WAVE = 1
+Constant EXISTS_AS_VAR_OR_STR = 2
+Constant EXISTS_AS_FUNCTION = 3
+Constant EXISTS_AS_OPERATION = 4
+Constant EXISTS_AS_MACRO = 5
+Constant EXISTS_AS_USERFUNCTION = 6
+/// @}
+
+/// @name Return codes of the Igor WinType function
+/// @anchor wintypeReturnCodes
+/// @{
+Constant WINTYPE_NOWINDOW = 0
+Constant WINTYPE_GRAPH = 1
+Constant WINTYPE_TABLE = 2
+Constant WINTYPE_LAYOUT = 3
+Constant WINTYPE_NOTEBOOK = 5
+Constant WINTYPE_PANEL = 7
+Constant WINTYPE_XOP = 13
+Constant WINTYPE_CAMERA = 15
+Constant WINTYPE_GIZMO = 17
+/// @}
+
+/// @name Panel tag codes to identify panel types, set in creation macro as main window userdata($EXPCONFIG_UDATA_PANELTYPE)
+/// @anchor panelTags
+/// @{
+StrConstant EXPCONFIG_UDATA_PANELTYPE = "Config_PanelType"
+
+StrConstant PANELTAG_DAEPHYS = "DA_Ephys"
+StrConstant PANELTAG_DATABROWSER = "DataBrowser"
+/// @}
+
+/// @name Bit mask constants for properties for window control saving/restore
+/// @anchor WindowControlSavingMask
+/// @{
+Constant EXPCONFIG_SAVE_VALUE = 1
+Constant EXPCONFIG_SAVE_POSITION = 2
+Constant EXPCONFIG_SAVE_USERDATA = 4
+Constant EXPCONFIG_SAVE_DISABLED = 8
+Constant EXPCONFIG_SAVE_CTRLTYPE = 16
+Constant EXPCONFIG_SAVE_POPUPMENU_AS_STRING_ONLY = 32
+Constant EXPCONFIG_SAVE_POPUPMENU_AS_INDEX_ONLY = 64
+Constant EXPCONFIG_MINIMIZE_ON_RESTORE = 128
+Constant EXPCONFIG_SAVE_BUTTONS_ONLY_PRESSED = 256
+Constant EXPCONFIG_SAVE_ONLY_RELEVANT = 512
+/// @}
+
+/// @name Correlated control name/type/valuetype list for use with e.g. ControlInfo
+/// @anchor IgorControlData
+/// @{
+StrConstant EXPCONFIG_GUI_CTRLLIST = "Button;Chart;CheckBox;CustomControl;GroupBox;ListBox;PopupMenu;SetVariable;Slider;TabControl;TitleBox;ValDisplay;"
+StrConstant EXPCONFIG_GUI_CTRLTYPES = "1;6;2;12;9;11;3;5;7;8;10;4;"
+StrConstant EXPCONFIG_GUI_VVALUE =      "1;1;1;1;0;1;1;1;1;1;0;1;"
+StrConstant EXPCONFIG_GUI_SVALUE =      "0;1;0;0;1;1;1;1;1;1;0;1;"
+StrConstant EXPCONFIG_GUI_SDATAFOLDER = "0;0;0;0;0;1;0;1;1;0;1;0;"
+/// 0 does not apply, 1 V_Value, 2 S_Value, 3 S_DataFolder for EXPCONFIG_SAVE_ONLY_RELEVANT
+StrConstant EXPCONFIG_GUI_PREFERRED =   "0;2;0;0;0;3;2;0;1;1;0;1;"
+
+StrConstant EXPCONFIG_GUI_SUSERDATA =   "1;0;1;1;0;1;1;1;1;1;0;0;"
 /// @}

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -4201,6 +4201,10 @@ Function/S DAP_CreateDAEphysPanel()
 
 	string panel
 
+	if(!WindowExists("HistoryCarbonCopy"))
+		CreateHistoryNotebook()
+	endif
+
 	// upgrade folder locations
 	GetITCDevicesFolder()
 
@@ -4212,10 +4216,6 @@ Function/S DAP_CreateDAEphysPanel()
 	panel = GetCurrentWindow()
 	SCOPE_OpenScopeWindow(panel)
 	AddVersionToPanel(panel, DA_EPHYS_PANEL_VERSION)
-
-	if(!WindowExists("HistoryCarbonCopy"))
-		CreateHistoryNotebook()
-	endif
 
 	return panel
 End

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -29,6 +29,27 @@ static StrConstant GUI_CONTROLSAVESTATE_DISABLED = "oldDisabledState"
 // PCIe-6343 | PXI-6259
 static StrConstant NI_DAC_PATTERNS = "AI:32;AO:4;COUNTER:4;DIOPORTS:3;LINES:32,8,8|AI:32;AO:4;COUNTER:2;DIOPORTS:3;LINES:32,8,8"
 
+/// @brief Creates meta information about coupled CheckBoxes (Radio Button) controls
+///        Used for saving/restoring the GUI state
+/// @return Free text wave with lists of coupled CheckBox controls
+Function/WAVE DAP_GetRadioButtonCoupling()
+
+	Make/FREE/T/N=10 w
+
+	w[0] = "Radio_ClampMode_0;Radio_ClampMode_1;Radio_ClampMode_1IZ;"
+	w[1] = "Radio_ClampMode_2;Radio_ClampMode_3;Radio_ClampMode_3IZ;"
+	w[2] = "Radio_ClampMode_4;Radio_ClampMode_5;Radio_ClampMode_5IZ;"
+	w[3] = "Radio_ClampMode_6;Radio_ClampMode_7;Radio_ClampMode_7IZ;"
+	w[4] = "Radio_ClampMode_8;Radio_ClampMode_9;Radio_ClampMode_9IZ;"
+	w[5] = "Radio_ClampMode_10;Radio_ClampMode_11;Radio_ClampMode_11IZ;"
+	w[6] = "Radio_ClampMode_12;Radio_ClampMode_13;Radio_ClampMode_13IZ;"
+	w[7] = "Radio_ClampMode_14;Radio_ClampMode_15;Radio_ClampMode_15IZ;"
+	w[8] = "Radio_ClampMode_AllVClamp;Radio_ClampMode_AllIClamp;Radio_ClampMode_AllIZero;"
+	w[9] = "check_Settings_Option_3;check_Settings_SetOption_5;"
+
+	return w
+End
+
 /// @brief Returns a list of DAC devices for NI devices
 /// @return list of NI DAC devices
 Function/S DAP_GetNIDeviceList()

--- a/Packages/MIES/MIES_DAEphys_Macro.ipf
+++ b/Packages/MIES/MIES_DAEphys_Macro.ipf
@@ -11,7 +11,7 @@
 
 Window DA_Ephys() : Panel
 	PauseUpdate; Silent 1		// building window...
-	NewPanel /K=1 /W=(157,759,661,1639)
+	NewPanel /K=1 /W=(1098,1078,1602,1958)
 	ValDisplay valdisp_DataAcq_P_LED_Clear,pos={366.00,297.00},size={84.00,27.00},disable=1
 	ValDisplay valdisp_DataAcq_P_LED_Clear,help={"red:user"},userdata(tabnum)=  "0"
 	ValDisplay valdisp_DataAcq_P_LED_Clear,userdata(tabcontrol)=  "tab_DataAcq_Pressure"
@@ -57,7 +57,8 @@ Window DA_Ephys() : Panel
 	ValDisplay valdisp_DataAcq_P_LED_7,userdata(ResizeControlsInfo)= A"!!,I1J,hs=J,hne!!#=K!!!!\"!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	ValDisplay valdisp_DataAcq_P_LED_7,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	ValDisplay valdisp_DataAcq_P_LED_7,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	ValDisplay valdisp_DataAcq_P_LED_7,frame=5
+	ValDisplay valdisp_DataAcq_P_LED_7,userdata(ControlArray)=  "valdisp_DataAcq_P_LED"
+	ValDisplay valdisp_DataAcq_P_LED_7,userdata(ControlArrayIndex)=  "7",frame=5
 	ValDisplay valdisp_DataAcq_P_LED_7,limits={-1,2,0},barmisc={0,0},mode= 2,highColor= (65535,49000,49000),lowColor= (65535,65535,65535),zeroColor= (49151,53155,65535)
 	ValDisplay valdisp_DataAcq_P_LED_7,value= _NUM:-1
 	ValDisplay valdisp_DataAcq_P_LED_6,pos={362.00,345.00},size={42.00,27.00},disable=1
@@ -67,7 +68,8 @@ Window DA_Ephys() : Panel
 	ValDisplay valdisp_DataAcq_P_LED_6,userdata(ResizeControlsInfo)= A"!!,Hq!!#BgJ,hne!!#=K!!!!\"!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	ValDisplay valdisp_DataAcq_P_LED_6,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	ValDisplay valdisp_DataAcq_P_LED_6,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	ValDisplay valdisp_DataAcq_P_LED_6,frame=5
+	ValDisplay valdisp_DataAcq_P_LED_6,userdata(ControlArray)=  "valdisp_DataAcq_P_LED"
+	ValDisplay valdisp_DataAcq_P_LED_6,userdata(ControlArrayIndex)=  "6",frame=5
 	ValDisplay valdisp_DataAcq_P_LED_6,limits={-1,2,0},barmisc={0,0},mode= 2,highColor= (65535,49000,49000),lowColor= (65535,65535,65535),zeroColor= (49151,53155,65535)
 	ValDisplay valdisp_DataAcq_P_LED_6,value= _NUM:-1
 	ValDisplay valdisp_DataAcq_P_LED_5,pos={319.00,345.00},size={42.00,27.00},disable=1
@@ -77,7 +79,8 @@ Window DA_Ephys() : Panel
 	ValDisplay valdisp_DataAcq_P_LED_5,userdata(ResizeControlsInfo)= A"!!,H[J,hs=J,hne!!#=K!!!!\"!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	ValDisplay valdisp_DataAcq_P_LED_5,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	ValDisplay valdisp_DataAcq_P_LED_5,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	ValDisplay valdisp_DataAcq_P_LED_5,frame=5
+	ValDisplay valdisp_DataAcq_P_LED_5,userdata(ControlArray)=  "valdisp_DataAcq_P_LED"
+	ValDisplay valdisp_DataAcq_P_LED_5,userdata(ControlArrayIndex)=  "5",frame=5
 	ValDisplay valdisp_DataAcq_P_LED_5,limits={-1,2,0},barmisc={0,0},mode= 2,highColor= (65535,49000,49000),lowColor= (65535,65535,65535),zeroColor= (49151,53155,65535)
 	ValDisplay valdisp_DataAcq_P_LED_5,value= _NUM:-1
 	ValDisplay valdisp_DataAcq_P_LED_4,pos={276.00,345.00},size={42.00,27.00},disable=1
@@ -87,7 +90,9 @@ Window DA_Ephys() : Panel
 	ValDisplay valdisp_DataAcq_P_LED_4,userdata(ResizeControlsInfo)= A"!!,HF!!#BgJ,hne!!#=K!!!!\"!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	ValDisplay valdisp_DataAcq_P_LED_4,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	ValDisplay valdisp_DataAcq_P_LED_4,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	ValDisplay valdisp_DataAcq_P_LED_4,frame=5,valueBackColor=(61423,61423,61423)
+	ValDisplay valdisp_DataAcq_P_LED_4,userdata(ControlArray)=  "valdisp_DataAcq_P_LED"
+	ValDisplay valdisp_DataAcq_P_LED_4,userdata(ControlArrayIndex)=  "4",frame=5
+	ValDisplay valdisp_DataAcq_P_LED_4,valueBackColor=(61423,61423,61423)
 	ValDisplay valdisp_DataAcq_P_LED_4,limits={-1,2,0},barmisc={0,0},mode= 2,highColor= (65535,49000,49000),lowColor= (65535,65535,65535),zeroColor= (49151,53155,65535)
 	ValDisplay valdisp_DataAcq_P_LED_4,value= _NUM:-1
 	ValDisplay valdisp_DataAcq_P_LED_4,limitsBackColor= (61423,61423,61423)
@@ -98,7 +103,8 @@ Window DA_Ephys() : Panel
 	ValDisplay valdisp_DataAcq_P_LED_3,userdata(ResizeControlsInfo)= A"!!,H&!!#BgJ,hne!!#=K!!!!\"!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	ValDisplay valdisp_DataAcq_P_LED_3,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	ValDisplay valdisp_DataAcq_P_LED_3,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	ValDisplay valdisp_DataAcq_P_LED_3,frame=5
+	ValDisplay valdisp_DataAcq_P_LED_3,userdata(ControlArray)=  "valdisp_DataAcq_P_LED"
+	ValDisplay valdisp_DataAcq_P_LED_3,userdata(ControlArrayIndex)=  "3",frame=5
 	ValDisplay valdisp_DataAcq_P_LED_3,limits={-1,2,0},barmisc={0,0},mode= 2,highColor= (65535,49000,49000),lowColor= (65535,65535,65535),zeroColor= (49151,53155,65535)
 	ValDisplay valdisp_DataAcq_P_LED_3,value= _NUM:-1
 	ValDisplay valdisp_DataAcq_P_LED_2,pos={190.00,345.00},size={42.00,27.00},disable=1
@@ -108,7 +114,8 @@ Window DA_Ephys() : Panel
 	ValDisplay valdisp_DataAcq_P_LED_2,userdata(ResizeControlsInfo)= A"!!,GP!!#BgJ,hne!!#=K!!!!\"!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	ValDisplay valdisp_DataAcq_P_LED_2,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	ValDisplay valdisp_DataAcq_P_LED_2,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	ValDisplay valdisp_DataAcq_P_LED_2,frame=5
+	ValDisplay valdisp_DataAcq_P_LED_2,userdata(ControlArray)=  "valdisp_DataAcq_P_LED"
+	ValDisplay valdisp_DataAcq_P_LED_2,userdata(ControlArrayIndex)=  "2",frame=5
 	ValDisplay valdisp_DataAcq_P_LED_2,limits={-1,2,0},barmisc={0,0},mode= 2,highColor= (65535,49000,49000),lowColor= (65535,65535,65535),zeroColor= (49151,53155,65535)
 	ValDisplay valdisp_DataAcq_P_LED_2,value= _NUM:-1
 	ValDisplay valdisp_DataAcq_P_LED_0,pos={105.00,345.00},size={42.00,27.00},disable=1
@@ -118,7 +125,8 @@ Window DA_Ephys() : Panel
 	ValDisplay valdisp_DataAcq_P_LED_0,userdata(ResizeControlsInfo)= A"!!,F9!!#BgJ,hne!!#=K!!!!\"!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	ValDisplay valdisp_DataAcq_P_LED_0,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	ValDisplay valdisp_DataAcq_P_LED_0,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	ValDisplay valdisp_DataAcq_P_LED_0,frame=5
+	ValDisplay valdisp_DataAcq_P_LED_0,userdata(ControlArray)=  "valdisp_DataAcq_P_LED"
+	ValDisplay valdisp_DataAcq_P_LED_0,userdata(ControlArrayIndex)=  "0",frame=5
 	ValDisplay valdisp_DataAcq_P_LED_0,limits={-1,2,0},barmisc={0,0},mode= 2,highColor= (65535,49000,49000),lowColor= (65535,65535,65535),zeroColor= (49151,53155,65535)
 	ValDisplay valdisp_DataAcq_P_LED_0,value= _NUM:-1
 	ValDisplay valdisp_DataAcq_P_LED_1,pos={147.00,345.00},size={42.00,27.00},disable=1
@@ -128,7 +136,8 @@ Window DA_Ephys() : Panel
 	ValDisplay valdisp_DataAcq_P_LED_1,userdata(ResizeControlsInfo)= A"!!,G%!!#BgJ,hne!!#=K!!!!\"!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	ValDisplay valdisp_DataAcq_P_LED_1,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	ValDisplay valdisp_DataAcq_P_LED_1,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	ValDisplay valdisp_DataAcq_P_LED_1,frame=5
+	ValDisplay valdisp_DataAcq_P_LED_1,userdata(ControlArray)=  "valdisp_DataAcq_P_LED"
+	ValDisplay valdisp_DataAcq_P_LED_1,userdata(ControlArrayIndex)=  "1",frame=5
 	ValDisplay valdisp_DataAcq_P_LED_1,limits={-1,2,0},barmisc={0,0},mode= 2,highColor= (65535,49000,49000),lowColor= (65535,65535,65535),zeroColor= (49151,53155,65535)
 	ValDisplay valdisp_DataAcq_P_LED_1,value= _NUM:-1
 	ValDisplay valdisp_DataAcq_P_3,pos={238.00,351.00},size={35.00,21.00},bodyWidth=35,disable=1
@@ -136,7 +145,9 @@ Window DA_Ephys() : Panel
 	ValDisplay valdisp_DataAcq_P_3,userdata(ResizeControlsInfo)= A"!!,H*!!#BiJ,hnE!!#<`z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	ValDisplay valdisp_DataAcq_P_3,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	ValDisplay valdisp_DataAcq_P_3,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
-	ValDisplay valdisp_DataAcq_P_3,fSize=14,frame=0,fStyle=0
+	ValDisplay valdisp_DataAcq_P_3,userdata(ControlArray)=  "valdisp_DataAcq_P"
+	ValDisplay valdisp_DataAcq_P_3,userdata(ControlArrayIndex)=  "3",fSize=14
+	ValDisplay valdisp_DataAcq_P_3,frame=0,fStyle=0
 	ValDisplay valdisp_DataAcq_P_3,valueBackColor=(65535,65535,65535,0)
 	ValDisplay valdisp_DataAcq_P_3,limits={0,0,0},barmisc={0,1000},value= #"0.00"
 	GroupBox group_DataAcq_WholeCell,pos={39.00,198.00},size={150.00,60.00},disable=1,title="       Whole Cell"
@@ -145,6 +156,7 @@ Window DA_Ephys() : Panel
 	GroupBox group_DataAcq_WholeCell,userdata(ResizeControlsInfo)= A"!!,D3!!#AW!!#A%!!#?1z!!,c)Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	GroupBox group_DataAcq_WholeCell,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	GroupBox group_DataAcq_WholeCell,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	GroupBox group_DataAcq_WholeCell,userdata(Config_RestorePriority)=  "40"
 	TitleBox Title_settings_SetManagement,pos={948.00,-99.00},size={390.00,213.00},disable=1,title="Set Management Decision Tree"
 	TitleBox Title_settings_SetManagement,userdata(tabnum)=  "5"
 	TitleBox Title_settings_SetManagement,userdata(tabcontrol)=  "ADC"
@@ -168,392 +180,486 @@ Window DA_Ephys() : Panel
 	CheckBox Check_AD_00,userdata(ResizeControlsInfo)= A"!!,BY!!#?O!!#<`!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_AD_00,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_AD_00,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_AD_00,value= 0,side= 1
+	CheckBox Check_AD_00,userdata(ControlArray)=  "Check_AD"
+	CheckBox Check_AD_00,userdata(ControlArrayIndex)=  "0",value= 0,side= 1
 	CheckBox Check_AD_01,pos={18.00,120.00},size={22.00,15.00},disable=1,proc=DAP_CheckProc_AD,title="1"
 	CheckBox Check_AD_01,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_AD_01,userdata(ResizeControlsInfo)= A"!!,BY!!#@V!!#<`!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_AD_01,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_AD_01,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_AD_01,value= 0,side= 1
+	CheckBox Check_AD_01,userdata(ControlArray)=  "Check_AD"
+	CheckBox Check_AD_01,userdata(ControlArrayIndex)=  "1",value= 0,side= 1
 	CheckBox Check_AD_02,pos={18.00,165.00},size={22.00,15.00},disable=1,proc=DAP_CheckProc_AD,title="2"
 	CheckBox Check_AD_02,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_AD_02,userdata(ResizeControlsInfo)= A"!!,BY!!#A6!!#<`!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_AD_02,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_AD_02,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_AD_02,value= 0,side= 1
+	CheckBox Check_AD_02,userdata(ControlArray)=  "Check_AD"
+	CheckBox Check_AD_02,userdata(ControlArrayIndex)=  "2",value= 0,side= 1
 	CheckBox Check_AD_03,pos={18.00,213.00},size={22.00,15.00},disable=1,proc=DAP_CheckProc_AD,title="3"
 	CheckBox Check_AD_03,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_AD_03,userdata(ResizeControlsInfo)= A"!!,BY!!#Ae!!#<`!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_AD_03,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_AD_03,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_AD_03,value= 0,side= 1
+	CheckBox Check_AD_03,userdata(ControlArray)=  "Check_AD"
+	CheckBox Check_AD_03,userdata(ControlArrayIndex)=  "3",value= 0,side= 1
 	CheckBox Check_AD_04,pos={18.00,258.00},size={22.00,15.00},disable=1,proc=DAP_CheckProc_AD,title="4"
 	CheckBox Check_AD_04,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_AD_04,userdata(ResizeControlsInfo)= A"!!,BY!!#B<!!#<`!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_AD_04,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_AD_04,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_AD_04,value= 0,side= 1
+	CheckBox Check_AD_04,userdata(ControlArray)=  "Check_AD"
+	CheckBox Check_AD_04,userdata(ControlArrayIndex)=  "4",value= 0,side= 1
 	CheckBox Check_AD_05,pos={18.00,306.00},size={22.00,15.00},disable=1,proc=DAP_CheckProc_AD,title="5"
 	CheckBox Check_AD_05,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_AD_05,userdata(ResizeControlsInfo)= A"!!,BY!!#BSJ,hm6!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_AD_05,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_AD_05,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_AD_05,value= 0,side= 1
+	CheckBox Check_AD_05,userdata(ControlArray)=  "Check_AD"
+	CheckBox Check_AD_05,userdata(ControlArrayIndex)=  "5",value= 0,side= 1
 	CheckBox Check_AD_06,pos={18.00,351.00},size={22.00,15.00},disable=1,proc=DAP_CheckProc_AD,title="6"
 	CheckBox Check_AD_06,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_AD_06,userdata(ResizeControlsInfo)= A"!!,BY!!#BjJ,hm6!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_AD_06,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_AD_06,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_AD_06,value= 0,side= 1
+	CheckBox Check_AD_06,userdata(ControlArray)=  "Check_AD"
+	CheckBox Check_AD_06,userdata(ControlArrayIndex)=  "6",value= 0,side= 1
 	CheckBox Check_AD_07,pos={18.00,399.00},size={22.00,15.00},disable=1,proc=DAP_CheckProc_AD,title="7"
 	CheckBox Check_AD_07,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_AD_07,userdata(ResizeControlsInfo)= A"!!,BY!!#C-!!#<`!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_AD_07,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_AD_07,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_AD_07,value= 0,side= 1
+	CheckBox Check_AD_07,userdata(ControlArray)=  "Check_AD"
+	CheckBox Check_AD_07,userdata(ControlArrayIndex)=  "7",value= 0,side= 1
 	CheckBox Check_AD_08,pos={198.00,75.00},size={22.00,15.00},disable=1,proc=DAP_CheckProc_AD,title="8"
 	CheckBox Check_AD_08,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_AD_08,userdata(ResizeControlsInfo)= A"!!,GX!!#?O!!#<`!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_AD_08,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_AD_08,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_AD_08,value= 0,side= 1
+	CheckBox Check_AD_08,userdata(ControlArray)=  "Check_AD"
+	CheckBox Check_AD_08,userdata(ControlArrayIndex)=  "8",value= 0,side= 1
 	CheckBox Check_AD_09,pos={198.00,120.00},size={22.00,15.00},disable=1,proc=DAP_CheckProc_AD,title="9"
 	CheckBox Check_AD_09,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_AD_09,userdata(ResizeControlsInfo)= A"!!,GX!!#@V!!#<`!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_AD_09,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_AD_09,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_AD_09,value= 0,side= 1
+	CheckBox Check_AD_09,userdata(ControlArray)=  "Check_AD"
+	CheckBox Check_AD_09,userdata(ControlArrayIndex)=  "9",value= 0,side= 1
 	CheckBox Check_AD_10,pos={192.00,165.00},size={28.00,15.00},disable=1,proc=DAP_CheckProc_AD,title="10"
 	CheckBox Check_AD_10,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_AD_10,userdata(ResizeControlsInfo)= A"!!,GR!!#A6!!#=;!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_AD_10,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_AD_10,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_AD_10,value= 0,side= 1
+	CheckBox Check_AD_10,userdata(ControlArray)=  "Check_AD"
+	CheckBox Check_AD_10,userdata(ControlArrayIndex)=  "10",value= 0,side= 1
 	CheckBox Check_AD_12,pos={192.00,258.00},size={28.00,15.00},disable=1,proc=DAP_CheckProc_AD,title="12"
 	CheckBox Check_AD_12,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_AD_12,userdata(ResizeControlsInfo)= A"!!,GR!!#B<!!#=;!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_AD_12,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_AD_12,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_AD_12,value= 0,side= 1
+	CheckBox Check_AD_12,userdata(ControlArray)=  "Check_AD"
+	CheckBox Check_AD_12,userdata(ControlArrayIndex)=  "12",value= 0,side= 1
 	CheckBox Check_AD_11,pos={192.00,213.00},size={28.00,15.00},disable=1,proc=DAP_CheckProc_AD,title="11"
 	CheckBox Check_AD_11,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_AD_11,userdata(ResizeControlsInfo)= A"!!,GR!!#Ae!!#=;!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_AD_11,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_AD_11,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_AD_11,value= 0,side= 1
+	CheckBox Check_AD_11,userdata(ControlArray)=  "Check_AD"
+	CheckBox Check_AD_11,userdata(ControlArrayIndex)=  "11",value= 0,side= 1
 	SetVariable Gain_AD_00,pos={46.00,75.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_00,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_AD_00,userdata(ResizeControlsInfo)= A"!!,DW!!#?O!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_00,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_AD_00,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_AD_00,userdata(ControlArray)=  "Gain_AD"
+	SetVariable Gain_AD_00,userdata(ControlArrayIndex)=  "0"
 	SetVariable Gain_AD_00,limits={0,inf,1},value= _NUM:0
 	SetVariable Gain_AD_01,pos={46.00,120.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_01,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_AD_01,userdata(ResizeControlsInfo)= A"!!,DW!!#@V!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_01,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_AD_01,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_AD_01,userdata(ControlArray)=  "Gain_AD"
+	SetVariable Gain_AD_01,userdata(ControlArrayIndex)=  "1"
 	SetVariable Gain_AD_01,limits={0,inf,1},value= _NUM:0
 	SetVariable Gain_AD_02,pos={46.00,165.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_02,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_AD_02,userdata(ResizeControlsInfo)= A"!!,DW!!#A6!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_02,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_AD_02,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_AD_02,userdata(ControlArray)=  "Gain_AD"
+	SetVariable Gain_AD_02,userdata(ControlArrayIndex)=  "2"
 	SetVariable Gain_AD_02,limits={0,inf,1},value= _NUM:0
 	SetVariable Gain_AD_03,pos={46.00,213.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_03,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_AD_03,userdata(ResizeControlsInfo)= A"!!,DW!!#Ae!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_03,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_AD_03,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_AD_03,userdata(ControlArray)=  "Gain_AD"
+	SetVariable Gain_AD_03,userdata(ControlArrayIndex)=  "3"
 	SetVariable Gain_AD_03,limits={0,inf,1},value= _NUM:0
 	SetVariable Gain_AD_04,pos={46.00,258.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_04,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_AD_04,userdata(ResizeControlsInfo)= A"!!,DW!!#B<!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_04,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_AD_04,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_AD_04,userdata(ControlArray)=  "Gain_AD"
+	SetVariable Gain_AD_04,userdata(ControlArrayIndex)=  "4"
 	SetVariable Gain_AD_04,limits={0,inf,1},value= _NUM:0
 	SetVariable Gain_AD_05,pos={46.00,306.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_05,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_AD_05,userdata(ResizeControlsInfo)= A"!!,DW!!#BSJ,ho,!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_05,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_AD_05,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_AD_05,userdata(ControlArray)=  "Gain_AD"
+	SetVariable Gain_AD_05,userdata(ControlArrayIndex)=  "5"
 	SetVariable Gain_AD_05,limits={0,inf,1},value= _NUM:0
 	SetVariable Gain_AD_06,pos={46.00,351.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_06,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_AD_06,userdata(ResizeControlsInfo)= A"!!,DW!!#BjJ,ho,!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_06,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_AD_06,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_AD_06,userdata(ControlArray)=  "Gain_AD"
+	SetVariable Gain_AD_06,userdata(ControlArrayIndex)=  "6"
 	SetVariable Gain_AD_06,limits={0,inf,1},value= _NUM:0
 	SetVariable Gain_AD_07,pos={46.00,399.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_07,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_AD_07,userdata(ResizeControlsInfo)= A"!!,DW!!#C-!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_07,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_AD_07,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_AD_07,userdata(ControlArray)=  "Gain_AD"
+	SetVariable Gain_AD_07,userdata(ControlArrayIndex)=  "7"
 	SetVariable Gain_AD_07,limits={0,inf,1},value= _NUM:0
 	SetVariable Gain_AD_08,pos={226.00,75.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_08,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_AD_08,userdata(ResizeControlsInfo)= A"!!,Gu!!#?O!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_08,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_AD_08,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_AD_08,userdata(ControlArray)=  "Gain_AD"
+	SetVariable Gain_AD_08,userdata(ControlArrayIndex)=  "8"
 	SetVariable Gain_AD_08,limits={0,inf,1},value= _NUM:0
 	SetVariable Gain_AD_09,pos={226.00,120.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_09,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_AD_09,userdata(ResizeControlsInfo)= A"!!,Gu!!#@V!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_09,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_AD_09,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_AD_09,userdata(ControlArray)=  "Gain_AD"
+	SetVariable Gain_AD_09,userdata(ControlArrayIndex)=  "9"
 	SetVariable Gain_AD_09,limits={0,inf,1},value= _NUM:0
 	SetVariable Gain_AD_10,pos={226.00,165.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_10,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_AD_10,userdata(ResizeControlsInfo)= A"!!,Gu!!#A6!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_10,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_AD_10,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_AD_10,userdata(ControlArray)=  "Gain_AD"
+	SetVariable Gain_AD_10,userdata(ControlArrayIndex)=  "10"
 	SetVariable Gain_AD_10,limits={0,inf,1},value= _NUM:0
 	SetVariable Gain_AD_11,pos={226.00,213.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_11,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_AD_11,userdata(ResizeControlsInfo)= A"!!,Gu!!#Ae!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_11,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_AD_11,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_AD_11,userdata(ControlArray)=  "Gain_AD"
+	SetVariable Gain_AD_11,userdata(ControlArrayIndex)=  "11"
 	SetVariable Gain_AD_11,limits={0,inf,1},value= _NUM:0
 	SetVariable Gain_AD_12,pos={226.00,258.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_12,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_AD_12,userdata(ResizeControlsInfo)= A"!!,Gu!!#B<!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_12,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_AD_12,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_AD_12,userdata(ControlArray)=  "Gain_AD"
+	SetVariable Gain_AD_12,userdata(ControlArrayIndex)=  "12"
 	SetVariable Gain_AD_12,limits={0,inf,1},value= _NUM:0
 	CheckBox Check_AD_13,pos={192.00,306.00},size={28.00,15.00},disable=1,proc=DAP_CheckProc_AD,title="13"
 	CheckBox Check_AD_13,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_AD_13,userdata(ResizeControlsInfo)= A"!!,GR!!#BSJ,hmf!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_AD_13,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_AD_13,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_AD_13,value= 0,side= 1
+	CheckBox Check_AD_13,userdata(ControlArray)=  "Check_AD"
+	CheckBox Check_AD_13,userdata(ControlArrayIndex)=  "13",value= 0,side= 1
 	CheckBox Check_AD_14,pos={192.00,351.00},size={28.00,15.00},disable=1,proc=DAP_CheckProc_AD,title="14"
 	CheckBox Check_AD_14,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_AD_14,userdata(ResizeControlsInfo)= A"!!,GR!!#BjJ,hmf!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_AD_14,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_AD_14,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_AD_14,value= 0,side= 1
+	CheckBox Check_AD_14,userdata(ControlArray)=  "Check_AD"
+	CheckBox Check_AD_14,userdata(ControlArrayIndex)=  "14",value= 0,side= 1
 	CheckBox Check_AD_15,pos={192.00,399.00},size={28.00,15.00},disable=1,proc=DAP_CheckProc_AD,title="15"
 	CheckBox Check_AD_15,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_AD_15,userdata(ResizeControlsInfo)= A"!!,GR!!#C-!!#=;!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_AD_15,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_AD_15,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_AD_15,value= 0,side= 1
+	CheckBox Check_AD_15,userdata(ControlArray)=  "Check_AD"
+	CheckBox Check_AD_15,userdata(ControlArrayIndex)=  "15",value= 0,side= 1
 	SetVariable Gain_AD_13,pos={226.00,306.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_13,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_AD_13,userdata(ResizeControlsInfo)= A"!!,Gu!!#BSJ,ho,!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_13,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_AD_13,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_AD_13,userdata(ControlArray)=  "Gain_AD"
+	SetVariable Gain_AD_13,userdata(ControlArrayIndex)=  "13"
 	SetVariable Gain_AD_13,limits={0,inf,1},value= _NUM:0
 	SetVariable Gain_AD_14,pos={226.00,351.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_14,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_AD_14,userdata(ResizeControlsInfo)= A"!!,Gu!!#BjJ,ho,!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_14,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_AD_14,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_AD_14,userdata(ControlArray)=  "Gain_AD"
+	SetVariable Gain_AD_14,userdata(ControlArrayIndex)=  "14"
 	SetVariable Gain_AD_14,limits={0,inf,1},value= _NUM:0
 	SetVariable Gain_AD_15,pos={226.00,399.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_15,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_AD_15,userdata(ResizeControlsInfo)= A"!!,Gu!!#C-!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_15,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_AD_15,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_AD_15,userdata(ControlArray)=  "Gain_AD"
+	SetVariable Gain_AD_15,userdata(ControlArrayIndex)=  "15"
 	SetVariable Gain_AD_15,limits={0,inf,1},value= _NUM:0
 	CheckBox Check_DA_00,pos={18.00,75.00},size={22.00,15.00},disable=1,proc=DAP_DAorTTLCheckProc,title="0"
 	CheckBox Check_DA_00,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_DA_00,userdata(ResizeControlsInfo)= A"!!,BY!!#?O!!#<`!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_DA_00,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_DA_00,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_DA_00,value= 0,side= 1
+	CheckBox Check_DA_00,userdata(ControlArray)=  "Check_DA"
+	CheckBox Check_DA_00,userdata(ControlArrayIndex)=  "0",value= 0,side= 1
 	CheckBox Check_DA_01,pos={18.00,120.00},size={22.00,15.00},disable=1,proc=DAP_DAorTTLCheckProc,title="1"
 	CheckBox Check_DA_01,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_DA_01,userdata(ResizeControlsInfo)= A"!!,BY!!#@V!!#<`!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_DA_01,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_DA_01,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_DA_01,value= 0,side= 1
+	CheckBox Check_DA_01,userdata(ControlArray)=  "Check_DA"
+	CheckBox Check_DA_01,userdata(ControlArrayIndex)=  "1",value= 0,side= 1
 	CheckBox Check_DA_02,pos={18.00,165.00},size={22.00,15.00},disable=1,proc=DAP_DAorTTLCheckProc,title="2"
 	CheckBox Check_DA_02,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_DA_02,userdata(ResizeControlsInfo)= A"!!,BY!!#A6!!#<`!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_DA_02,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_DA_02,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_DA_02,value= 0,side= 1
+	CheckBox Check_DA_02,userdata(ControlArray)=  "Check_DA"
+	CheckBox Check_DA_02,userdata(ControlArrayIndex)=  "2",value= 0,side= 1
 	CheckBox Check_DA_03,pos={18.00,213.00},size={22.00,15.00},disable=1,proc=DAP_DAorTTLCheckProc,title="3"
 	CheckBox Check_DA_03,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_DA_03,userdata(ResizeControlsInfo)= A"!!,BY!!#Ae!!#<`!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_DA_03,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_DA_03,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_DA_03,value= 0,side= 1
+	CheckBox Check_DA_03,userdata(ControlArray)=  "Check_DA"
+	CheckBox Check_DA_03,userdata(ControlArrayIndex)=  "3",value= 0,side= 1
 	CheckBox Check_DA_04,pos={18.00,258.00},size={22.00,15.00},disable=1,proc=DAP_DAorTTLCheckProc,title="4"
 	CheckBox Check_DA_04,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_DA_04,userdata(ResizeControlsInfo)= A"!!,BY!!#B<!!#<`!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_DA_04,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_DA_04,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_DA_04,value= 0,side= 1
+	CheckBox Check_DA_04,userdata(ControlArray)=  "Check_DA"
+	CheckBox Check_DA_04,userdata(ControlArrayIndex)=  "4",value= 0,side= 1
 	CheckBox Check_DA_05,pos={18.00,306.00},size={22.00,15.00},disable=1,proc=DAP_DAorTTLCheckProc,title="5"
 	CheckBox Check_DA_05,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_DA_05,userdata(ResizeControlsInfo)= A"!!,BY!!#BSJ,hm6!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_DA_05,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_DA_05,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_DA_05,value= 0,side= 1
+	CheckBox Check_DA_05,userdata(ControlArray)=  "Check_DA"
+	CheckBox Check_DA_05,userdata(ControlArrayIndex)=  "5",value= 0,side= 1
 	CheckBox Check_DA_06,pos={18.00,351.00},size={22.00,15.00},disable=1,proc=DAP_DAorTTLCheckProc,title="6"
 	CheckBox Check_DA_06,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_DA_06,userdata(ResizeControlsInfo)= A"!!,BY!!#BjJ,hm6!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_DA_06,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_DA_06,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_DA_06,value= 0,side= 1
+	CheckBox Check_DA_06,userdata(ControlArray)=  "Check_DA"
+	CheckBox Check_DA_06,userdata(ControlArrayIndex)=  "6",value= 0,side= 1
 	CheckBox Check_DA_07,pos={18.00,399.00},size={22.00,15.00},disable=1,proc=DAP_DAorTTLCheckProc,title="7"
 	CheckBox Check_DA_07,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_DA_07,userdata(ResizeControlsInfo)= A"!!,BY!!#C-!!#<`!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_DA_07,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_DA_07,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_DA_07,value= 0,side= 1
+	CheckBox Check_DA_07,userdata(ControlArray)=  "Check_DA"
+	CheckBox Check_DA_07,userdata(ControlArrayIndex)=  "7",value= 0,side= 1
 	SetVariable Gain_DA_00,pos={48.00,75.00},size={48.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_DA_00,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_DA_00,userdata(ResizeControlsInfo)= A"!!,DW!!#?O!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_DA_00,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_DA_00,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_DA_00,userdata(ControlArray)=  "Gain_DA"
+	SetVariable Gain_DA_00,userdata(ControlArrayIndex)=  "0"
 	SetVariable Gain_DA_00,limits={0,inf,1},value= _NUM:0
 	SetVariable Gain_DA_01,pos={48.00,120.00},size={48.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_DA_01,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_DA_01,userdata(ResizeControlsInfo)= A"!!,DW!!#@V!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_DA_01,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_DA_01,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_DA_01,userdata(ControlArray)=  "Gain_DA"
+	SetVariable Gain_DA_01,userdata(ControlArrayIndex)=  "1"
 	SetVariable Gain_DA_01,limits={0,inf,1},value= _NUM:0
 	SetVariable Gain_DA_02,pos={48.00,165.00},size={48.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_DA_02,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_DA_02,userdata(ResizeControlsInfo)= A"!!,DW!!#A6!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_DA_02,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_DA_02,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_DA_02,userdata(ControlArray)=  "Gain_DA"
+	SetVariable Gain_DA_02,userdata(ControlArrayIndex)=  "2"
 	SetVariable Gain_DA_02,limits={0,inf,1},value= _NUM:0
 	SetVariable Gain_DA_03,pos={48.00,213.00},size={48.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_DA_03,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_DA_03,userdata(ResizeControlsInfo)= A"!!,DW!!#Ae!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_DA_03,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_DA_03,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_DA_03,userdata(ControlArray)=  "Gain_DA"
+	SetVariable Gain_DA_03,userdata(ControlArrayIndex)=  "3"
 	SetVariable Gain_DA_03,limits={0,inf,1},value= _NUM:0
 	SetVariable Gain_DA_04,pos={48.00,258.00},size={48.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_DA_04,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_DA_04,userdata(ResizeControlsInfo)= A"!!,DW!!#B<!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_DA_04,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_DA_04,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_DA_04,userdata(ControlArray)=  "Gain_DA"
+	SetVariable Gain_DA_04,userdata(ControlArrayIndex)=  "4"
 	SetVariable Gain_DA_04,limits={0,inf,1},value= _NUM:0
 	SetVariable Gain_DA_05,pos={48.00,306.00},size={48.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_DA_05,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_DA_05,userdata(ResizeControlsInfo)= A"!!,DW!!#BSJ,ho,!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_DA_05,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_DA_05,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_DA_05,userdata(ControlArray)=  "Gain_DA"
+	SetVariable Gain_DA_05,userdata(ControlArrayIndex)=  "5"
 	SetVariable Gain_DA_05,limits={0,inf,1},value= _NUM:0
 	SetVariable Gain_DA_06,pos={48.00,351.00},size={48.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_DA_06,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_DA_06,userdata(ResizeControlsInfo)= A"!!,DW!!#BjJ,ho,!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_DA_06,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_DA_06,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_DA_06,userdata(ControlArray)=  "Gain_DA"
+	SetVariable Gain_DA_06,userdata(ControlArrayIndex)=  "6"
 	SetVariable Gain_DA_06,limits={0,inf,1},value= _NUM:0
 	SetVariable Gain_DA_07,pos={48.00,399.00},size={48.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_DA_07,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_DA_07,userdata(ResizeControlsInfo)= A"!!,DW!!#C-!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_DA_07,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_DA_07,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_DA_07,userdata(ControlArray)=  "Gain_DA"
+	SetVariable Gain_DA_07,userdata(ControlArrayIndex)=  "7"
 	SetVariable Gain_DA_07,limits={0,inf,1},value= _NUM:0
 	PopupMenu Wave_DA_00,pos={135.00,75.00},size={138.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList,title="/V"
 	PopupMenu Wave_DA_00,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	PopupMenu Wave_DA_00,userdata(ResizeControlsInfo)= A"!!,Fq!!#?O!!#@n!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu Wave_DA_00,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu Wave_DA_00,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	PopupMenu Wave_DA_00,fSize=10
+	PopupMenu Wave_DA_00,userdata(ControlArray)=  "Wave_DA"
+	PopupMenu Wave_DA_00,userdata(ControlArrayIndex)=  "0",fSize=10
 	PopupMenu Wave_DA_00,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(0,\"*DA*\")"
 	PopupMenu Wave_DA_01,pos={135.00,120.00},size={138.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList,title="/V"
 	PopupMenu Wave_DA_01,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	PopupMenu Wave_DA_01,userdata(ResizeControlsInfo)= A"!!,Fq!!#@V!!#@n!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu Wave_DA_01,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu Wave_DA_01,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	PopupMenu Wave_DA_01,fSize=10
+	PopupMenu Wave_DA_01,userdata(ControlArray)=  "Wave_DA"
+	PopupMenu Wave_DA_01,userdata(ControlArrayIndex)=  "1",fSize=10
 	PopupMenu Wave_DA_01,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(0,\"*DA*\")"
 	PopupMenu Wave_DA_02,pos={135.00,165.00},size={138.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList,title="/V"
 	PopupMenu Wave_DA_02,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	PopupMenu Wave_DA_02,userdata(ResizeControlsInfo)= A"!!,Fq!!#A6!!#@n!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu Wave_DA_02,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu Wave_DA_02,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	PopupMenu Wave_DA_02,fSize=10
+	PopupMenu Wave_DA_02,userdata(ControlArray)=  "Wave_DA"
+	PopupMenu Wave_DA_02,userdata(ControlArrayIndex)=  "2",fSize=10
 	PopupMenu Wave_DA_02,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(0,\"*DA*\")"
 	PopupMenu Wave_DA_03,pos={135.00,213.00},size={138.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList,title="/V"
 	PopupMenu Wave_DA_03,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	PopupMenu Wave_DA_03,userdata(ResizeControlsInfo)= A"!!,Fq!!#Ae!!#@n!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu Wave_DA_03,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu Wave_DA_03,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	PopupMenu Wave_DA_03,fSize=10
+	PopupMenu Wave_DA_03,userdata(ControlArray)=  "Wave_DA"
+	PopupMenu Wave_DA_03,userdata(ControlArrayIndex)=  "3",fSize=10
 	PopupMenu Wave_DA_03,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(0,\"*DA*\")"
 	PopupMenu Wave_DA_04,pos={135.00,258.00},size={138.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList,title="/V"
 	PopupMenu Wave_DA_04,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	PopupMenu Wave_DA_04,userdata(ResizeControlsInfo)= A"!!,Fq!!#B<!!#@n!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu Wave_DA_04,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu Wave_DA_04,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	PopupMenu Wave_DA_04,fSize=10
+	PopupMenu Wave_DA_04,userdata(ControlArray)=  "Wave_DA"
+	PopupMenu Wave_DA_04,userdata(ControlArrayIndex)=  "4",fSize=10
 	PopupMenu Wave_DA_04,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(0,\"*DA*\")"
 	PopupMenu Wave_DA_05,pos={135.00,306.00},size={138.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList,title="/V"
 	PopupMenu Wave_DA_05,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	PopupMenu Wave_DA_05,userdata(ResizeControlsInfo)= A"!!,Fq!!#BSJ,hqD!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu Wave_DA_05,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu Wave_DA_05,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	PopupMenu Wave_DA_05,fSize=10
+	PopupMenu Wave_DA_05,userdata(ControlArray)=  "Wave_DA"
+	PopupMenu Wave_DA_05,userdata(ControlArrayIndex)=  "5",fSize=10
 	PopupMenu Wave_DA_05,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(0,\"*DA*\")"
 	PopupMenu Wave_DA_06,pos={135.00,351.00},size={138.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList,title="/V"
 	PopupMenu Wave_DA_06,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	PopupMenu Wave_DA_06,userdata(ResizeControlsInfo)= A"!!,Fq!!#BjJ,hqD!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu Wave_DA_06,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu Wave_DA_06,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	PopupMenu Wave_DA_06,fSize=10
+	PopupMenu Wave_DA_06,userdata(ControlArray)=  "Wave_DA"
+	PopupMenu Wave_DA_06,userdata(ControlArrayIndex)=  "6",fSize=10
 	PopupMenu Wave_DA_06,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(0,\"*DA*\")"
 	PopupMenu Wave_DA_07,pos={135.00,399.00},size={138.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList,title="/V"
 	PopupMenu Wave_DA_07,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	PopupMenu Wave_DA_07,userdata(ResizeControlsInfo)= A"!!,Fq!!#C-!!#@n!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu Wave_DA_07,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu Wave_DA_07,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	PopupMenu Wave_DA_07,fSize=10
+	PopupMenu Wave_DA_07,userdata(ControlArray)=  "Wave_DA"
+	PopupMenu Wave_DA_07,userdata(ControlArrayIndex)=  "7",fSize=10
 	PopupMenu Wave_DA_07,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(0,\"*DA*\")"
 	SetVariable Scale_DA_00,pos={288.00,75.00},size={48.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Scale_DA_00,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Scale_DA_00,userdata(ResizeControlsInfo)= A"!!,HL!!#?O!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Scale_DA_00,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Scale_DA_00,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Scale_DA_00,userdata(ControlArray)=  "Scale_DA"
+	SetVariable Scale_DA_00,userdata(ControlArrayIndex)=  "0"
 	SetVariable Scale_DA_00,limits={-inf,inf,10},value= _NUM:1
 	SetVariable Scale_DA_01,pos={288.00,120.00},size={48.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Scale_DA_01,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Scale_DA_01,userdata(ResizeControlsInfo)= A"!!,HL!!#@V!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Scale_DA_01,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Scale_DA_01,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Scale_DA_01,userdata(ControlArray)=  "Scale_DA"
+	SetVariable Scale_DA_01,userdata(ControlArrayIndex)=  "1"
 	SetVariable Scale_DA_01,limits={-inf,inf,10},value= _NUM:1
 	SetVariable Scale_DA_02,pos={288.00,165.00},size={48.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Scale_DA_02,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Scale_DA_02,userdata(ResizeControlsInfo)= A"!!,HL!!#A6!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Scale_DA_02,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Scale_DA_02,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Scale_DA_02,userdata(ControlArray)=  "Scale_DA"
+	SetVariable Scale_DA_02,userdata(ControlArrayIndex)=  "2"
 	SetVariable Scale_DA_02,limits={-inf,inf,10},value= _NUM:1
 	SetVariable Scale_DA_03,pos={288.00,213.00},size={48.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Scale_DA_03,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Scale_DA_03,userdata(ResizeControlsInfo)= A"!!,HL!!#Ae!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Scale_DA_03,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Scale_DA_03,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Scale_DA_03,userdata(ControlArray)=  "Scale_DA"
+	SetVariable Scale_DA_03,userdata(ControlArrayIndex)=  "3"
 	SetVariable Scale_DA_03,limits={-inf,inf,10},value= _NUM:1
 	SetVariable Scale_DA_04,pos={288.00,258.00},size={48.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Scale_DA_04,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Scale_DA_04,userdata(ResizeControlsInfo)= A"!!,HL!!#B<!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Scale_DA_04,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Scale_DA_04,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Scale_DA_04,value= _NUM:1
+	SetVariable Scale_DA_04,userdata(ControlArray)=  "Scale_DA"
+	SetVariable Scale_DA_04,userdata(ControlArrayIndex)=  "4",value= _NUM:1
 	SetVariable Scale_DA_05,pos={288.00,306.00},size={48.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Scale_DA_05,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Scale_DA_05,userdata(ResizeControlsInfo)= A"!!,HL!!#BSJ,ho,!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Scale_DA_05,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Scale_DA_05,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Scale_DA_05,value= _NUM:1
+	SetVariable Scale_DA_05,userdata(ControlArray)=  "Scale_DA"
+	SetVariable Scale_DA_05,userdata(ControlArrayIndex)=  "5",value= _NUM:1
 	SetVariable Scale_DA_06,pos={288.00,351.00},size={48.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Scale_DA_06,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Scale_DA_06,userdata(ResizeControlsInfo)= A"!!,HL!!#BjJ,ho,!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Scale_DA_06,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Scale_DA_06,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Scale_DA_06,userdata(ControlArray)=  "Scale_DA"
+	SetVariable Scale_DA_06,userdata(ControlArrayIndex)=  "6"
 	SetVariable Scale_DA_06,limits={-inf,inf,10},value= _NUM:1
 	SetVariable Scale_DA_07,pos={283.00,399.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Scale_DA_07,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Scale_DA_07,userdata(ResizeControlsInfo)= A"!!,HL!!#C-!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Scale_DA_07,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Scale_DA_07,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Scale_DA_07,userdata(ControlArray)=  "Scale_DA"
+	SetVariable Scale_DA_07,userdata(ControlArrayIndex)=  "7"
 	SetVariable Scale_DA_07,limits={-inf,inf,10},value= _NUM:1
 	SetVariable SetVar_DataAcq_Comment,pos={42.00,775.00},size={373.00,22.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="Comment"
 	SetVariable SetVar_DataAcq_Comment,help={"Appends a comment to wave note of next sweep"}
@@ -577,7 +683,7 @@ Window DA_Ephys() : Panel
 	CheckBox Check_DataAcq1_RepeatAcq,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_DataAcq1_RepeatAcq,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
 	CheckBox Check_DataAcq1_RepeatAcq,value= 1
-	SetVariable SetVar_DataAcq_ITI,pos={57.00,711.00},size={79.00,18.00},bodyWidth=35,disable=1,proc=DAP_SetVarProc_SyncCtrl,title="\\JCITl (sec)"
+	SetVariable SetVar_DataAcq_ITI,pos={56.00,711.00},size={80.00,18.00},bodyWidth=35,disable=1,proc=DAP_SetVarProc_SyncCtrl,title="\\JCITl (sec)"
 	SetVariable SetVar_DataAcq_ITI,userdata(tabnum)=  "0"
 	SetVariable SetVar_DataAcq_ITI,userdata(tabcontrol)=  "ADC"
 	SetVariable SetVar_DataAcq_ITI,userdata(ResizeControlsInfo)= A"!!,E*!!#D?!!#?Y!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
@@ -595,6 +701,8 @@ Window DA_Ephys() : Panel
 	CheckBox Check_DataAcqHS_00,userdata(ResizeControlsInfo)= A"!!,Ff!!#?e!!#<`!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_DataAcqHS_00,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_DataAcqHS_00,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	CheckBox Check_DataAcqHS_00,userdata(ControlArray)=  "Check_DataAcqHS"
+	CheckBox Check_DataAcqHS_00,userdata(ControlArrayIndex)=  "0"
 	CheckBox Check_DataAcqHS_00,labelBack=(65280,0,0),value= 0
 	SetVariable SetVar_DataAcq_TPDuration,pos={30.00,417.00},size={127.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVarProc_TestPulseSett,title="Duration (ms)"
 	SetVariable SetVar_DataAcq_TPDuration,help={"Duration of the testpulse in milliseconds"}
@@ -603,6 +711,7 @@ Window DA_Ephys() : Panel
 	SetVariable SetVar_DataAcq_TPDuration,userdata(ResizeControlsInfo)= A"!!,DG!!#C5J,hq8!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable SetVar_DataAcq_TPDuration,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable SetVar_DataAcq_TPDuration,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable SetVar_DataAcq_TPDuration,userdata(Config_GroupPath)=  "Test Pulse"
 	SetVariable SetVar_DataAcq_TPDuration,limits={1,inf,5},value= _NUM:10
 	SetVariable SetVar_DataAcq_TPBaselinePerc,pos={165.00,417.00},size={118.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVarProc_TestPulseSett,title="Baseline (%)"
 	SetVariable SetVar_DataAcq_TPBaselinePerc,help={"Length of the baseline before and after the testpulse, in parts of the total testpulse duration"}
@@ -611,6 +720,7 @@ Window DA_Ephys() : Panel
 	SetVariable SetVar_DataAcq_TPBaselinePerc,userdata(ResizeControlsInfo)= A"!!,GC!!#C5J,hq&!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable SetVar_DataAcq_TPBaselinePerc,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable SetVar_DataAcq_TPBaselinePerc,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable SetVar_DataAcq_TPBaselinePerc,userdata(Config_GroupPath)=  "Test Pulse"
 	SetVariable SetVar_DataAcq_TPBaselinePerc,limits={25,49,1},value= _NUM:25
 	SetVariable SetVar_DataAcq_TPAmplitude,pos={300.00,417.00},size={69.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVarProc_TPAmp,title="VC"
 	SetVariable SetVar_DataAcq_TPAmplitude,help={"Amplitude of the testpulse in voltage clamp mode"}
@@ -619,104 +729,129 @@ Window DA_Ephys() : Panel
 	SetVariable SetVar_DataAcq_TPAmplitude,userdata(ResizeControlsInfo)= A"!!,HU!!#C5J,hon!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable SetVar_DataAcq_TPAmplitude,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable SetVar_DataAcq_TPAmplitude,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable SetVar_DataAcq_TPAmplitude,userdata(Config_GroupPath)=  "Test Pulse"
 	SetVariable SetVar_DataAcq_TPAmplitude,value= _NUM:10
 	CheckBox Check_TTL_00,pos={18.00,75.00},size={22.00,15.00},disable=1,proc=DAP_DAorTTLCheckProc,title="0"
 	CheckBox Check_TTL_00,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_TTL_00,userdata(ResizeControlsInfo)= A"!!,BY!!#?O!!#<`!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_TTL_00,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_TTL_00,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_TTL_00,value= 0
+	CheckBox Check_TTL_00,userdata(ControlArray)=  "Check_TTL"
+	CheckBox Check_TTL_00,userdata(ControlArrayIndex)=  "0",value= 0
 	CheckBox Check_TTL_01,pos={18.00,120.00},size={22.00,15.00},disable=1,proc=DAP_DAorTTLCheckProc,title="1"
 	CheckBox Check_TTL_01,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_TTL_01,userdata(ResizeControlsInfo)= A"!!,BY!!#@V!!#<`!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_TTL_01,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_TTL_01,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_TTL_01,value= 0
+	CheckBox Check_TTL_01,userdata(ControlArray)=  "Check_TTL"
+	CheckBox Check_TTL_01,userdata(ControlArrayIndex)=  "1",value= 0
 	CheckBox Check_TTL_02,pos={18.00,165.00},size={22.00,15.00},disable=1,proc=DAP_DAorTTLCheckProc,title="2"
 	CheckBox Check_TTL_02,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_TTL_02,userdata(ResizeControlsInfo)= A"!!,BY!!#A6!!#<`!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_TTL_02,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_TTL_02,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_TTL_02,value= 0
+	CheckBox Check_TTL_02,userdata(ControlArray)=  "Check_TTL"
+	CheckBox Check_TTL_02,userdata(ControlArrayIndex)=  "2",value= 0
 	CheckBox Check_TTL_03,pos={18.00,213.00},size={22.00,15.00},disable=1,proc=DAP_DAorTTLCheckProc,title="3"
 	CheckBox Check_TTL_03,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_TTL_03,userdata(ResizeControlsInfo)= A"!!,BY!!#Ae!!#<`!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_TTL_03,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_TTL_03,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_TTL_03,value= 0
+	CheckBox Check_TTL_03,userdata(ControlArray)=  "Check_TTL"
+	CheckBox Check_TTL_03,userdata(ControlArrayIndex)=  "3",value= 0
 	CheckBox Check_TTL_04,pos={18.00,258.00},size={22.00,15.00},disable=1,proc=DAP_DAorTTLCheckProc,title="4"
 	CheckBox Check_TTL_04,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_TTL_04,userdata(ResizeControlsInfo)= A"!!,BY!!#B<!!#<`!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_TTL_04,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_TTL_04,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_TTL_04,value= 0
+	CheckBox Check_TTL_04,userdata(ControlArray)=  "Check_TTL"
+	CheckBox Check_TTL_04,userdata(ControlArrayIndex)=  "4",value= 0
 	CheckBox Check_TTL_05,pos={18.00,306.00},size={22.00,15.00},disable=1,proc=DAP_DAorTTLCheckProc,title="5"
 	CheckBox Check_TTL_05,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_TTL_05,userdata(ResizeControlsInfo)= A"!!,BY!!#BSJ,hm6!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_TTL_05,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_TTL_05,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_TTL_05,value= 0
+	CheckBox Check_TTL_05,userdata(ControlArray)=  "Check_TTL"
+	CheckBox Check_TTL_05,userdata(ControlArrayIndex)=  "5",value= 0
 	CheckBox Check_TTL_06,pos={18.00,351.00},size={22.00,15.00},disable=1,proc=DAP_DAorTTLCheckProc,title="6"
 	CheckBox Check_TTL_06,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_TTL_06,userdata(ResizeControlsInfo)= A"!!,BY!!#BjJ,hm6!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_TTL_06,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_TTL_06,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_TTL_06,value= 0
+	CheckBox Check_TTL_06,userdata(ControlArray)=  "Check_TTL"
+	CheckBox Check_TTL_06,userdata(ControlArrayIndex)=  "6",value= 0
 	CheckBox Check_TTL_07,pos={18.00,399.00},size={22.00,15.00},disable=1,proc=DAP_DAorTTLCheckProc,title="7"
 	CheckBox Check_TTL_07,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_TTL_07,userdata(ResizeControlsInfo)= A"!!,BY!!#C-!!#<`!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_TTL_07,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_TTL_07,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_TTL_07,value= 0
+	CheckBox Check_TTL_07,userdata(ControlArray)=  "Check_TTL"
+	CheckBox Check_TTL_07,userdata(ControlArrayIndex)=  "7",value= 0
 	PopupMenu Wave_TTL_00,pos={100.00,75.00},size={125.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList
 	PopupMenu Wave_TTL_00,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	PopupMenu Wave_TTL_00,userdata(ResizeControlsInfo)= A"!!,F3!!#?O!!#@^!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu Wave_TTL_00,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu Wave_TTL_00,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu Wave_TTL_00,userdata(ControlArray)=  "Wave_TTL"
+	PopupMenu Wave_TTL_00,userdata(ControlArrayIndex)=  "0"
 	PopupMenu Wave_TTL_00,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(1,\"*TTL*\")"
 	PopupMenu Wave_TTL_01,pos={100.00,120.00},size={125.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList
 	PopupMenu Wave_TTL_01,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	PopupMenu Wave_TTL_01,userdata(ResizeControlsInfo)= A"!!,F3!!#@V!!#@^!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu Wave_TTL_01,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu Wave_TTL_01,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu Wave_TTL_01,userdata(ControlArray)=  "Wave_TTL"
+	PopupMenu Wave_TTL_01,userdata(ControlArrayIndex)=  "1"
 	PopupMenu Wave_TTL_01,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(1,\"*TTL*\")"
 	PopupMenu Wave_TTL_02,pos={100.00,165.00},size={125.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList
 	PopupMenu Wave_TTL_02,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	PopupMenu Wave_TTL_02,userdata(ResizeControlsInfo)= A"!!,F3!!#A6!!#@^!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu Wave_TTL_02,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu Wave_TTL_02,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu Wave_TTL_02,userdata(ControlArray)=  "Wave_TTL"
+	PopupMenu Wave_TTL_02,userdata(ControlArrayIndex)=  "2"
 	PopupMenu Wave_TTL_02,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(1,\"*TTL*\")"
 	PopupMenu Wave_TTL_03,pos={100.00,213.00},size={125.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList
 	PopupMenu Wave_TTL_03,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	PopupMenu Wave_TTL_03,userdata(ResizeControlsInfo)= A"!!,F3!!#Ae!!#@^!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu Wave_TTL_03,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu Wave_TTL_03,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu Wave_TTL_03,userdata(ControlArray)=  "Wave_TTL"
+	PopupMenu Wave_TTL_03,userdata(ControlArrayIndex)=  "3"
 	PopupMenu Wave_TTL_03,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(1,\"*TTL*\")"
 	PopupMenu Wave_TTL_04,pos={100.00,258.00},size={125.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList
 	PopupMenu Wave_TTL_04,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	PopupMenu Wave_TTL_04,userdata(ResizeControlsInfo)= A"!!,F3!!#B<!!#@^!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu Wave_TTL_04,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu Wave_TTL_04,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu Wave_TTL_04,userdata(ControlArray)=  "Wave_TTL"
+	PopupMenu Wave_TTL_04,userdata(ControlArrayIndex)=  "4"
 	PopupMenu Wave_TTL_04,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(1,\"*TTL*\")"
 	PopupMenu Wave_TTL_05,pos={100.00,306.00},size={125.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList
 	PopupMenu Wave_TTL_05,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	PopupMenu Wave_TTL_05,userdata(ResizeControlsInfo)= A"!!,F3!!#BSJ,hq4!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu Wave_TTL_05,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu Wave_TTL_05,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu Wave_TTL_05,userdata(ControlArray)=  "Wave_TTL"
+	PopupMenu Wave_TTL_05,userdata(ControlArrayIndex)=  "5"
 	PopupMenu Wave_TTL_05,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(1,\"*TTL*\")"
 	PopupMenu Wave_TTL_06,pos={100.00,351.00},size={125.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList
 	PopupMenu Wave_TTL_06,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	PopupMenu Wave_TTL_06,userdata(ResizeControlsInfo)= A"!!,F3!!#BjJ,hq4!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu Wave_TTL_06,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu Wave_TTL_06,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu Wave_TTL_06,userdata(ControlArray)=  "Wave_TTL"
+	PopupMenu Wave_TTL_06,userdata(ControlArrayIndex)=  "6"
 	PopupMenu Wave_TTL_06,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(1,\"*TTL*\")"
 	PopupMenu Wave_TTL_07,pos={100.00,399.00},size={125.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList
 	PopupMenu Wave_TTL_07,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	PopupMenu Wave_TTL_07,userdata(ResizeControlsInfo)= A"!!,F3!!#C-!!#@^!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu Wave_TTL_07,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu Wave_TTL_07,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu Wave_TTL_07,userdata(ControlArray)=  "Wave_TTL"
+	PopupMenu Wave_TTL_07,userdata(ControlArrayIndex)=  "7"
 	PopupMenu Wave_TTL_07,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(1,\"*TTL*\")"
-	CheckBox Check_Settings_TrigOut,pos={33.00,255.00},size={58.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="\\JCTrig Out"
+	CheckBox Check_Settings_TrigOut,pos={33.00,255.00},size={59.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="\\JCTrig Out"
 	CheckBox Check_Settings_TrigOut,help={"Turns on TTL pulse at onset of sweep"}
 	CheckBox Check_Settings_TrigOut,userdata(tabnum)=  "5"
 	CheckBox Check_Settings_TrigOut,userdata(tabcontrol)=  "ADC"
@@ -724,7 +859,7 @@ Window DA_Ephys() : Panel
 	CheckBox Check_Settings_TrigOut,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_Settings_TrigOut,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
 	CheckBox Check_Settings_TrigOut,fColor=(65280,43520,0),value= 0
-	CheckBox Check_Settings_TrigIn,pos={33.00,276.00},size={48.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="\\JCTrig In"
+	CheckBox Check_Settings_TrigIn,pos={33.00,276.00},size={49.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="\\JCTrig In"
 	CheckBox Check_Settings_TrigIn,help={"Starts Data Aquisition with TTL signal to trig in port on rack"}
 	CheckBox Check_Settings_TrigIn,userdata(tabnum)=  "5"
 	CheckBox Check_Settings_TrigIn,userdata(tabcontrol)=  "ADC"
@@ -779,193 +914,233 @@ Window DA_Ephys() : Panel
 	CheckBox Check_AsyncAD_00,userdata(ResizeControlsInfo)= A"!!,G<!!#>F!!#>.!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_AsyncAD_00,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_AsyncAD_00,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_AsyncAD_00,value= 0
+	CheckBox Check_AsyncAD_00,userdata(ControlArray)=  "Check_AsyncAD"
+	CheckBox Check_AsyncAD_00,userdata(ControlArrayIndex)=  "0",value= 0
 	CheckBox Check_AsyncAD_01,pos={171.00,96.00},size={41.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="AD 1"
 	CheckBox Check_AsyncAD_01,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_AsyncAD_01,userdata(ResizeControlsInfo)= A"!!,G;!!#@&!!#>.!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_AsyncAD_01,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_AsyncAD_01,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_AsyncAD_01,value= 0
+	CheckBox Check_AsyncAD_01,userdata(ControlArray)=  "Check_AsyncAD"
+	CheckBox Check_AsyncAD_01,userdata(ControlArrayIndex)=  "1",value= 0
 	CheckBox Check_AsyncAD_02,pos={171.00,147.00},size={41.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="AD 2"
 	CheckBox Check_AsyncAD_02,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_AsyncAD_02,userdata(ResizeControlsInfo)= A"!!,G;!!#A#!!#>.!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_AsyncAD_02,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_AsyncAD_02,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_AsyncAD_02,value= 0
+	CheckBox Check_AsyncAD_02,userdata(ControlArray)=  "Check_AsyncAD"
+	CheckBox Check_AsyncAD_02,userdata(ControlArrayIndex)=  "2",value= 0
 	CheckBox Check_AsyncAD_03,pos={171.00,198.00},size={41.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="AD 3"
 	CheckBox Check_AsyncAD_03,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_AsyncAD_03,userdata(ResizeControlsInfo)= A"!!,G;!!#AV!!#>.!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_AsyncAD_03,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_AsyncAD_03,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_AsyncAD_03,value= 0
+	CheckBox Check_AsyncAD_03,userdata(ControlArray)=  "Check_AsyncAD"
+	CheckBox Check_AsyncAD_03,userdata(ControlArrayIndex)=  "3",value= 0
 	CheckBox Check_AsyncAD_04,pos={171.00,249.00},size={41.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="AD 4"
 	CheckBox Check_AsyncAD_04,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_AsyncAD_04,userdata(ResizeControlsInfo)= A"!!,G;!!#B4!!#>.!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_AsyncAD_04,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_AsyncAD_04,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_AsyncAD_04,value= 0
+	CheckBox Check_AsyncAD_04,userdata(ControlArray)=  "Check_AsyncAD"
+	CheckBox Check_AsyncAD_04,userdata(ControlArrayIndex)=  "4",value= 0
 	CheckBox Check_AsyncAD_05,pos={171.00,300.00},size={41.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="AD 5"
 	CheckBox Check_AsyncAD_05,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_AsyncAD_05,userdata(ResizeControlsInfo)= A"!!,G;!!#BPJ,hnY!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_AsyncAD_05,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_AsyncAD_05,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_AsyncAD_05,value= 0
+	CheckBox Check_AsyncAD_05,userdata(ControlArray)=  "Check_AsyncAD"
+	CheckBox Check_AsyncAD_05,userdata(ControlArrayIndex)=  "5",value= 0
 	CheckBox Check_AsyncAD_06,pos={171.00,351.00},size={41.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="AD 6"
 	CheckBox Check_AsyncAD_06,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_AsyncAD_06,userdata(ResizeControlsInfo)= A"!!,G;!!#Bj!!#>.!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_AsyncAD_06,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_AsyncAD_06,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_AsyncAD_06,value= 0
+	CheckBox Check_AsyncAD_06,userdata(ControlArray)=  "Check_AsyncAD"
+	CheckBox Check_AsyncAD_06,userdata(ControlArrayIndex)=  "6",value= 0
 	CheckBox Check_AsyncAD_07,pos={171.00,402.00},size={41.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="AD 7"
 	CheckBox Check_AsyncAD_07,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_AsyncAD_07,userdata(ResizeControlsInfo)= A"!!,G;!!#C/!!#>.!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_AsyncAD_07,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_AsyncAD_07,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_AsyncAD_07,value= 0
+	CheckBox Check_AsyncAD_07,userdata(ControlArray)=  "Check_AsyncAD"
+	CheckBox Check_AsyncAD_07,userdata(ControlArrayIndex)=  "7",value= 0
 	SetVariable Gain_AsyncAD_00,pos={217.00,42.00},size={77.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState,title="gain"
 	SetVariable Gain_AsyncAD_00,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_AsyncAD_00,userdata(ResizeControlsInfo)= A"!!,Gp!!#>>!!#?S!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AsyncAD_00,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_AsyncAD_00,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_AsyncAD_00,userdata(ControlArray)=  "Gain_AsyncAD"
+	SetVariable Gain_AsyncAD_00,userdata(ControlArrayIndex)=  "0"
 	SetVariable Gain_AsyncAD_00,limits={0,inf,1},value= _NUM:1
 	SetVariable Gain_AsyncAD_01,pos={217.00,93.00},size={77.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState,title="gain"
 	SetVariable Gain_AsyncAD_01,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_AsyncAD_01,userdata(ResizeControlsInfo)= A"!!,Gp!!#@\"!!#?S!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AsyncAD_01,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_AsyncAD_01,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_AsyncAD_01,userdata(ControlArray)=  "Gain_AsyncAD"
+	SetVariable Gain_AsyncAD_01,userdata(ControlArrayIndex)=  "1"
 	SetVariable Gain_AsyncAD_01,limits={0,inf,1},value= _NUM:1
 	SetVariable Gain_AsyncAD_02,pos={217.00,144.00},size={77.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState,title="gain"
 	SetVariable Gain_AsyncAD_02,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_AsyncAD_02,userdata(ResizeControlsInfo)= A"!!,Gp!!#A!!!#?S!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AsyncAD_02,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_AsyncAD_02,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_AsyncAD_02,userdata(ControlArray)=  "Gain_AsyncAD"
+	SetVariable Gain_AsyncAD_02,userdata(ControlArrayIndex)=  "2"
 	SetVariable Gain_AsyncAD_02,limits={0,inf,1},value= _NUM:1
 	SetVariable Gain_AsyncAD_03,pos={217.00,195.00},size={77.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState,title="gain"
 	SetVariable Gain_AsyncAD_03,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_AsyncAD_03,userdata(ResizeControlsInfo)= A"!!,Gp!!#AT!!#?S!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AsyncAD_03,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_AsyncAD_03,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_AsyncAD_03,userdata(ControlArray)=  "Gain_AsyncAD"
+	SetVariable Gain_AsyncAD_03,userdata(ControlArrayIndex)=  "3"
 	SetVariable Gain_AsyncAD_03,limits={0,inf,1},value= _NUM:1
 	SetVariable Gain_AsyncAD_04,pos={217.00,246.00},size={77.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState,title="gain"
 	SetVariable Gain_AsyncAD_04,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_AsyncAD_04,userdata(ResizeControlsInfo)= A"!!,Gp!!#B2!!#?S!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AsyncAD_04,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_AsyncAD_04,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_AsyncAD_04,userdata(ControlArray)=  "Gain_AsyncAD"
+	SetVariable Gain_AsyncAD_04,userdata(ControlArrayIndex)=  "4"
 	SetVariable Gain_AsyncAD_04,limits={0,inf,1},value= _NUM:1
 	SetVariable Gain_AsyncAD_05,pos={217.00,297.00},size={77.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState,title="gain"
 	SetVariable Gain_AsyncAD_05,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_AsyncAD_05,userdata(ResizeControlsInfo)= A"!!,Gp!!#BOJ,hp)!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AsyncAD_05,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_AsyncAD_05,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_AsyncAD_05,userdata(ControlArray)=  "Gain_AsyncAD"
+	SetVariable Gain_AsyncAD_05,userdata(ControlArrayIndex)=  "5"
 	SetVariable Gain_AsyncAD_05,limits={0,inf,1},value= _NUM:1
 	SetVariable Gain_AsyncAD_06,pos={217.00,348.00},size={77.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState,title="gain"
 	SetVariable Gain_AsyncAD_06,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_AsyncAD_06,userdata(ResizeControlsInfo)= A"!!,Gp!!#Bi!!#?S!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AsyncAD_06,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_AsyncAD_06,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_AsyncAD_06,userdata(ControlArray)=  "Gain_AsyncAD"
+	SetVariable Gain_AsyncAD_06,userdata(ControlArrayIndex)=  "6"
 	SetVariable Gain_AsyncAD_06,limits={0,inf,1},value= _NUM:1
 	SetVariable Gain_AsyncAD_07,pos={217.00,402.00},size={77.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState,title="gain"
 	SetVariable Gain_AsyncAD_07,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable Gain_AsyncAD_07,userdata(ResizeControlsInfo)= A"!!,Gp!!#C.!!#?S!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AsyncAD_07,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Gain_AsyncAD_07,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Gain_AsyncAD_07,userdata(ControlArray)=  "Gain_AsyncAD"
+	SetVariable Gain_AsyncAD_07,userdata(ControlArrayIndex)=  "7"
 	SetVariable Gain_AsyncAD_07,limits={0,inf,1},value= _NUM:1
 	SetVariable Title_AsyncAD_00,pos={12.00,42.00},size={150.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="Title"
 	SetVariable Title_AsyncAD_00,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable Title_AsyncAD_00,userdata(ResizeControlsInfo)= A"!!,An!!#>>!!#A%!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Title_AsyncAD_00,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Title_AsyncAD_00,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Title_AsyncAD_00,value= _STR:""
+	SetVariable Title_AsyncAD_00,userdata(ControlArray)=  "Title_AsyncAD"
+	SetVariable Title_AsyncAD_00,userdata(ControlArrayIndex)=  "0",value= _STR:""
 	SetVariable Title_AsyncAD_01,pos={12.00,93.00},size={150.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="Title"
 	SetVariable Title_AsyncAD_01,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable Title_AsyncAD_01,userdata(ResizeControlsInfo)= A"!!,An!!#@\"!!#A%!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Title_AsyncAD_01,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Title_AsyncAD_01,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Title_AsyncAD_01,value= _STR:""
+	SetVariable Title_AsyncAD_01,userdata(ControlArray)=  "Title_AsyncAD"
+	SetVariable Title_AsyncAD_01,userdata(ControlArrayIndex)=  "1",value= _STR:""
 	SetVariable Title_AsyncAD_02,pos={12.00,144.00},size={150.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="Title"
 	SetVariable Title_AsyncAD_02,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable Title_AsyncAD_02,userdata(ResizeControlsInfo)= A"!!,An!!#A!!!#A%!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Title_AsyncAD_02,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Title_AsyncAD_02,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Title_AsyncAD_02,value= _STR:""
+	SetVariable Title_AsyncAD_02,userdata(ControlArray)=  "Title_AsyncAD"
+	SetVariable Title_AsyncAD_02,userdata(ControlArrayIndex)=  "2",value= _STR:""
 	SetVariable Title_AsyncAD_03,pos={12.00,195.00},size={150.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="Title"
 	SetVariable Title_AsyncAD_03,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable Title_AsyncAD_03,userdata(ResizeControlsInfo)= A"!!,An!!#AT!!#A%!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Title_AsyncAD_03,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Title_AsyncAD_03,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Title_AsyncAD_03,value= _STR:""
+	SetVariable Title_AsyncAD_03,userdata(ControlArray)=  "Title_AsyncAD"
+	SetVariable Title_AsyncAD_03,userdata(ControlArrayIndex)=  "3",value= _STR:""
 	SetVariable Title_AsyncAD_04,pos={9.00,246.00},size={150.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="Title"
 	SetVariable Title_AsyncAD_04,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable Title_AsyncAD_04,userdata(ResizeControlsInfo)= A"!!,A>!!#B2!!#A%!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Title_AsyncAD_04,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Title_AsyncAD_04,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Title_AsyncAD_04,value= _STR:""
+	SetVariable Title_AsyncAD_04,userdata(ControlArray)=  "Title_AsyncAD"
+	SetVariable Title_AsyncAD_04,userdata(ControlArrayIndex)=  "4",value= _STR:""
 	SetVariable Title_AsyncAD_05,pos={12.00,297.00},size={150.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="Title"
 	SetVariable Title_AsyncAD_05,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable Title_AsyncAD_05,userdata(ResizeControlsInfo)= A"!!,An!!#BOJ,hqP!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Title_AsyncAD_05,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Title_AsyncAD_05,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Title_AsyncAD_05,value= _STR:""
+	SetVariable Title_AsyncAD_05,userdata(ControlArray)=  "Title_AsyncAD"
+	SetVariable Title_AsyncAD_05,userdata(ControlArrayIndex)=  "5",value= _STR:""
 	SetVariable Title_AsyncAD_06,pos={12.00,348.00},size={150.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="Title"
 	SetVariable Title_AsyncAD_06,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable Title_AsyncAD_06,userdata(ResizeControlsInfo)= A"!!,An!!#Bi!!#A%!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Title_AsyncAD_06,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Title_AsyncAD_06,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Title_AsyncAD_06,value= _STR:""
+	SetVariable Title_AsyncAD_06,userdata(ControlArray)=  "Title_AsyncAD"
+	SetVariable Title_AsyncAD_06,userdata(ControlArrayIndex)=  "6",value= _STR:""
 	SetVariable Title_AsyncAD_07,pos={12.00,402.00},size={150.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="Title"
 	SetVariable Title_AsyncAD_07,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable Title_AsyncAD_07,userdata(ResizeControlsInfo)= A"!!,An!!#C.!!#A%!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Title_AsyncAD_07,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Title_AsyncAD_07,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Title_AsyncAD_07,value= _STR:""
+	SetVariable Title_AsyncAD_07,userdata(ControlArray)=  "Title_AsyncAD"
+	SetVariable Title_AsyncAD_07,userdata(ControlArrayIndex)=  "7",value= _STR:""
 	SetVariable Unit_AsyncAD_00,pos={315.00,42.00},size={75.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="Unit"
 	SetVariable Unit_AsyncAD_00,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable Unit_AsyncAD_00,userdata(ResizeControlsInfo)= A"!!,HXJ,hni!!#?O!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_AsyncAD_00,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Unit_AsyncAD_00,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Unit_AsyncAD_00,value= _STR:""
+	SetVariable Unit_AsyncAD_00,userdata(ControlArray)=  "Unit_AsyncAD"
+	SetVariable Unit_AsyncAD_00,userdata(ControlArrayIndex)=  "0",value= _STR:""
 	SetVariable Unit_AsyncAD_01,pos={315.00,93.00},size={75.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="Unit"
 	SetVariable Unit_AsyncAD_01,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable Unit_AsyncAD_01,userdata(ResizeControlsInfo)= A"!!,HXJ,hpM!!#?O!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_AsyncAD_01,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Unit_AsyncAD_01,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Unit_AsyncAD_01,value= _STR:""
+	SetVariable Unit_AsyncAD_01,userdata(ControlArray)=  "Unit_AsyncAD"
+	SetVariable Unit_AsyncAD_01,userdata(ControlArrayIndex)=  "1",value= _STR:""
 	SetVariable Unit_AsyncAD_02,pos={315.00,144.00},size={75.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="Unit"
 	SetVariable Unit_AsyncAD_02,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable Unit_AsyncAD_02,userdata(ResizeControlsInfo)= A"!!,HXJ,hqL!!#?O!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_AsyncAD_02,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Unit_AsyncAD_02,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Unit_AsyncAD_02,value= _STR:""
+	SetVariable Unit_AsyncAD_02,userdata(ControlArray)=  "Unit_AsyncAD"
+	SetVariable Unit_AsyncAD_02,userdata(ControlArrayIndex)=  "2",value= _STR:""
 	SetVariable Unit_AsyncAD_03,pos={315.00,195.00},size={75.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="Unit"
 	SetVariable Unit_AsyncAD_03,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable Unit_AsyncAD_03,userdata(ResizeControlsInfo)= A"!!,HXJ,hr*!!#?O!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_AsyncAD_03,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Unit_AsyncAD_03,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Unit_AsyncAD_03,value= _STR:""
+	SetVariable Unit_AsyncAD_03,userdata(ControlArray)=  "Unit_AsyncAD"
+	SetVariable Unit_AsyncAD_03,userdata(ControlArrayIndex)=  "3",value= _STR:""
 	SetVariable Unit_AsyncAD_04,pos={315.00,246.00},size={75.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="Unit"
 	SetVariable Unit_AsyncAD_04,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable Unit_AsyncAD_04,userdata(ResizeControlsInfo)= A"!!,HXJ,hr]!!#?O!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_AsyncAD_04,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Unit_AsyncAD_04,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Unit_AsyncAD_04,value= _STR:""
+	SetVariable Unit_AsyncAD_04,userdata(ControlArray)=  "Unit_AsyncAD"
+	SetVariable Unit_AsyncAD_04,userdata(ControlArrayIndex)=  "4",value= _STR:""
 	SetVariable Unit_AsyncAD_05,pos={315.00,297.00},size={75.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="Unit"
 	SetVariable Unit_AsyncAD_05,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable Unit_AsyncAD_05,userdata(ResizeControlsInfo)= A"!!,HXJ,hs%!!#?O!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_AsyncAD_05,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Unit_AsyncAD_05,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Unit_AsyncAD_05,value= _STR:""
+	SetVariable Unit_AsyncAD_05,userdata(ControlArray)=  "Unit_AsyncAD"
+	SetVariable Unit_AsyncAD_05,userdata(ControlArrayIndex)=  "5",value= _STR:""
 	SetVariable Unit_AsyncAD_06,pos={315.00,348.00},size={75.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="Unit"
 	SetVariable Unit_AsyncAD_06,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable Unit_AsyncAD_06,userdata(ResizeControlsInfo)= A"!!,HXJ,hs?!!#?O!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_AsyncAD_06,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Unit_AsyncAD_06,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Unit_AsyncAD_06,value= _STR:""
+	SetVariable Unit_AsyncAD_06,userdata(ControlArray)=  "Unit_AsyncAD"
+	SetVariable Unit_AsyncAD_06,userdata(ControlArrayIndex)=  "6",value= _STR:""
 	SetVariable Unit_AsyncAD_07,pos={315.00,402.00},size={75.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="Unit"
 	SetVariable Unit_AsyncAD_07,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable Unit_AsyncAD_07,userdata(ResizeControlsInfo)= A"!!,HXJ,hsY!!#?O!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_AsyncAD_07,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Unit_AsyncAD_07,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Unit_AsyncAD_07,value= _STR:""
+	SetVariable Unit_AsyncAD_07,userdata(ControlArray)=  "Unit_AsyncAD"
+	SetVariable Unit_AsyncAD_07,userdata(ControlArrayIndex)=  "7",value= _STR:""
 	CheckBox Check_Settings_Append,pos={33.00,466.00},size={145.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="Enable async acquisition"
 	CheckBox Check_Settings_Append,help={"Enable querying and storing the asynchronous parameters in the labnotebook."}
 	CheckBox Check_Settings_Append,userdata(tabnum)=  "5"
@@ -974,7 +1149,7 @@ Window DA_Ephys() : Panel
 	CheckBox Check_Settings_Append,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_Settings_Append,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
 	CheckBox Check_Settings_Append,value= 0
-	CheckBox Check_Settings_BkgTP,pos={27.00,84.00},size={96.00,15.00},disable=3,proc=DAP_CheckProc_UpdateGuiState,title="Background TP"
+	CheckBox Check_Settings_BkgTP,pos={27.00,84.00},size={97.00,15.00},disable=3,proc=DAP_CheckProc_UpdateGuiState,title="Background TP"
 	CheckBox Check_Settings_BkgTP,help={"Perform testpulse in the background, keeping the GUI responsive."}
 	CheckBox Check_Settings_BkgTP,userdata(tabnum)=  "5"
 	CheckBox Check_Settings_BkgTP,userdata(tabcontrol)=  "ADC"
@@ -995,6 +1170,8 @@ Window DA_Ephys() : Panel
 	CheckBox Radio_ClampMode_0,userdata(ResizeControlsInfo)= A"!!,Ff!!#?1!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Radio_ClampMode_0,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Radio_ClampMode_0,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	CheckBox Radio_ClampMode_0,userdata(Config_RestorePriority)=  "30"
+	CheckBox Radio_ClampMode_0,userdata(Config_NiceName)=  "Headstage_0_VC"
 	CheckBox Radio_ClampMode_0,value= 1,mode=1
 	TitleBox Title_DataAcq_VC,pos={42.00,60.00},size={77.00,15.00},disable=1,title="Voltage Clamp"
 	TitleBox Title_DataAcq_VC,userdata(tabnum)=  "0",userdata(tabcontrol)=  "ADC"
@@ -1020,190 +1197,243 @@ Window DA_Ephys() : Panel
 	CheckBox Check_DataAcqHS_01,userdata(ResizeControlsInfo)= A"!!,G2!!#?e!!#<`!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_DataAcqHS_01,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_DataAcqHS_01,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_DataAcqHS_01,value= 0
+	CheckBox Check_DataAcqHS_01,userdata(ControlArray)=  "Check_DataAcqHS"
+	CheckBox Check_DataAcqHS_01,userdata(ControlArrayIndex)=  "1",value= 0
 	CheckBox Check_DataAcqHS_02,pos={195.00,84.00},size={22.00,15.00},disable=1,proc=DAP_CheckProc_HedstgeChck,title="2"
 	CheckBox Check_DataAcqHS_02,userdata(tabnum)=  "0",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_DataAcqHS_02,userdata(ResizeControlsInfo)= A"!!,GT!!#?e!!#<`!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_DataAcqHS_02,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_DataAcqHS_02,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_DataAcqHS_02,value= 0
+	CheckBox Check_DataAcqHS_02,userdata(ControlArray)=  "Check_DataAcqHS"
+	CheckBox Check_DataAcqHS_02,userdata(ControlArrayIndex)=  "2",value= 0
 	CheckBox Check_DataAcqHS_03,pos={228.00,84.00},size={22.00,15.00},disable=1,proc=DAP_CheckProc_HedstgeChck,title="3"
 	CheckBox Check_DataAcqHS_03,userdata(tabnum)=  "0",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_DataAcqHS_03,userdata(ResizeControlsInfo)= A"!!,H!!!#?e!!#<`!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_DataAcqHS_03,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_DataAcqHS_03,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_DataAcqHS_03,value= 0
+	CheckBox Check_DataAcqHS_03,userdata(ControlArray)=  "Check_DataAcqHS"
+	CheckBox Check_DataAcqHS_03,userdata(ControlArrayIndex)=  "3",value= 0
 	CheckBox Check_DataAcqHS_04,pos={264.00,84.00},size={22.00,15.00},disable=1,proc=DAP_CheckProc_HedstgeChck,title="4"
 	CheckBox Check_DataAcqHS_04,userdata(tabnum)=  "0",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_DataAcqHS_04,userdata(ResizeControlsInfo)= A"!!,H?!!#?e!!#<`!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_DataAcqHS_04,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_DataAcqHS_04,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_DataAcqHS_04,value= 0
+	CheckBox Check_DataAcqHS_04,userdata(ControlArray)=  "Check_DataAcqHS"
+	CheckBox Check_DataAcqHS_04,userdata(ControlArrayIndex)=  "4",value= 0
 	CheckBox Check_DataAcqHS_05,pos={297.00,84.00},size={22.00,15.00},disable=1,proc=DAP_CheckProc_HedstgeChck,title="5"
 	CheckBox Check_DataAcqHS_05,userdata(tabnum)=  "0",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_DataAcqHS_05,userdata(ResizeControlsInfo)= A"!!,HP!!#?e!!#<`!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_DataAcqHS_05,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_DataAcqHS_05,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_DataAcqHS_05,value= 0
+	CheckBox Check_DataAcqHS_05,userdata(ControlArray)=  "Check_DataAcqHS"
+	CheckBox Check_DataAcqHS_05,userdata(ControlArrayIndex)=  "5",value= 0
 	CheckBox Check_DataAcqHS_06,pos={330.00,84.00},size={22.00,15.00},disable=1,proc=DAP_CheckProc_HedstgeChck,title="6"
 	CheckBox Check_DataAcqHS_06,userdata(tabnum)=  "0",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_DataAcqHS_06,userdata(ResizeControlsInfo)= A"!!,Ha!!#?e!!#<`!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_DataAcqHS_06,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_DataAcqHS_06,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_DataAcqHS_06,value= 0
+	CheckBox Check_DataAcqHS_06,userdata(ControlArray)=  "Check_DataAcqHS"
+	CheckBox Check_DataAcqHS_06,userdata(ControlArrayIndex)=  "6",value= 0
 	CheckBox Check_DataAcqHS_07,pos={366.00,84.00},size={22.00,15.00},disable=1,proc=DAP_CheckProc_HedstgeChck,title="7"
 	CheckBox Check_DataAcqHS_07,userdata(tabnum)=  "0",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_DataAcqHS_07,userdata(ResizeControlsInfo)= A"!!,Hr!!#?c!!#<`!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_DataAcqHS_07,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_DataAcqHS_07,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_DataAcqHS_07,value= 0
+	CheckBox Check_DataAcqHS_07,userdata(ControlArray)=  "Check_DataAcqHS"
+	CheckBox Check_DataAcqHS_07,userdata(ControlArrayIndex)=  "7",value= 0
 	CheckBox Radio_ClampMode_1,pos={129.00,111.00},size={14.00,14.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
 	CheckBox Radio_ClampMode_1,userdata(tabnum)=  "0",userdata(tabcontrol)=  "ADC"
 	CheckBox Radio_ClampMode_1,userdata(ResizeControlsInfo)= A"!!,Ff!!#@B!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Radio_ClampMode_1,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Radio_ClampMode_1,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	CheckBox Radio_ClampMode_1,userdata(Config_RestorePriority)=  "30"
+	CheckBox Radio_ClampMode_1,userdata(Config_NiceName)=  "Headstage_0_IC"
 	CheckBox Radio_ClampMode_1,value= 0,mode=1
 	CheckBox Radio_ClampMode_2,pos={162.00,60.00},size={14.00,14.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
 	CheckBox Radio_ClampMode_2,userdata(tabnum)=  "0",userdata(tabcontrol)=  "ADC"
 	CheckBox Radio_ClampMode_2,userdata(ResizeControlsInfo)= A"!!,G2!!#?1!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Radio_ClampMode_2,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Radio_ClampMode_2,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	CheckBox Radio_ClampMode_2,userdata(Config_RestorePriority)=  "30"
+	CheckBox Radio_ClampMode_2,userdata(Config_NiceName)=  "Headstage_1_VC"
 	CheckBox Radio_ClampMode_2,value= 1,mode=1
 	CheckBox Radio_ClampMode_3,pos={162.00,111.00},size={14.00,14.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
 	CheckBox Radio_ClampMode_3,userdata(tabnum)=  "0",userdata(tabcontrol)=  "ADC"
 	CheckBox Radio_ClampMode_3,userdata(ResizeControlsInfo)= A"!!,G2!!#@B!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Radio_ClampMode_3,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Radio_ClampMode_3,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	CheckBox Radio_ClampMode_3,userdata(Config_RestorePriority)=  "30"
+	CheckBox Radio_ClampMode_3,userdata(Config_NiceName)=  "Headstage_1_IC"
 	CheckBox Radio_ClampMode_3,value= 0,mode=1
 	CheckBox Radio_ClampMode_4,pos={195.00,60.00},size={14.00,14.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
 	CheckBox Radio_ClampMode_4,userdata(tabnum)=  "0",userdata(tabcontrol)=  "ADC"
 	CheckBox Radio_ClampMode_4,userdata(ResizeControlsInfo)= A"!!,GT!!#?1!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Radio_ClampMode_4,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Radio_ClampMode_4,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	CheckBox Radio_ClampMode_4,userdata(Config_RestorePriority)=  "30"
+	CheckBox Radio_ClampMode_4,userdata(Config_NiceName)=  "Headstage_2_VC"
 	CheckBox Radio_ClampMode_4,value= 1,mode=1
 	CheckBox Radio_ClampMode_5,pos={195.00,111.00},size={14.00,14.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
 	CheckBox Radio_ClampMode_5,userdata(tabnum)=  "0",userdata(tabcontrol)=  "ADC"
 	CheckBox Radio_ClampMode_5,userdata(ResizeControlsInfo)= A"!!,GT!!#@B!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Radio_ClampMode_5,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Radio_ClampMode_5,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	CheckBox Radio_ClampMode_5,userdata(Config_RestorePriority)=  "30"
+	CheckBox Radio_ClampMode_5,userdata(Config_NiceName)=  "Headstage_2_IC"
 	CheckBox Radio_ClampMode_5,value= 0,mode=1
 	CheckBox Radio_ClampMode_6,pos={228.00,60.00},size={14.00,14.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
 	CheckBox Radio_ClampMode_6,userdata(tabnum)=  "0",userdata(tabcontrol)=  "ADC"
 	CheckBox Radio_ClampMode_6,userdata(ResizeControlsInfo)= A"!!,H!!!#?1!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Radio_ClampMode_6,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Radio_ClampMode_6,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	CheckBox Radio_ClampMode_6,userdata(Config_RestorePriority)=  "30"
+	CheckBox Radio_ClampMode_6,userdata(Config_NiceName)=  "Headstage_3_VC"
 	CheckBox Radio_ClampMode_6,value= 1,mode=1
 	CheckBox Radio_ClampMode_7,pos={228.00,111.00},size={14.00,14.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
 	CheckBox Radio_ClampMode_7,userdata(tabnum)=  "0",userdata(tabcontrol)=  "ADC"
 	CheckBox Radio_ClampMode_7,userdata(ResizeControlsInfo)= A"!!,H!!!#@B!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Radio_ClampMode_7,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Radio_ClampMode_7,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	CheckBox Radio_ClampMode_7,userdata(Config_RestorePriority)=  "30"
+	CheckBox Radio_ClampMode_7,userdata(Config_NiceName)=  "Headstage_3_IC"
 	CheckBox Radio_ClampMode_7,value= 0,mode=1
 	CheckBox Radio_ClampMode_8,pos={264.00,60.00},size={14.00,14.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
 	CheckBox Radio_ClampMode_8,userdata(tabnum)=  "0",userdata(tabcontrol)=  "ADC"
 	CheckBox Radio_ClampMode_8,userdata(ResizeControlsInfo)= A"!!,H?!!#?1!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Radio_ClampMode_8,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Radio_ClampMode_8,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	CheckBox Radio_ClampMode_8,userdata(Config_RestorePriority)=  "30"
+	CheckBox Radio_ClampMode_8,userdata(Config_NiceName)=  "Headstage_4_VC"
 	CheckBox Radio_ClampMode_8,value= 1,mode=1
 	CheckBox Radio_ClampMode_9,pos={264.00,111.00},size={14.00,14.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
 	CheckBox Radio_ClampMode_9,userdata(tabnum)=  "0",userdata(tabcontrol)=  "ADC"
 	CheckBox Radio_ClampMode_9,userdata(ResizeControlsInfo)= A"!!,H?!!#@B!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Radio_ClampMode_9,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Radio_ClampMode_9,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	CheckBox Radio_ClampMode_9,userdata(Config_RestorePriority)=  "30"
+	CheckBox Radio_ClampMode_9,userdata(Config_NiceName)=  "Headstage_4_IC"
 	CheckBox Radio_ClampMode_9,value= 0,mode=1
 	CheckBox Radio_ClampMode_10,pos={297.00,60.00},size={14.00,14.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
 	CheckBox Radio_ClampMode_10,userdata(tabnum)=  "0",userdata(tabcontrol)=  "ADC"
 	CheckBox Radio_ClampMode_10,userdata(ResizeControlsInfo)= A"!!,HP!!#?1!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Radio_ClampMode_10,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Radio_ClampMode_10,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	CheckBox Radio_ClampMode_10,userdata(Config_RestorePriority)=  "30"
+	CheckBox Radio_ClampMode_10,userdata(Config_NiceName)=  "Headstage_5_VC"
 	CheckBox Radio_ClampMode_10,value= 1,mode=1
 	CheckBox Radio_ClampMode_11,pos={297.00,111.00},size={14.00,14.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
 	CheckBox Radio_ClampMode_11,userdata(tabnum)=  "0",userdata(tabcontrol)=  "ADC"
 	CheckBox Radio_ClampMode_11,userdata(ResizeControlsInfo)= A"!!,HP!!#@B!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Radio_ClampMode_11,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Radio_ClampMode_11,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	CheckBox Radio_ClampMode_11,userdata(Config_RestorePriority)=  "30"
+	CheckBox Radio_ClampMode_11,userdata(Config_NiceName)=  "Headstage_5_IC"
 	CheckBox Radio_ClampMode_11,value= 0,mode=1
 	CheckBox Radio_ClampMode_12,pos={330.00,60.00},size={14.00,14.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
 	CheckBox Radio_ClampMode_12,userdata(tabnum)=  "0",userdata(tabcontrol)=  "ADC"
 	CheckBox Radio_ClampMode_12,userdata(ResizeControlsInfo)= A"!!,Ha!!#?1!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Radio_ClampMode_12,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Radio_ClampMode_12,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	CheckBox Radio_ClampMode_12,userdata(Config_RestorePriority)=  "30"
+	CheckBox Radio_ClampMode_12,userdata(Config_NiceName)=  "Headstage_6_VC"
 	CheckBox Radio_ClampMode_12,value= 1,mode=1
 	CheckBox Radio_ClampMode_13,pos={330.00,111.00},size={14.00,14.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
 	CheckBox Radio_ClampMode_13,userdata(tabnum)=  "0",userdata(tabcontrol)=  "ADC"
 	CheckBox Radio_ClampMode_13,userdata(ResizeControlsInfo)= A"!!,Ha!!#@B!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Radio_ClampMode_13,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Radio_ClampMode_13,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	CheckBox Radio_ClampMode_13,userdata(Config_RestorePriority)=  "30"
+	CheckBox Radio_ClampMode_13,userdata(Config_NiceName)=  "Headstage_6_IC"
 	CheckBox Radio_ClampMode_13,value= 0,mode=1
 	CheckBox Radio_ClampMode_14,pos={366.00,60.00},size={14.00,14.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
 	CheckBox Radio_ClampMode_14,userdata(tabnum)=  "0",userdata(tabcontrol)=  "ADC"
 	CheckBox Radio_ClampMode_14,userdata(ResizeControlsInfo)= A"!!,Hr!!#?1!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Radio_ClampMode_14,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Radio_ClampMode_14,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	CheckBox Radio_ClampMode_14,userdata(Config_RestorePriority)=  "30"
+	CheckBox Radio_ClampMode_14,userdata(Config_NiceName)=  "Headstage_7_VC"
 	CheckBox Radio_ClampMode_14,value= 1,mode=1
 	CheckBox Radio_ClampMode_15,pos={366.00,111.00},size={14.00,14.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
 	CheckBox Radio_ClampMode_15,userdata(tabnum)=  "0",userdata(tabcontrol)=  "ADC"
 	CheckBox Radio_ClampMode_15,userdata(ResizeControlsInfo)= A"!!,Hr!!#@B!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Radio_ClampMode_15,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Radio_ClampMode_15,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	CheckBox Radio_ClampMode_15,userdata(Config_RestorePriority)=  "30"
+	CheckBox Radio_ClampMode_15,userdata(Config_NiceName)=  "Headstage_7_IC"
 	CheckBox Radio_ClampMode_15,value= 0,mode=1
-	CheckBox Radio_ClampMode_1IZ,pos={129.00,180.00},size={12.00,12.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
+	CheckBox Radio_ClampMode_1IZ,pos={129.00,180.00},size={14.00,14.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
 	CheckBox Radio_ClampMode_1IZ,userdata(tabnum)=  "2"
 	CheckBox Radio_ClampMode_1IZ,userdata(tabcontrol)=  "tab_DataAcq_Amp"
 	CheckBox Radio_ClampMode_1IZ,userdata(ResizeControlsInfo)= A"!!,G!!!#AD!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Radio_ClampMode_1IZ,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Radio_ClampMode_1IZ,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	CheckBox Radio_ClampMode_1IZ,userdata(Config_RestorePriority)=  "30"
+	CheckBox Radio_ClampMode_1IZ,userdata(Config_NiceName)=  "Headstage_0_IZero"
 	CheckBox Radio_ClampMode_1IZ,value= 0,mode=1
-	CheckBox Radio_ClampMode_3IZ,pos={162.00,180.00},size={12.00,12.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
+	CheckBox Radio_ClampMode_3IZ,pos={162.00,180.00},size={14.00,14.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
 	CheckBox Radio_ClampMode_3IZ,userdata(tabnum)=  "2"
 	CheckBox Radio_ClampMode_3IZ,userdata(tabcontrol)=  "tab_DataAcq_Amp"
 	CheckBox Radio_ClampMode_3IZ,userdata(ResizeControlsInfo)= A"!!,GB!!#AD!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Radio_ClampMode_3IZ,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Radio_ClampMode_3IZ,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	CheckBox Radio_ClampMode_3IZ,userdata(Config_RestorePriority)=  "30"
+	CheckBox Radio_ClampMode_3IZ,userdata(Config_NiceName)=  "Headstage_1_IZero"
 	CheckBox Radio_ClampMode_3IZ,value= 0,mode=1
-	CheckBox Radio_ClampMode_5IZ,pos={195.00,180.00},size={12.00,12.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
+	CheckBox Radio_ClampMode_5IZ,pos={195.00,180.00},size={14.00,14.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
 	CheckBox Radio_ClampMode_5IZ,userdata(tabnum)=  "2"
 	CheckBox Radio_ClampMode_5IZ,userdata(tabcontrol)=  "tab_DataAcq_Amp"
 	CheckBox Radio_ClampMode_5IZ,userdata(ResizeControlsInfo)= A"!!,Gd!!#AD!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Radio_ClampMode_5IZ,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Radio_ClampMode_5IZ,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	CheckBox Radio_ClampMode_5IZ,userdata(Config_RestorePriority)=  "30"
+	CheckBox Radio_ClampMode_5IZ,userdata(Config_NiceName)=  "Headstage_2_IZero"
 	CheckBox Radio_ClampMode_5IZ,value= 0,mode=1
-	CheckBox Radio_ClampMode_7IZ,pos={231.00,180.00},size={12.00,12.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
+	CheckBox Radio_ClampMode_7IZ,pos={231.00,180.00},size={14.00,14.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
 	CheckBox Radio_ClampMode_7IZ,userdata(tabnum)=  "2"
 	CheckBox Radio_ClampMode_7IZ,userdata(tabcontrol)=  "tab_DataAcq_Amp"
 	CheckBox Radio_ClampMode_7IZ,userdata(ResizeControlsInfo)= A"!!,H1!!#AD!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Radio_ClampMode_7IZ,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Radio_ClampMode_7IZ,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	CheckBox Radio_ClampMode_7IZ,userdata(Config_RestorePriority)=  "30"
+	CheckBox Radio_ClampMode_7IZ,userdata(Config_NiceName)=  "Headstage_3_IZero"
 	CheckBox Radio_ClampMode_7IZ,value= 0,mode=1
-	CheckBox Radio_ClampMode_9IZ,pos={264.00,180.00},size={12.00,12.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
+	CheckBox Radio_ClampMode_9IZ,pos={264.00,180.00},size={14.00,14.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
 	CheckBox Radio_ClampMode_9IZ,userdata(tabnum)=  "2"
 	CheckBox Radio_ClampMode_9IZ,userdata(tabcontrol)=  "tab_DataAcq_Amp"
 	CheckBox Radio_ClampMode_9IZ,userdata(ResizeControlsInfo)= A"!!,HG!!#AD!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Radio_ClampMode_9IZ,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Radio_ClampMode_9IZ,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	CheckBox Radio_ClampMode_9IZ,userdata(Config_RestorePriority)=  "30"
+	CheckBox Radio_ClampMode_9IZ,userdata(Config_NiceName)=  "Headstage_4_IZero"
 	CheckBox Radio_ClampMode_9IZ,value= 0,mode=1
-	CheckBox Radio_ClampMode_11IZ,pos={297.00,180.00},size={12.00,12.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
+	CheckBox Radio_ClampMode_11IZ,pos={297.00,180.00},size={14.00,14.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
 	CheckBox Radio_ClampMode_11IZ,userdata(tabnum)=  "2"
 	CheckBox Radio_ClampMode_11IZ,userdata(tabcontrol)=  "tab_DataAcq_Amp"
 	CheckBox Radio_ClampMode_11IZ,userdata(ResizeControlsInfo)= A"!!,HX!!#AD!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Radio_ClampMode_11IZ,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Radio_ClampMode_11IZ,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	CheckBox Radio_ClampMode_11IZ,userdata(Config_RestorePriority)=  "30"
+	CheckBox Radio_ClampMode_11IZ,userdata(Config_NiceName)=  "Headstage_5_IZero"
 	CheckBox Radio_ClampMode_11IZ,value= 0,mode=1
-	CheckBox Radio_ClampMode_13IZ,pos={333.00,180.00},size={12.00,12.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
+	CheckBox Radio_ClampMode_13IZ,pos={333.00,180.00},size={14.00,14.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
 	CheckBox Radio_ClampMode_13IZ,userdata(tabnum)=  "2"
 	CheckBox Radio_ClampMode_13IZ,userdata(tabcontrol)=  "tab_DataAcq_Amp"
 	CheckBox Radio_ClampMode_13IZ,userdata(ResizeControlsInfo)= A"!!,Hi!!#AD!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Radio_ClampMode_13IZ,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Radio_ClampMode_13IZ,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	CheckBox Radio_ClampMode_13IZ,userdata(Config_RestorePriority)=  "30"
+	CheckBox Radio_ClampMode_13IZ,userdata(Config_NiceName)=  "Headstage_6_IZero"
 	CheckBox Radio_ClampMode_13IZ,value= 0,mode=1
-	CheckBox Radio_ClampMode_15IZ,pos={366.00,180.00},size={12.00,12.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
+	CheckBox Radio_ClampMode_15IZ,pos={366.00,180.00},size={14.00,14.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
 	CheckBox Radio_ClampMode_15IZ,userdata(tabnum)=  "2"
 	CheckBox Radio_ClampMode_15IZ,userdata(tabcontrol)=  "tab_DataAcq_Amp"
 	CheckBox Radio_ClampMode_15IZ,userdata(ResizeControlsInfo)= A"!!,I%!!#AD!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Radio_ClampMode_15IZ,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Radio_ClampMode_15IZ,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	CheckBox Radio_ClampMode_15IZ,userdata(Config_RestorePriority)=  "30"
+	CheckBox Radio_ClampMode_15IZ,userdata(Config_NiceName)=  "Headstage_7_IZero"
 	CheckBox Radio_ClampMode_15IZ,value= 0,mode=1
-	TitleBox Title_DataAcq_IE0,pos={66.00,177.00},size={54.00,15.00},disable=1,title="I=0 Clamp"
+	TitleBox Title_DataAcq_IE0,pos={66.00,177.00},size={55.00,15.00},disable=1,title="I=0 Clamp"
 	TitleBox Title_DataAcq_IE0,userdata(tabnum)=  "2"
 	TitleBox Title_DataAcq_IE0,userdata(tabcontrol)=  "tab_DataAcq_Amp"
 	TitleBox Title_DataAcq_IE0,userdata(ResizeControlsInfo)= A"!!,E^!!#AB!!#>j!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
@@ -1216,6 +1446,8 @@ Window DA_Ephys() : Panel
 	PopupMenu Popup_Settings_VC_DA,userdata(ResizeControlsInfo)= A"!!,DG!!#C2J,hnu!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu Popup_Settings_VC_DA,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu Popup_Settings_VC_DA,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu Popup_Settings_VC_DA,userdata(Config_DontRestore)=  "1"
+	PopupMenu Popup_Settings_VC_DA,userdata(Config_DontSave)=  "1"
 	PopupMenu Popup_Settings_VC_DA,mode=1,popvalue="0",value= #"\"0;1;2;3;4;5;6;7\""
 	PopupMenu Popup_Settings_VC_AD,pos={45.00,435.00},size={47.00,19.00},proc=DAP_PopMenuProc_CAA,title="AD"
 	PopupMenu Popup_Settings_VC_AD,userdata(tabnum)=  "6"
@@ -1223,13 +1455,17 @@ Window DA_Ephys() : Panel
 	PopupMenu Popup_Settings_VC_AD,userdata(ResizeControlsInfo)= A"!!,DG!!#C?!!#>J!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu Popup_Settings_VC_AD,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu Popup_Settings_VC_AD,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu Popup_Settings_VC_AD,userdata(Config_DontRestore)=  "1"
+	PopupMenu Popup_Settings_VC_AD,userdata(Config_DontSave)=  "1"
 	PopupMenu Popup_Settings_VC_AD,mode=1,popvalue="0",value= #"\"0;1;2;3;4;5;6;7;8;9;10;11;12;13;14;15\""
-	PopupMenu Popup_Settings_IC_AD,pos={225.00,435.00},size={47.00,19.00},proc=DAP_PopMenuProc_CAA,title="AD"
+	PopupMenu Popup_Settings_IC_AD,pos={225.00,434.00},size={47.00,19.00},proc=DAP_PopMenuProc_CAA,title="AD"
 	PopupMenu Popup_Settings_IC_AD,userdata(tabnum)=  "6"
 	PopupMenu Popup_Settings_IC_AD,userdata(tabcontrol)=  "ADC"
 	PopupMenu Popup_Settings_IC_AD,userdata(ResizeControlsInfo)= A"!!,Gr!!#C?!!#>J!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu Popup_Settings_IC_AD,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu Popup_Settings_IC_AD,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu Popup_Settings_IC_AD,userdata(Config_DontRestore)=  "1"
+	PopupMenu Popup_Settings_IC_AD,userdata(Config_DontSave)=  "1"
 	PopupMenu Popup_Settings_IC_AD,mode=1,popvalue="0",value= #"\"0;1;2;3;4;5;6;7;8;9;10;11;12;13;14;15\""
 	SetVariable setvar_Settings_VC_DAgain,pos={105.00,411.00},size={48.00,18.00},proc=DAP_SetVarProc_CAA
 	SetVariable setvar_Settings_VC_DAgain,userdata(tabnum)=  "6"
@@ -1237,6 +1473,8 @@ Window DA_Ephys() : Panel
 	SetVariable setvar_Settings_VC_DAgain,userdata(ResizeControlsInfo)= A"!!,F;!!#C3J,ho,!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable setvar_Settings_VC_DAgain,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable setvar_Settings_VC_DAgain,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable setvar_Settings_VC_DAgain,userdata(Config_DontRestore)=  "1"
+	SetVariable setvar_Settings_VC_DAgain,userdata(Config_DontSave)=  "1"
 	SetVariable setvar_Settings_VC_DAgain,value= _NUM:20
 	SetVariable setvar_Settings_VC_ADgain,pos={105.00,438.00},size={48.00,18.00},proc=DAP_SetVarProc_CAA
 	SetVariable setvar_Settings_VC_ADgain,userdata(tabnum)=  "6"
@@ -1244,6 +1482,8 @@ Window DA_Ephys() : Panel
 	SetVariable setvar_Settings_VC_ADgain,userdata(ResizeControlsInfo)= A"!!,F;!!#C@!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable setvar_Settings_VC_ADgain,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable setvar_Settings_VC_ADgain,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable setvar_Settings_VC_ADgain,userdata(Config_DontRestore)=  "1"
+	SetVariable setvar_Settings_VC_ADgain,userdata(Config_DontSave)=  "1"
 	SetVariable setvar_Settings_VC_ADgain,value= _NUM:0.00999999977648258
 	SetVariable setvar_Settings_IC_ADgain,pos={285.00,438.00},size={48.00,18.00},proc=DAP_SetVarProc_CAA
 	SetVariable setvar_Settings_IC_ADgain,userdata(tabnum)=  "6"
@@ -1251,6 +1491,8 @@ Window DA_Ephys() : Panel
 	SetVariable setvar_Settings_IC_ADgain,userdata(ResizeControlsInfo)= A"!!,HJJ,hsk!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable setvar_Settings_IC_ADgain,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable setvar_Settings_IC_ADgain,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable setvar_Settings_IC_ADgain,userdata(Config_DontRestore)=  "1"
+	SetVariable setvar_Settings_IC_ADgain,userdata(Config_DontSave)=  "1"
 	SetVariable setvar_Settings_IC_ADgain,value= _NUM:0.00999999977648258
 	PopupMenu Popup_Settings_HeadStage,pos={64.00,327.00},size={91.00,19.00},proc=DAP_PopMenuProc_Headstage,title="Head Stage"
 	PopupMenu Popup_Settings_HeadStage,userdata(tabnum)=  "6"
@@ -1258,6 +1500,8 @@ Window DA_Ephys() : Panel
 	PopupMenu Popup_Settings_HeadStage,userdata(ResizeControlsInfo)= A"!!,DG!!#B^J,hpE!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu Popup_Settings_HeadStage,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu Popup_Settings_HeadStage,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu Popup_Settings_HeadStage,userdata(Config_DontSave)=  "1"
+	PopupMenu Popup_Settings_HeadStage,userdata(Config_DontRestore)=  "1"
 	PopupMenu Popup_Settings_HeadStage,mode=1,popvalue="0",value= #"\"0;1;2;3;4;5;6;7\""
 	PopupMenu popup_Settings_Amplifier,pos={34.00,357.00},size={235.00,19.00},bodyWidth=150,proc=DAP_PopMenuProc_CAA,title="Amplfier (700B)"
 	PopupMenu popup_Settings_Amplifier,userdata(tabnum)=  "6"
@@ -1265,6 +1509,8 @@ Window DA_Ephys() : Panel
 	PopupMenu popup_Settings_Amplifier,userdata(ResizeControlsInfo)= A"!!,Cp!!#Bm!!#B%!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu popup_Settings_Amplifier,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu popup_Settings_Amplifier,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu popup_Settings_Amplifier,userdata(Config_DontSave)=  "1"
+	PopupMenu popup_Settings_Amplifier,userdata(Config_DontRestore)=  "1"
 	PopupMenu popup_Settings_Amplifier,mode=1,popvalue="- none -",value= #"DAP_GetNiceAmplifierChannelList()"
 	PopupMenu Popup_Settings_IC_DA,pos={225.00,411.00},size={47.00,19.00},proc=DAP_PopMenuProc_CAA,title="DA"
 	PopupMenu Popup_Settings_IC_DA,userdata(tabnum)=  "6"
@@ -1272,6 +1518,8 @@ Window DA_Ephys() : Panel
 	PopupMenu Popup_Settings_IC_DA,userdata(ResizeControlsInfo)= A"!!,Gr!!#C2J,hnu!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu Popup_Settings_IC_DA,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu Popup_Settings_IC_DA,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu Popup_Settings_IC_DA,userdata(Config_DontRestore)=  "1"
+	PopupMenu Popup_Settings_IC_DA,userdata(Config_DontSave)=  "1"
 	PopupMenu Popup_Settings_IC_DA,mode=1,popvalue="0",value= #"\"0;1;2;3;4;5;6;7\""
 	SetVariable setvar_Settings_IC_DAgain,pos={288.00,411.00},size={48.00,18.00},proc=DAP_SetVarProc_CAA
 	SetVariable setvar_Settings_IC_DAgain,userdata(tabnum)=  "6"
@@ -1279,6 +1527,8 @@ Window DA_Ephys() : Panel
 	SetVariable setvar_Settings_IC_DAgain,userdata(ResizeControlsInfo)= A"!!,HK!!#C3J,ho,!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable setvar_Settings_IC_DAgain,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable setvar_Settings_IC_DAgain,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable setvar_Settings_IC_DAgain,userdata(Config_DontRestore)=  "1"
+	SetVariable setvar_Settings_IC_DAgain,userdata(Config_DontSave)=  "1"
 	SetVariable setvar_Settings_IC_DAgain,value= _NUM:400
 	TitleBox Title_settings_Hardware_VC,pos={57.00,393.00},size={47.00,15.00},title="V-Clamp"
 	TitleBox Title_settings_Hardware_VC,userdata(tabnum)=  "6"
@@ -1305,98 +1555,114 @@ Window DA_Ephys() : Panel
 	SetVariable Search_DA_00,userdata(ResizeControlsInfo)= A"!!,G)!!#@&!!#@\\!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Search_DA_00,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Search_DA_00,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Search_DA_00,value= _STR:""
+	SetVariable Search_DA_00,userdata(ControlArray)=  "Search_DA"
+	SetVariable Search_DA_00,userdata(ControlArrayIndex)=  "0",value= _STR:""
 	SetVariable Search_DA_01,pos={153.00,141.00},size={123.00,18.00},disable=1,proc=DAP_SetVarProc_Channel_Search,title="Search filter"
 	SetVariable Search_DA_01,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Search_DA_01,userdata(ResizeControlsInfo)= A"!!,G)!!#@s!!#@\\!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Search_DA_01,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Search_DA_01,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Search_DA_01,value= _STR:""
+	SetVariable Search_DA_01,userdata(ControlArray)=  "Search_DA"
+	SetVariable Search_DA_01,userdata(ControlArrayIndex)=  "1",value= _STR:""
 	SetVariable Search_DA_02,pos={153.00,189.00},size={123.00,18.00},disable=1,proc=DAP_SetVarProc_Channel_Search,title="Search filter"
 	SetVariable Search_DA_02,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Search_DA_02,userdata(ResizeControlsInfo)= A"!!,G)!!#AL!!#@\\!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Search_DA_02,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Search_DA_02,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Search_DA_02,value= _STR:""
+	SetVariable Search_DA_02,userdata(ControlArray)=  "Search_DA"
+	SetVariable Search_DA_02,userdata(ControlArrayIndex)=  "2",value= _STR:""
 	SetVariable Search_DA_03,pos={153.00,234.00},size={123.00,18.00},disable=1,proc=DAP_SetVarProc_Channel_Search,title="Search filter"
 	SetVariable Search_DA_03,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Search_DA_03,userdata(ResizeControlsInfo)= A"!!,G)!!#B&!!#@\\!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Search_DA_03,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Search_DA_03,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Search_DA_03,value= _STR:""
+	SetVariable Search_DA_03,userdata(ControlArray)=  "Search_DA"
+	SetVariable Search_DA_03,userdata(ControlArrayIndex)=  "3",value= _STR:""
 	SetVariable Search_DA_04,pos={153.00,282.00},size={123.00,18.00},disable=1,proc=DAP_SetVarProc_Channel_Search,title="Search filter"
 	SetVariable Search_DA_04,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Search_DA_04,userdata(ResizeControlsInfo)= A"!!,G)!!#BG!!#@\\!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Search_DA_04,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Search_DA_04,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Search_DA_04,value= _STR:""
+	SetVariable Search_DA_04,userdata(ControlArray)=  "Search_DA"
+	SetVariable Search_DA_04,userdata(ControlArrayIndex)=  "4",value= _STR:""
 	SetVariable Search_DA_05,pos={153.00,327.00},size={123.00,18.00},disable=1,proc=DAP_SetVarProc_Channel_Search,title="Search filter"
 	SetVariable Search_DA_05,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Search_DA_05,userdata(ResizeControlsInfo)= A"!!,G)!!#B^J,hq2!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Search_DA_05,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Search_DA_05,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Search_DA_05,value= _STR:""
+	SetVariable Search_DA_05,userdata(ControlArray)=  "Search_DA"
+	SetVariable Search_DA_05,userdata(ControlArrayIndex)=  "5",value= _STR:""
 	SetVariable Search_DA_06,pos={153.00,375.00},size={123.00,18.00},disable=1,proc=DAP_SetVarProc_Channel_Search,title="Search filter"
 	SetVariable Search_DA_06,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Search_DA_06,userdata(ResizeControlsInfo)= A"!!,G)!!#BuJ,hq2!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Search_DA_06,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Search_DA_06,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Search_DA_06,value= _STR:""
+	SetVariable Search_DA_06,userdata(ControlArray)=  "Search_DA"
+	SetVariable Search_DA_06,userdata(ControlArrayIndex)=  "6",value= _STR:""
 	SetVariable Search_DA_07,pos={153.00,420.00},size={123.00,18.00},disable=1,proc=DAP_SetVarProc_Channel_Search,title="Search filter"
 	SetVariable Search_DA_07,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Search_DA_07,userdata(ResizeControlsInfo)= A"!!,G)!!#C8!!#@\\!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Search_DA_07,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Search_DA_07,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Search_DA_07,value= _STR:""
+	SetVariable Search_DA_07,userdata(ControlArray)=  "Search_DA"
+	SetVariable Search_DA_07,userdata(ControlArrayIndex)=  "7",value= _STR:""
 	SetVariable Search_TTL_00,pos={102.00,96.00},size={123.00,18.00},disable=1,proc=DAP_SetVarProc_Channel_Search,title="Search filter"
 	SetVariable Search_TTL_00,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	SetVariable Search_TTL_00,userdata(ResizeControlsInfo)= A"!!,F1!!#@&!!#@\\!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Search_TTL_00,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Search_TTL_00,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Search_TTL_00,value= _STR:""
+	SetVariable Search_TTL_00,userdata(ControlArray)=  "Search_TTL"
+	SetVariable Search_TTL_00,userdata(ControlArrayIndex)=  "0",value= _STR:""
 	SetVariable Search_TTL_01,pos={102.00,141.00},size={123.00,18.00},disable=1,proc=DAP_SetVarProc_Channel_Search,title="Search filter"
 	SetVariable Search_TTL_01,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	SetVariable Search_TTL_01,userdata(ResizeControlsInfo)= A"!!,F1!!#@s!!#@\\!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Search_TTL_01,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Search_TTL_01,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Search_TTL_01,value= _STR:""
+	SetVariable Search_TTL_01,userdata(ControlArray)=  "Search_TTL"
+	SetVariable Search_TTL_01,userdata(ControlArrayIndex)=  "1",value= _STR:""
 	SetVariable Search_TTL_02,pos={102.00,189.00},size={123.00,18.00},disable=1,proc=DAP_SetVarProc_Channel_Search,title="Search filter"
 	SetVariable Search_TTL_02,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	SetVariable Search_TTL_02,userdata(ResizeControlsInfo)= A"!!,F1!!#AM!!#@\\!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Search_TTL_02,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Search_TTL_02,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Search_TTL_02,value= _STR:""
+	SetVariable Search_TTL_02,userdata(ControlArray)=  "Search_TTL"
+	SetVariable Search_TTL_02,userdata(ControlArrayIndex)=  "2",value= _STR:""
 	SetVariable Search_TTL_03,pos={102.00,237.00},size={123.00,18.00},disable=1,proc=DAP_SetVarProc_Channel_Search,title="Search filter"
 	SetVariable Search_TTL_03,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	SetVariable Search_TTL_03,userdata(ResizeControlsInfo)= A"!!,F1!!#B'!!#@\\!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Search_TTL_03,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Search_TTL_03,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Search_TTL_03,value= _STR:""
+	SetVariable Search_TTL_03,userdata(ControlArray)=  "Search_TTL"
+	SetVariable Search_TTL_03,userdata(ControlArrayIndex)=  "3",value= _STR:""
 	SetVariable Search_TTL_04,pos={102.00,282.00},size={123.00,18.00},disable=1,proc=DAP_SetVarProc_Channel_Search,title="Search filter"
 	SetVariable Search_TTL_04,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	SetVariable Search_TTL_04,userdata(ResizeControlsInfo)= A"!!,F1!!#BH!!#@\\!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Search_TTL_04,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Search_TTL_04,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Search_TTL_04,value= _STR:""
+	SetVariable Search_TTL_04,userdata(ControlArray)=  "Search_TTL"
+	SetVariable Search_TTL_04,userdata(ControlArrayIndex)=  "4",value= _STR:""
 	SetVariable Search_TTL_05,pos={102.00,330.00},size={123.00,18.00},disable=1,proc=DAP_SetVarProc_Channel_Search,title="Search filter"
 	SetVariable Search_TTL_05,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	SetVariable Search_TTL_05,userdata(ResizeControlsInfo)= A"!!,F1!!#B_J,hq2!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Search_TTL_05,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Search_TTL_05,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Search_TTL_05,value= _STR:""
+	SetVariable Search_TTL_05,userdata(ControlArray)=  "Search_TTL"
+	SetVariable Search_TTL_05,userdata(ControlArrayIndex)=  "5",value= _STR:""
 	SetVariable Search_TTL_06,pos={102.00,378.00},size={123.00,18.00},disable=1,proc=DAP_SetVarProc_Channel_Search,title="Search filter"
 	SetVariable Search_TTL_06,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	SetVariable Search_TTL_06,userdata(ResizeControlsInfo)= A"!!,F1!!#C\"!!#@\\!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Search_TTL_06,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Search_TTL_06,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Search_TTL_06,value= _STR:""
+	SetVariable Search_TTL_06,userdata(ControlArray)=  "Search_TTL"
+	SetVariable Search_TTL_06,userdata(ControlArrayIndex)=  "6",value= _STR:""
 	SetVariable Search_TTL_07,pos={102.00,423.00},size={123.00,18.00},disable=1,proc=DAP_SetVarProc_Channel_Search,title="Search filter"
 	SetVariable Search_TTL_07,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	SetVariable Search_TTL_07,userdata(ResizeControlsInfo)= A"!!,F1!!#C9J,hq2!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Search_TTL_07,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Search_TTL_07,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Search_TTL_07,value= _STR:""
-	CheckBox Check_DataAcq_Indexing,pos={179.00,637.00},size={62.00,15.00},disable=1,proc=DAP_CheckProc_IndexingState,title="Indexing"
+	SetVariable Search_TTL_07,userdata(ControlArray)=  "Search_TTL"
+	SetVariable Search_TTL_07,userdata(ControlArrayIndex)=  "7",value= _STR:""
+	CheckBox Check_DataAcq_Indexing,pos={179.00,637.00},size={61.00,15.00},disable=1,proc=DAP_CheckProc_IndexingState,title="Indexing"
 	CheckBox Check_DataAcq_Indexing,help={"Data acquisition proceeds to next wave in DAC or TTL popup menu list"}
 	CheckBox Check_DataAcq_Indexing,userdata(tabnum)=  "0"
 	CheckBox Check_DataAcq_Indexing,userdata(tabcontrol)=  "ADC"
@@ -1442,96 +1708,128 @@ Window DA_Ephys() : Panel
 	PopupMenu IndexEnd_DA_00,userdata(ResizeControlsInfo)= A"!!,HkJ,hp%!!#@^!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu IndexEnd_DA_00,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu IndexEnd_DA_00,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu IndexEnd_DA_00,userdata(ControlArray)=  "IndexEnd_DA"
+	PopupMenu IndexEnd_DA_00,userdata(ControlArrayIndex)=  "0"
 	PopupMenu IndexEnd_DA_00,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(0,\"*DA*\")"
 	PopupMenu IndexEnd_DA_01,pos={346.00,120.00},size={125.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList
 	PopupMenu IndexEnd_DA_01,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	PopupMenu IndexEnd_DA_01,userdata(ResizeControlsInfo)= A"!!,HkJ,hq,!!#@^!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu IndexEnd_DA_01,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu IndexEnd_DA_01,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu IndexEnd_DA_01,userdata(ControlArray)=  "IndexEnd_DA"
+	PopupMenu IndexEnd_DA_01,userdata(ControlArrayIndex)=  "1"
 	PopupMenu IndexEnd_DA_01,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(0,\"*DA*\")"
 	PopupMenu IndexEnd_DA_02,pos={346.00,165.00},size={125.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList
 	PopupMenu IndexEnd_DA_02,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	PopupMenu IndexEnd_DA_02,userdata(ResizeControlsInfo)= A"!!,HkJ,hqa!!#@^!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu IndexEnd_DA_02,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu IndexEnd_DA_02,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu IndexEnd_DA_02,userdata(ControlArray)=  "IndexEnd_DA"
+	PopupMenu IndexEnd_DA_02,userdata(ControlArrayIndex)=  "2"
 	PopupMenu IndexEnd_DA_02,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(0,\"*DA*\")"
 	PopupMenu IndexEnd_DA_03,pos={346.00,213.00},size={125.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList
 	PopupMenu IndexEnd_DA_03,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	PopupMenu IndexEnd_DA_03,userdata(ResizeControlsInfo)= A"!!,HkJ,hr;!!#@^!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu IndexEnd_DA_03,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu IndexEnd_DA_03,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu IndexEnd_DA_03,userdata(ControlArray)=  "IndexEnd_DA"
+	PopupMenu IndexEnd_DA_03,userdata(ControlArrayIndex)=  "3"
 	PopupMenu IndexEnd_DA_03,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(0,\"*DA*\")"
 	PopupMenu IndexEnd_DA_04,pos={346.00,258.00},size={125.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList
 	PopupMenu IndexEnd_DA_04,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	PopupMenu IndexEnd_DA_04,userdata(ResizeControlsInfo)= A"!!,HkJ,hrg!!#@^!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu IndexEnd_DA_04,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu IndexEnd_DA_04,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu IndexEnd_DA_04,userdata(ControlArray)=  "IndexEnd_DA"
+	PopupMenu IndexEnd_DA_04,userdata(ControlArrayIndex)=  "4"
 	PopupMenu IndexEnd_DA_04,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(0,\"*DA*\")"
 	PopupMenu IndexEnd_DA_05,pos={346.00,306.00},size={125.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList
 	PopupMenu IndexEnd_DA_05,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	PopupMenu IndexEnd_DA_05,userdata(ResizeControlsInfo)= A"!!,HkJ,hs)J,hq4!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu IndexEnd_DA_05,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu IndexEnd_DA_05,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu IndexEnd_DA_05,userdata(ControlArray)=  "IndexEnd_DA"
+	PopupMenu IndexEnd_DA_05,userdata(ControlArrayIndex)=  "5"
 	PopupMenu IndexEnd_DA_05,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(0,\"*DA*\")"
 	PopupMenu IndexEnd_DA_06,pos={346.00,351.00},size={125.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList
 	PopupMenu IndexEnd_DA_06,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	PopupMenu IndexEnd_DA_06,userdata(ResizeControlsInfo)= A"!!,HkJ,hs@J,hq4!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu IndexEnd_DA_06,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu IndexEnd_DA_06,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu IndexEnd_DA_06,userdata(ControlArray)=  "IndexEnd_DA"
+	PopupMenu IndexEnd_DA_06,userdata(ControlArrayIndex)=  "6"
 	PopupMenu IndexEnd_DA_06,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(0,\"*DA*\")"
 	PopupMenu IndexEnd_DA_07,pos={346.00,399.00},size={125.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList
 	PopupMenu IndexEnd_DA_07,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	PopupMenu IndexEnd_DA_07,userdata(ResizeControlsInfo)= A"!!,HkJ,hsX!!#@^!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu IndexEnd_DA_07,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu IndexEnd_DA_07,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu IndexEnd_DA_07,userdata(ControlArray)=  "IndexEnd_DA"
+	PopupMenu IndexEnd_DA_07,userdata(ControlArrayIndex)=  "7"
 	PopupMenu IndexEnd_DA_07,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(0,\"*DA*\")"
 	PopupMenu IndexEnd_TTL_00,pos={241.00,75.00},size={125.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList
 	PopupMenu IndexEnd_TTL_00,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	PopupMenu IndexEnd_TTL_00,userdata(ResizeControlsInfo)= A"!!,H.!!#?O!!#@^!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu IndexEnd_TTL_00,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu IndexEnd_TTL_00,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu IndexEnd_TTL_00,userdata(ControlArray)=  "IndexEnd_TTL"
+	PopupMenu IndexEnd_TTL_00,userdata(ControlArrayIndex)=  "0"
 	PopupMenu IndexEnd_TTL_00,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(1,\"*TTL*\")"
 	PopupMenu IndexEnd_TTL_01,pos={238.00,120.00},size={125.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList
 	PopupMenu IndexEnd_TTL_01,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	PopupMenu IndexEnd_TTL_01,userdata(ResizeControlsInfo)= A"!!,H-!!#@V!!#@^!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu IndexEnd_TTL_01,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu IndexEnd_TTL_01,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu IndexEnd_TTL_01,userdata(ControlArray)=  "IndexEnd_TTL"
+	PopupMenu IndexEnd_TTL_01,userdata(ControlArrayIndex)=  "1"
 	PopupMenu IndexEnd_TTL_01,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(1,\"*TTL*\")"
 	PopupMenu IndexEnd_TTL_02,pos={238.00,165.00},size={125.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList
 	PopupMenu IndexEnd_TTL_02,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	PopupMenu IndexEnd_TTL_02,userdata(ResizeControlsInfo)= A"!!,H-!!#A6!!#@^!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu IndexEnd_TTL_02,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu IndexEnd_TTL_02,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu IndexEnd_TTL_02,userdata(ControlArray)=  "IndexEnd_TTL"
+	PopupMenu IndexEnd_TTL_02,userdata(ControlArrayIndex)=  "2"
 	PopupMenu IndexEnd_TTL_02,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(1,\"*TTL*\")"
 	PopupMenu IndexEnd_TTL_03,pos={238.00,213.00},size={125.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList
 	PopupMenu IndexEnd_TTL_03,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	PopupMenu IndexEnd_TTL_03,userdata(ResizeControlsInfo)= A"!!,H-!!#Ae!!#@^!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu IndexEnd_TTL_03,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu IndexEnd_TTL_03,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu IndexEnd_TTL_03,userdata(ControlArray)=  "IndexEnd_TTL"
+	PopupMenu IndexEnd_TTL_03,userdata(ControlArrayIndex)=  "3"
 	PopupMenu IndexEnd_TTL_03,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(1,\"*TTL*\")"
 	PopupMenu IndexEnd_TTL_04,pos={238.00,258.00},size={125.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList
 	PopupMenu IndexEnd_TTL_04,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	PopupMenu IndexEnd_TTL_04,userdata(ResizeControlsInfo)= A"!!,H-!!#B<!!#@^!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu IndexEnd_TTL_04,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu IndexEnd_TTL_04,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu IndexEnd_TTL_04,userdata(ControlArray)=  "IndexEnd_TTL"
+	PopupMenu IndexEnd_TTL_04,userdata(ControlArrayIndex)=  "4"
 	PopupMenu IndexEnd_TTL_04,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(1,\"*TTL*\")"
 	PopupMenu IndexEnd_TTL_05,pos={238.00,306.00},size={125.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList
 	PopupMenu IndexEnd_TTL_05,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	PopupMenu IndexEnd_TTL_05,userdata(ResizeControlsInfo)= A"!!,H-!!#BSJ,hq4!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu IndexEnd_TTL_05,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu IndexEnd_TTL_05,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu IndexEnd_TTL_05,userdata(ControlArray)=  "IndexEnd_TTL"
+	PopupMenu IndexEnd_TTL_05,userdata(ControlArrayIndex)=  "5"
 	PopupMenu IndexEnd_TTL_05,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(1,\"*TTL*\")"
 	PopupMenu IndexEnd_TTL_06,pos={238.00,351.00},size={125.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList
 	PopupMenu IndexEnd_TTL_06,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	PopupMenu IndexEnd_TTL_06,userdata(ResizeControlsInfo)= A"!!,H-!!#BjJ,hq4!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu IndexEnd_TTL_06,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu IndexEnd_TTL_06,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu IndexEnd_TTL_06,userdata(ControlArray)=  "IndexEnd_TTL"
+	PopupMenu IndexEnd_TTL_06,userdata(ControlArrayIndex)=  "6"
 	PopupMenu IndexEnd_TTL_06,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(1,\"*TTL*\")"
 	PopupMenu IndexEnd_TTL_07,pos={241.00,399.00},size={125.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList
 	PopupMenu IndexEnd_TTL_07,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	PopupMenu IndexEnd_TTL_07,userdata(ResizeControlsInfo)= A"!!,H.!!#C-!!#@^!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu IndexEnd_TTL_07,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu IndexEnd_TTL_07,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu IndexEnd_TTL_07,userdata(ControlArray)=  "IndexEnd_TTL"
+	PopupMenu IndexEnd_TTL_07,userdata(ControlArrayIndex)=  "7"
 	PopupMenu IndexEnd_TTL_07,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(1,\"*TTL*\")"
 	CheckBox check_Settings_ShowScopeWindow,pos={33.00,622.00},size={127.00,15.00},disable=1,proc=DAP_CheckProc_ShowScopeWin,title="Show Scope Window"
 	CheckBox check_Settings_ShowScopeWindow,help={"Enable the scope window to view ongoing acquistion"}
@@ -1547,7 +1845,7 @@ Window DA_Ephys() : Panel
 	Button button_DataAcq_TurnOffAllChan,userdata(ResizeControlsInfo)= A"!!,I?J,hp!!!#=S!!#>.z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	Button button_DataAcq_TurnOffAllChan,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	Button button_DataAcq_TurnOffAllChan,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox check_Settings_ITITP,pos={27.00,108.00},size={128.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="Activate TP during ITI"
+	CheckBox check_Settings_ITITP,pos={27.00,108.00},size={130.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="Activate TP during ITI"
 	CheckBox check_Settings_ITITP,userdata(tabnum)=  "5"
 	CheckBox check_Settings_ITITP,userdata(tabcontrol)=  "ADC"
 	CheckBox check_Settings_ITITP,userdata(ResizeControlsInfo)= A"!!,Cl!!#@>!!#@e!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
@@ -1581,145 +1879,169 @@ Window DA_Ephys() : Panel
 	SetVariable min_AsyncAD_00,userdata(ResizeControlsInfo)= A"!!,F?!!#?=!!#?O!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable min_AsyncAD_00,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable min_AsyncAD_00,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable min_AsyncAD_00,value= _NUM:0
+	SetVariable min_AsyncAD_00,userdata(ControlArray)=  "min_AsyncAD"
+	SetVariable min_AsyncAD_00,userdata(ControlArrayIndex)=  "0",value= _NUM:0
 	SetVariable max_AsyncAD_00,pos={191.00,66.00},size={76.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState,title="max"
 	SetVariable max_AsyncAD_00,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable max_AsyncAD_00,userdata(ResizeControlsInfo)= A"!!,GU!!#?=!!#?Q!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable max_AsyncAD_00,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable max_AsyncAD_00,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable max_AsyncAD_00,value= _NUM:0
+	SetVariable max_AsyncAD_00,userdata(ControlArray)=  "max_AsyncAD"
+	SetVariable max_AsyncAD_00,userdata(ControlArrayIndex)=  "0",value= _NUM:0
 	CheckBox check_AsyncAlarm_00,pos={48.00,66.00},size={48.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="Alarm"
 	CheckBox check_AsyncAlarm_00,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	CheckBox check_AsyncAlarm_00,userdata(ResizeControlsInfo)= A"!!,DW!!#?A!!#>J!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox check_AsyncAlarm_00,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox check_AsyncAlarm_00,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox check_AsyncAlarm_00,value= 0
+	CheckBox check_AsyncAlarm_00,userdata(ControlArray)=  "check_AsyncAlarm"
+	CheckBox check_AsyncAlarm_00,userdata(ControlArrayIndex)=  "0",value= 0
 	SetVariable min_AsyncAD_01,pos={105.00,117.00},size={75.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState,title="min"
 	SetVariable min_AsyncAD_01,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable min_AsyncAD_01,userdata(ResizeControlsInfo)= A"!!,F?!!#@N!!#?O!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable min_AsyncAD_01,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable min_AsyncAD_01,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable min_AsyncAD_01,value= _NUM:0
+	SetVariable min_AsyncAD_01,userdata(ControlArray)=  "min_AsyncAD"
+	SetVariable min_AsyncAD_01,userdata(ControlArrayIndex)=  "1",value= _NUM:0
 	SetVariable max_AsyncAD_01,pos={191.00,117.00},size={76.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState,title="max"
 	SetVariable max_AsyncAD_01,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable max_AsyncAD_01,userdata(ResizeControlsInfo)= A"!!,GU!!#@N!!#?Q!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable max_AsyncAD_01,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable max_AsyncAD_01,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable max_AsyncAD_01,value= _NUM:0
+	SetVariable max_AsyncAD_01,userdata(ControlArray)=  "max_AsyncAD"
+	SetVariable max_AsyncAD_01,userdata(ControlArrayIndex)=  "1",value= _NUM:0
 	CheckBox check_AsyncAlarm_01,pos={48.00,117.00},size={48.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="Alarm"
 	CheckBox check_AsyncAlarm_01,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	CheckBox check_AsyncAlarm_01,userdata(ResizeControlsInfo)= A"!!,DW!!#@R!!#>J!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox check_AsyncAlarm_01,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox check_AsyncAlarm_01,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox check_AsyncAlarm_01,value= 0
+	CheckBox check_AsyncAlarm_01,userdata(ControlArray)=  "check_AsyncAlarm"
+	CheckBox check_AsyncAlarm_01,userdata(ControlArrayIndex)=  "1",value= 0
 	SetVariable min_AsyncAD_02,pos={105.00,168.00},size={75.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState,title="min"
 	SetVariable min_AsyncAD_02,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable min_AsyncAD_02,userdata(ResizeControlsInfo)= A"!!,F?!!#A8!!#?O!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable min_AsyncAD_02,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable min_AsyncAD_02,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable min_AsyncAD_02,value= _NUM:0
+	SetVariable min_AsyncAD_02,userdata(ControlArray)=  "min_AsyncAD"
+	SetVariable min_AsyncAD_02,userdata(ControlArrayIndex)=  "2",value= _NUM:0
 	SetVariable max_AsyncAD_02,pos={191.00,168.00},size={76.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState,title="max"
 	SetVariable max_AsyncAD_02,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable max_AsyncAD_02,userdata(ResizeControlsInfo)= A"!!,GU!!#A8!!#?Q!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable max_AsyncAD_02,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable max_AsyncAD_02,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable max_AsyncAD_02,value= _NUM:0
+	SetVariable max_AsyncAD_02,userdata(ControlArray)=  "max_AsyncAD"
+	SetVariable max_AsyncAD_02,userdata(ControlArrayIndex)=  "2",value= _NUM:0
 	CheckBox check_AsyncAlarm_02,pos={48.00,171.00},size={48.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="Alarm"
 	CheckBox check_AsyncAlarm_02,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	CheckBox check_AsyncAlarm_02,userdata(ResizeControlsInfo)= A"!!,DW!!#A:!!#>J!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox check_AsyncAlarm_02,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox check_AsyncAlarm_02,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox check_AsyncAlarm_02,value= 0
+	CheckBox check_AsyncAlarm_02,userdata(ControlArray)=  "check_AsyncAlarm"
+	CheckBox check_AsyncAlarm_02,userdata(ControlArrayIndex)=  "2",value= 0
 	SetVariable min_AsyncAD_03,pos={105.00,219.00},size={75.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState,title="min"
 	SetVariable min_AsyncAD_03,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable min_AsyncAD_03,userdata(ResizeControlsInfo)= A"!!,F?!!#Ak!!#?O!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable min_AsyncAD_03,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable min_AsyncAD_03,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable min_AsyncAD_03,value= _NUM:0
+	SetVariable min_AsyncAD_03,userdata(ControlArray)=  "min_AsyncAD"
+	SetVariable min_AsyncAD_03,userdata(ControlArrayIndex)=  "3",value= _NUM:0
 	SetVariable max_AsyncAD_03,pos={191.00,219.00},size={76.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState,title="max"
 	SetVariable max_AsyncAD_03,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable max_AsyncAD_03,userdata(ResizeControlsInfo)= A"!!,GU!!#Ak!!#?Q!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable max_AsyncAD_03,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable max_AsyncAD_03,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable max_AsyncAD_03,value= _NUM:0
+	SetVariable max_AsyncAD_03,userdata(ControlArray)=  "max_AsyncAD"
+	SetVariable max_AsyncAD_03,userdata(ControlArrayIndex)=  "3",value= _NUM:0
 	CheckBox check_AsyncAlarm_03,pos={48.00,222.00},size={48.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="Alarm"
 	CheckBox check_AsyncAlarm_03,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	CheckBox check_AsyncAlarm_03,userdata(ResizeControlsInfo)= A"!!,DW!!#Am!!#>J!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox check_AsyncAlarm_03,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox check_AsyncAlarm_03,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox check_AsyncAlarm_03,value= 0
+	CheckBox check_AsyncAlarm_03,userdata(ControlArray)=  "check_AsyncAlarm"
+	CheckBox check_AsyncAlarm_03,userdata(ControlArrayIndex)=  "3",value= 0
 	SetVariable min_AsyncAD_04,pos={105.00,270.00},size={75.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState,title="min"
 	SetVariable min_AsyncAD_04,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable min_AsyncAD_04,userdata(ResizeControlsInfo)= A"!!,F?!!#BB!!#?O!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable min_AsyncAD_04,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable min_AsyncAD_04,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable min_AsyncAD_04,value= _NUM:0
+	SetVariable min_AsyncAD_04,userdata(ControlArray)=  "min_AsyncAD"
+	SetVariable min_AsyncAD_04,userdata(ControlArrayIndex)=  "4",value= _NUM:0
 	SetVariable max_AsyncAD_04,pos={191.00,270.00},size={76.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState,title="max"
 	SetVariable max_AsyncAD_04,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable max_AsyncAD_04,userdata(ResizeControlsInfo)= A"!!,GU!!#BB!!#?Q!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable max_AsyncAD_04,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable max_AsyncAD_04,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable max_AsyncAD_04,value= _NUM:0
+	SetVariable max_AsyncAD_04,userdata(ControlArray)=  "max_AsyncAD"
+	SetVariable max_AsyncAD_04,userdata(ControlArrayIndex)=  "4",value= _NUM:0
 	CheckBox check_AsyncAlarm_04,pos={48.00,273.00},size={48.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="Alarm"
 	CheckBox check_AsyncAlarm_04,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	CheckBox check_AsyncAlarm_04,userdata(ResizeControlsInfo)= A"!!,DW!!#BC!!#>J!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox check_AsyncAlarm_04,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox check_AsyncAlarm_04,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox check_AsyncAlarm_04,value= 0
+	CheckBox check_AsyncAlarm_04,userdata(ControlArray)=  "check_AsyncAlarm"
+	CheckBox check_AsyncAlarm_04,userdata(ControlArrayIndex)=  "4",value= 0
 	SetVariable min_AsyncAD_05,pos={105.00,321.00},size={75.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState,title="min"
 	SetVariable min_AsyncAD_05,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable min_AsyncAD_05,userdata(ResizeControlsInfo)= A"!!,F?!!#B[J,hp%!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable min_AsyncAD_05,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable min_AsyncAD_05,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable min_AsyncAD_05,value= _NUM:0
+	SetVariable min_AsyncAD_05,userdata(ControlArray)=  "min_AsyncAD"
+	SetVariable min_AsyncAD_05,userdata(ControlArrayIndex)=  "5",value= _NUM:0
 	SetVariable max_AsyncAD_05,pos={191.00,321.00},size={76.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState,title="max"
 	SetVariable max_AsyncAD_05,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable max_AsyncAD_05,userdata(ResizeControlsInfo)= A"!!,GU!!#B[J,hp'!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable max_AsyncAD_05,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable max_AsyncAD_05,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable max_AsyncAD_05,value= _NUM:0
+	SetVariable max_AsyncAD_05,userdata(ControlArray)=  "max_AsyncAD"
+	SetVariable max_AsyncAD_05,userdata(ControlArrayIndex)=  "5",value= _NUM:0
 	CheckBox check_AsyncAlarm_05,pos={48.00,324.00},size={48.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="Alarm"
 	CheckBox check_AsyncAlarm_05,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	CheckBox check_AsyncAlarm_05,userdata(ResizeControlsInfo)= A"!!,DW!!#B\\J,hnu!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox check_AsyncAlarm_05,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox check_AsyncAlarm_05,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox check_AsyncAlarm_05,value= 0
+	CheckBox check_AsyncAlarm_05,userdata(ControlArray)=  "check_AsyncAlarm"
+	CheckBox check_AsyncAlarm_05,userdata(ControlArrayIndex)=  "5",value= 0
 	SetVariable min_AsyncAD_06,pos={105.00,375.00},size={75.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState,title="min"
 	SetVariable min_AsyncAD_06,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable min_AsyncAD_06,userdata(ResizeControlsInfo)= A"!!,F?!!#BuJ,hp%!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable min_AsyncAD_06,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable min_AsyncAD_06,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable min_AsyncAD_06,value= _NUM:0
+	SetVariable min_AsyncAD_06,userdata(ControlArray)=  "min_AsyncAD"
+	SetVariable min_AsyncAD_06,userdata(ControlArrayIndex)=  "6",value= _NUM:0
 	SetVariable max_AsyncAD_06,pos={191.00,375.00},size={76.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState,title="max"
 	SetVariable max_AsyncAD_06,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable max_AsyncAD_06,userdata(ResizeControlsInfo)= A"!!,GU!!#BuJ,hp'!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable max_AsyncAD_06,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable max_AsyncAD_06,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable max_AsyncAD_06,value= _NUM:0
+	SetVariable max_AsyncAD_06,userdata(ControlArray)=  "max_AsyncAD"
+	SetVariable max_AsyncAD_06,userdata(ControlArrayIndex)=  "6",value= _NUM:0
 	CheckBox check_AsyncAlarm_06,pos={48.00,378.00},size={48.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="Alarm"
 	CheckBox check_AsyncAlarm_06,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	CheckBox check_AsyncAlarm_06,userdata(ResizeControlsInfo)= A"!!,DW!!#C\"!!#>J!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox check_AsyncAlarm_06,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox check_AsyncAlarm_06,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox check_AsyncAlarm_06,value= 0
+	CheckBox check_AsyncAlarm_06,userdata(ControlArray)=  "check_AsyncAlarm"
+	CheckBox check_AsyncAlarm_06,userdata(ControlArrayIndex)=  "6",value= 0
 	SetVariable min_AsyncAD_07,pos={105.00,426.00},size={75.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState,title="min"
 	SetVariable min_AsyncAD_07,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable min_AsyncAD_07,userdata(ResizeControlsInfo)= A"!!,F?!!#C:J,hp%!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable min_AsyncAD_07,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable min_AsyncAD_07,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable min_AsyncAD_07,value= _NUM:0
+	SetVariable min_AsyncAD_07,userdata(ControlArray)=  "min_AsyncAD"
+	SetVariable min_AsyncAD_07,userdata(ControlArrayIndex)=  "7",value= _NUM:0
 	SetVariable max_AsyncAD_07,pos={191.00,426.00},size={76.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState,title="max"
 	SetVariable max_AsyncAD_07,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	SetVariable max_AsyncAD_07,userdata(ResizeControlsInfo)= A"!!,GU!!#C:J,hp'!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable max_AsyncAD_07,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable max_AsyncAD_07,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable max_AsyncAD_07,value= _NUM:0
+	SetVariable max_AsyncAD_07,userdata(ControlArray)=  "max_AsyncAD"
+	SetVariable max_AsyncAD_07,userdata(ControlArrayIndex)=  "7",value= _NUM:0
 	CheckBox check_AsyncAlarm_07,pos={48.00,429.00},size={48.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="Alarm"
 	CheckBox check_AsyncAlarm_07,userdata(tabnum)=  "4",userdata(tabcontrol)=  "ADC"
 	CheckBox check_AsyncAlarm_07,userdata(ResizeControlsInfo)= A"!!,DW!!#C;J,hnu!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox check_AsyncAlarm_07,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox check_AsyncAlarm_07,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox check_AsyncAlarm_07,value= 0
+	CheckBox check_AsyncAlarm_07,userdata(ControlArray)=  "check_AsyncAlarm"
+	CheckBox check_AsyncAlarm_07,userdata(ControlArrayIndex)=  "7",value= 0
 	TitleBox Title_TTL_IndexStartEnd,pos={255.00,48.00},size={94.00,15.00},disable=1,title="\\JCIndexing End Set"
 	TitleBox Title_TTL_IndexStartEnd,userdata(tabnum)=  "3"
 	TitleBox Title_TTL_IndexStartEnd,userdata(tabcontrol)=  "ADC"
@@ -1771,7 +2093,7 @@ Window DA_Ephys() : Panel
 	CheckBox check_Settings_ScalingZero,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox check_Settings_ScalingZero,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
 	CheckBox check_Settings_ScalingZero,value= 0
-	CheckBox check_Settings_SetOption_04,pos={215.00,349.00},size={115.00,15.00},disable=3,proc=DAP_CheckProc_UpdateGuiState,title="Turn off headstage"
+	CheckBox check_Settings_SetOption_04,pos={215.00,349.00},size={116.00,15.00},disable=3,proc=DAP_CheckProc_UpdateGuiState,title="Turn off headstage"
 	CheckBox check_Settings_SetOption_04,help={"Turns off AD associated with DA via Channel and Amplifier Assignments"}
 	CheckBox check_Settings_SetOption_04,userdata(tabnum)=  "5"
 	CheckBox check_Settings_SetOption_04,userdata(tabcontrol)=  "ADC"
@@ -1821,8 +2143,9 @@ Window DA_Ephys() : Panel
 	PopupMenu popup_MoreSettings_Devices,userdata(ResizeControlsInfo)= A"!!,CL!!#?K!!#A3!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu popup_MoreSettings_Devices,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu popup_MoreSettings_Devices,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu popup_MoreSettings_Devices,userdata(Config_RestorePriority)=  "10"
 	PopupMenu popup_MoreSettings_Devices,mode=1,popvalue="- none -",value= #"DAP_GetDACDeviceList()"
-	SetVariable setvar_DataAcq_TerminationDelay,pos={288.00,675.00},size={175.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState,title="Termination delay (ms)"
+	SetVariable setvar_DataAcq_TerminationDelay,pos={287.00,675.00},size={176.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState,title="Termination delay (ms)"
 	SetVariable setvar_DataAcq_TerminationDelay,help={"Global set(s) termination delay. Continues recording after set sweep is complete. Useful when recorded phenomena continues after termination of final set epoch."}
 	SetVariable setvar_DataAcq_TerminationDelay,userdata(tabnum)=  "0"
 	SetVariable setvar_DataAcq_TerminationDelay,userdata(tabcontrol)=  "ADC"
@@ -1844,6 +2167,8 @@ Window DA_Ephys() : Panel
 	Button button_SettingsPlus_LockDevice,userdata(ResizeControlsInfo)= A"!!,G[!!#?K!!#?c!!#>Fz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	Button button_SettingsPlus_LockDevice,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	Button button_SettingsPlus_LockDevice,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	Button button_SettingsPlus_LockDevice,userdata(Config_RestorePriority)=  "20"
+	Button button_SettingsPlus_LockDevice,userdata(Config_PushButtonOnRestore)=  "1"
 	Button button_SettingsPlus_unLockDevic,pos={369.00,69.00},size={84.00,45.00},disable=2,proc=DAP_ButProc_Hrdwr_UnlckDev,title="Unlock device\r selection"
 	Button button_SettingsPlus_unLockDevic,userdata(tabnum)=  "6"
 	Button button_SettingsPlus_unLockDevic,userdata(tabcontrol)=  "ADC"
@@ -1911,7 +2236,8 @@ Window DA_Ephys() : Panel
 	CheckBox Check_DataAcq1_IndexingLocked,userdata(ResizeControlsInfo)= A"!!,Gb!!#DBJ,ho8!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_DataAcq1_IndexingLocked,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	CheckBox Check_DataAcq1_IndexingLocked,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
-	CheckBox Check_DataAcq1_IndexingLocked,value= 0
+	CheckBox Check_DataAcq1_IndexingLocked,userdata(Config_DontRestore)=  "1"
+	CheckBox Check_DataAcq1_IndexingLocked,userdata(Config_DontSave)=  "1",value= 0
 	SetVariable SetVar_DataAcq_ListRepeats,pos={173.00,689.00},size={109.00,18.00},bodyWidth=35,disable=1,proc=DAP_SetVarProc_TotSweepCount,title="Repeat List(s)"
 	SetVariable SetVar_DataAcq_ListRepeats,help={"This number is set automatically at based on the number of 1d waves contained in the largest set on active DA/TTL channels"}
 	SetVariable SetVar_DataAcq_ListRepeats,userdata(tabnum)=  "0"
@@ -1948,6 +2274,7 @@ Window DA_Ephys() : Panel
 	SetVariable SetVar_DataAcq_TPAmplitudeIC,userdata(ResizeControlsInfo)= A"!!,I$J,hs`J,hof!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable SetVar_DataAcq_TPAmplitudeIC,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable SetVar_DataAcq_TPAmplitudeIC,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable SetVar_DataAcq_TPAmplitudeIC,userdata(Config_GroupPath)=  "Test Pulse"
 	SetVariable SetVar_DataAcq_TPAmplitudeIC,value= _NUM:-50
 	SetVariable SetVar_Hardware_VC_DA_Unit,pos={165.00,411.00},size={30.00,18.00},proc=DAP_SetVarProc_CAA
 	SetVariable SetVar_Hardware_VC_DA_Unit,userdata(tabnum)=  "6"
@@ -1955,6 +2282,8 @@ Window DA_Ephys() : Panel
 	SetVariable SetVar_Hardware_VC_DA_Unit,userdata(ResizeControlsInfo)= A"!!,G5!!#C3J,hn)!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable SetVar_Hardware_VC_DA_Unit,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable SetVar_Hardware_VC_DA_Unit,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable SetVar_Hardware_VC_DA_Unit,userdata(Config_DontRestore)=  "1"
+	SetVariable SetVar_Hardware_VC_DA_Unit,userdata(Config_DontSave)=  "1"
 	SetVariable SetVar_Hardware_VC_DA_Unit,value= _STR:"mV"
 	SetVariable SetVar_Hardware_IC_DA_Unit,pos={342.00,414.00},size={30.00,18.00},proc=DAP_SetVarProc_CAA
 	SetVariable SetVar_Hardware_IC_DA_Unit,userdata(tabnum)=  "6"
@@ -1962,6 +2291,8 @@ Window DA_Ephys() : Panel
 	SetVariable SetVar_Hardware_IC_DA_Unit,userdata(ResizeControlsInfo)= A"!!,Hg!!#C4!!#=S!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable SetVar_Hardware_IC_DA_Unit,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable SetVar_Hardware_IC_DA_Unit,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable SetVar_Hardware_IC_DA_Unit,userdata(Config_DontRestore)=  "1"
+	SetVariable SetVar_Hardware_IC_DA_Unit,userdata(Config_DontSave)=  "1"
 	SetVariable SetVar_Hardware_IC_DA_Unit,value= _STR:"pA"
 	SetVariable SetVar_Hardware_VC_AD_Unit,pos={186.00,438.00},size={30.00,18.00},proc=DAP_SetVarProc_CAA
 	SetVariable SetVar_Hardware_VC_AD_Unit,userdata(tabnum)=  "6"
@@ -1969,6 +2300,8 @@ Window DA_Ephys() : Panel
 	SetVariable SetVar_Hardware_VC_AD_Unit,userdata(ResizeControlsInfo)= A"!!,GJ!!#C@!!#=S!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable SetVar_Hardware_VC_AD_Unit,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable SetVar_Hardware_VC_AD_Unit,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable SetVar_Hardware_VC_AD_Unit,userdata(Config_DontRestore)=  "1"
+	SetVariable SetVar_Hardware_VC_AD_Unit,userdata(Config_DontSave)=  "1"
 	SetVariable SetVar_Hardware_VC_AD_Unit,value= _STR:"pA"
 	SetVariable SetVar_Hardware_IC_AD_Unit,pos={366.00,438.00},size={30.00,18.00},proc=DAP_SetVarProc_CAA
 	SetVariable SetVar_Hardware_IC_AD_Unit,userdata(tabnum)=  "6"
@@ -1976,6 +2309,8 @@ Window DA_Ephys() : Panel
 	SetVariable SetVar_Hardware_IC_AD_Unit,userdata(ResizeControlsInfo)= A"!!,HrJ,hsk!!#=S!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable SetVar_Hardware_IC_AD_Unit,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable SetVar_Hardware_IC_AD_Unit,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable SetVar_Hardware_IC_AD_Unit,userdata(Config_DontRestore)=  "1"
+	SetVariable SetVar_Hardware_IC_AD_Unit,userdata(Config_DontSave)=  "1"
 	SetVariable SetVar_Hardware_IC_AD_Unit,value= _STR:"mV"
 	TitleBox Title_Hardware_VC_gain,pos={105.00,393.00},size={23.00,15.00},title="gain"
 	TitleBox Title_Hardware_VC_gain,userdata(tabnum)=  "6"
@@ -2010,6 +2345,8 @@ Window DA_Ephys() : Panel
 	SetVariable Unit_DA_00,userdata(ResizeControlsInfo)= A"!!,F7!!#?O!!#=S!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_DA_00,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable Unit_DA_00,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable Unit_DA_00,userdata(ControlArray)=  "Unit_DA"
+	SetVariable Unit_DA_00,userdata(ControlArrayIndex)=  "0"
 	SetVariable Unit_DA_00,limits={0,inf,1},value= _STR:""
 	TitleBox Title_DA_Unit,pos={105.00,48.00},size={24.00,15.00},disable=1,title="Unit"
 	TitleBox Title_DA_Unit,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
@@ -2022,138 +2359,184 @@ Window DA_Ephys() : Panel
 	SetVariable Unit_DA_01,userdata(ResizeControlsInfo)= A"!!,F7!!#@V!!#=S!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_DA_01,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable Unit_DA_01,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable Unit_DA_01,userdata(ControlArray)=  "Unit_DA"
+	SetVariable Unit_DA_01,userdata(ControlArrayIndex)=  "1"
 	SetVariable Unit_DA_01,limits={0,inf,1},value= _STR:""
 	SetVariable Unit_DA_02,pos={105.00,165.00},size={30.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Unit_DA_02,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Unit_DA_02,userdata(ResizeControlsInfo)= A"!!,F7!!#A6!!#=S!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_DA_02,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable Unit_DA_02,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable Unit_DA_02,userdata(ControlArray)=  "Unit_DA"
+	SetVariable Unit_DA_02,userdata(ControlArrayIndex)=  "2"
 	SetVariable Unit_DA_02,limits={0,inf,1},value= _STR:""
 	SetVariable Unit_DA_03,pos={105.00,213.00},size={30.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Unit_DA_03,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Unit_DA_03,userdata(ResizeControlsInfo)= A"!!,F7!!#Ae!!#=S!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_DA_03,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable Unit_DA_03,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable Unit_DA_03,userdata(ControlArray)=  "Unit_DA"
+	SetVariable Unit_DA_03,userdata(ControlArrayIndex)=  "3"
 	SetVariable Unit_DA_03,limits={0,inf,1},value= _STR:""
 	SetVariable Unit_DA_04,pos={105.00,258.00},size={30.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Unit_DA_04,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Unit_DA_04,userdata(ResizeControlsInfo)= A"!!,F7!!#B<!!#=S!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_DA_04,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable Unit_DA_04,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable Unit_DA_04,userdata(ControlArray)=  "Unit_DA"
+	SetVariable Unit_DA_04,userdata(ControlArrayIndex)=  "4"
 	SetVariable Unit_DA_04,limits={0,inf,1},value= _STR:""
 	SetVariable Unit_DA_05,pos={105.00,306.00},size={30.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Unit_DA_05,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Unit_DA_05,userdata(ResizeControlsInfo)= A"!!,F7!!#BSJ,hn)!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_DA_05,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable Unit_DA_05,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable Unit_DA_05,userdata(ControlArray)=  "Unit_DA"
+	SetVariable Unit_DA_05,userdata(ControlArrayIndex)=  "5"
 	SetVariable Unit_DA_05,limits={0,inf,1},value= _STR:""
 	SetVariable Unit_DA_06,pos={105.00,351.00},size={30.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Unit_DA_06,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Unit_DA_06,userdata(ResizeControlsInfo)= A"!!,F7!!#BjJ,hn)!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_DA_06,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable Unit_DA_06,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable Unit_DA_06,userdata(ControlArray)=  "Unit_DA"
+	SetVariable Unit_DA_06,userdata(ControlArrayIndex)=  "6"
 	SetVariable Unit_DA_06,limits={0,inf,1},value= _STR:""
 	SetVariable Unit_DA_07,pos={105.00,399.00},size={30.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Unit_DA_07,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Unit_DA_07,userdata(ResizeControlsInfo)= A"!!,F7!!#C-!!#=S!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_DA_07,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable Unit_DA_07,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable Unit_DA_07,userdata(ControlArray)=  "Unit_DA"
+	SetVariable Unit_DA_07,userdata(ControlArrayIndex)=  "7"
 	SetVariable Unit_DA_07,limits={0,inf,1},value= _STR:""
 	SetVariable Unit_AD_00,pos={108.00,75.00},size={39.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="V/"
 	SetVariable Unit_AD_00,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Unit_AD_00,userdata(ResizeControlsInfo)= A"!!,FA!!#?O!!#>.!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_AD_00,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable Unit_AD_00,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable Unit_AD_00,userdata(ControlArray)=  "Unit_AD"
+	SetVariable Unit_AD_00,userdata(ControlArrayIndex)=  "0"
 	SetVariable Unit_AD_00,limits={0,inf,1},value= _STR:""
 	SetVariable Unit_AD_01,pos={108.00,120.00},size={39.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="V/"
 	SetVariable Unit_AD_01,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Unit_AD_01,userdata(ResizeControlsInfo)= A"!!,FA!!#@V!!#>.!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_AD_01,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable Unit_AD_01,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable Unit_AD_01,userdata(ControlArray)=  "Unit_AD"
+	SetVariable Unit_AD_01,userdata(ControlArrayIndex)=  "1"
 	SetVariable Unit_AD_01,limits={0,inf,1},value= _STR:""
 	SetVariable Unit_AD_02,pos={108.00,165.00},size={39.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="V/"
 	SetVariable Unit_AD_02,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Unit_AD_02,userdata(ResizeControlsInfo)= A"!!,FA!!#A6!!#>.!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_AD_02,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable Unit_AD_02,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable Unit_AD_02,userdata(ControlArray)=  "Unit_AD"
+	SetVariable Unit_AD_02,userdata(ControlArrayIndex)=  "2"
 	SetVariable Unit_AD_02,limits={0,inf,1},value= _STR:""
 	SetVariable Unit_AD_03,pos={108.00,213.00},size={39.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="V/"
 	SetVariable Unit_AD_03,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Unit_AD_03,userdata(ResizeControlsInfo)= A"!!,FA!!#Ae!!#>.!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_AD_03,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable Unit_AD_03,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable Unit_AD_03,userdata(ControlArray)=  "Unit_AD"
+	SetVariable Unit_AD_03,userdata(ControlArrayIndex)=  "3"
 	SetVariable Unit_AD_03,limits={0,inf,1},value= _STR:""
 	SetVariable Unit_AD_04,pos={108.00,258.00},size={39.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="V/"
 	SetVariable Unit_AD_04,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Unit_AD_04,userdata(ResizeControlsInfo)= A"!!,FA!!#B<!!#>.!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_AD_04,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable Unit_AD_04,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable Unit_AD_04,userdata(ControlArray)=  "Unit_AD"
+	SetVariable Unit_AD_04,userdata(ControlArrayIndex)=  "4"
 	SetVariable Unit_AD_04,limits={0,inf,1},value= _STR:""
 	SetVariable Unit_AD_05,pos={108.00,306.00},size={39.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="V/"
 	SetVariable Unit_AD_05,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Unit_AD_05,userdata(ResizeControlsInfo)= A"!!,FA!!#BSJ,hnY!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_AD_05,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable Unit_AD_05,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable Unit_AD_05,userdata(ControlArray)=  "Unit_AD"
+	SetVariable Unit_AD_05,userdata(ControlArrayIndex)=  "5"
 	SetVariable Unit_AD_05,limits={0,inf,1},value= _STR:""
 	SetVariable Unit_AD_06,pos={108.00,351.00},size={39.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="V/"
 	SetVariable Unit_AD_06,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Unit_AD_06,userdata(ResizeControlsInfo)= A"!!,FA!!#BjJ,hnY!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_AD_06,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable Unit_AD_06,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable Unit_AD_06,userdata(ControlArray)=  "Unit_AD"
+	SetVariable Unit_AD_06,userdata(ControlArrayIndex)=  "6"
 	SetVariable Unit_AD_06,limits={0,inf,1},value= _STR:""
 	SetVariable Unit_AD_07,pos={108.00,399.00},size={39.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="V/"
 	SetVariable Unit_AD_07,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Unit_AD_07,userdata(ResizeControlsInfo)= A"!!,FA!!#C-!!#>.!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_AD_07,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable Unit_AD_07,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable Unit_AD_07,userdata(ControlArray)=  "Unit_AD"
+	SetVariable Unit_AD_07,userdata(ControlArrayIndex)=  "7"
 	SetVariable Unit_AD_07,limits={0,inf,1},value= _STR:""
 	SetVariable Unit_AD_08,pos={288.00,75.00},size={39.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="V/"
 	SetVariable Unit_AD_08,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Unit_AD_08,userdata(ResizeControlsInfo)= A"!!,HL!!#?O!!#>.!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_AD_08,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable Unit_AD_08,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable Unit_AD_08,userdata(ControlArray)=  "Unit_AD"
+	SetVariable Unit_AD_08,userdata(ControlArrayIndex)=  "8"
 	SetVariable Unit_AD_08,limits={0,inf,1},value= _STR:""
 	SetVariable Unit_AD_09,pos={288.00,120.00},size={39.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="V/"
 	SetVariable Unit_AD_09,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Unit_AD_09,userdata(ResizeControlsInfo)= A"!!,HL!!#@V!!#>.!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_AD_09,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable Unit_AD_09,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable Unit_AD_09,userdata(ControlArray)=  "Unit_AD"
+	SetVariable Unit_AD_09,userdata(ControlArrayIndex)=  "9"
 	SetVariable Unit_AD_09,limits={0,inf,1},value= _STR:""
 	SetVariable Unit_AD_10,pos={288.00,165.00},size={39.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="V/"
 	SetVariable Unit_AD_10,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Unit_AD_10,userdata(ResizeControlsInfo)= A"!!,HL!!#A6!!#>.!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_AD_10,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable Unit_AD_10,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable Unit_AD_10,userdata(ControlArray)=  "Unit_AD"
+	SetVariable Unit_AD_10,userdata(ControlArrayIndex)=  "10"
 	SetVariable Unit_AD_10,limits={0,inf,1},value= _STR:""
 	SetVariable Unit_AD_11,pos={288.00,213.00},size={39.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="V/"
 	SetVariable Unit_AD_11,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Unit_AD_11,userdata(ResizeControlsInfo)= A"!!,HL!!#Ae!!#>.!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_AD_11,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable Unit_AD_11,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable Unit_AD_11,userdata(ControlArray)=  "Unit_AD"
+	SetVariable Unit_AD_11,userdata(ControlArrayIndex)=  "11"
 	SetVariable Unit_AD_11,limits={0,inf,1},value= _STR:""
 	SetVariable Unit_AD_12,pos={288.00,258.00},size={39.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="V/"
 	SetVariable Unit_AD_12,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Unit_AD_12,userdata(ResizeControlsInfo)= A"!!,HL!!#B<!!#>.!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_AD_12,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable Unit_AD_12,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable Unit_AD_12,userdata(ControlArray)=  "Unit_AD"
+	SetVariable Unit_AD_12,userdata(ControlArrayIndex)=  "12"
 	SetVariable Unit_AD_12,limits={0,inf,1},value= _STR:""
 	SetVariable Unit_AD_13,pos={288.00,306.00},size={39.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="V/"
 	SetVariable Unit_AD_13,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Unit_AD_13,userdata(ResizeControlsInfo)= A"!!,HL!!#BSJ,hnY!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_AD_13,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable Unit_AD_13,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable Unit_AD_13,userdata(ControlArray)=  "Unit_AD"
+	SetVariable Unit_AD_13,userdata(ControlArrayIndex)=  "13"
 	SetVariable Unit_AD_13,limits={0,inf,1},value= _STR:""
 	SetVariable Unit_AD_14,pos={288.00,351.00},size={39.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="V/"
 	SetVariable Unit_AD_14,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Unit_AD_14,userdata(ResizeControlsInfo)= A"!!,HL!!#BjJ,hnY!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_AD_14,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable Unit_AD_14,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable Unit_AD_14,userdata(ControlArray)=  "Unit_AD"
+	SetVariable Unit_AD_14,userdata(ControlArrayIndex)=  "14"
 	SetVariable Unit_AD_14,limits={0,inf,1},value= _STR:""
 	SetVariable Unit_AD_15,pos={288.00,399.00},size={39.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState,title="V/"
 	SetVariable Unit_AD_15,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	SetVariable Unit_AD_15,userdata(ResizeControlsInfo)= A"!!,HL!!#C-!!#>.!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Unit_AD_15,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable Unit_AD_15,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable Unit_AD_15,userdata(ControlArray)=  "Unit_AD"
+	SetVariable Unit_AD_15,userdata(ControlArrayIndex)=  "15"
 	SetVariable Unit_AD_15,limits={0,inf,1},value= _STR:""
 	TitleBox Title_AD_Unit,pos={120.00,48.00},size={24.00,15.00},disable=1,title="Unit"
 	TitleBox Title_AD_Unit,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
@@ -2314,12 +2697,14 @@ Window DA_Ephys() : Panel
 	Button button_Hardware_Lead1600,userdata(ResizeControlsInfo)= A"!!,CL!!#AR!!#?Y!!#<`z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	Button button_Hardware_Lead1600,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	Button button_Hardware_Lead1600,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
-	PopupMenu popup_Hardware_AvailITC1600s,pos={0.00,240.00},size={201.00,19.00},bodyWidth=110,disable=3,title="Locked ITC1600s"
+	PopupMenu popup_Hardware_AvailITC1600s,pos={1.00,240.00},size={200.00,19.00},bodyWidth=110,disable=3,title="Locked ITC1600s"
 	PopupMenu popup_Hardware_AvailITC1600s,userdata(tabnum)=  "6"
 	PopupMenu popup_Hardware_AvailITC1600s,userdata(tabcontrol)=  "ADC"
 	PopupMenu popup_Hardware_AvailITC1600s,userdata(ResizeControlsInfo)= A"!!,CL!!#B*!!#@@!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu popup_Hardware_AvailITC1600s,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	PopupMenu popup_Hardware_AvailITC1600s,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	PopupMenu popup_Hardware_AvailITC1600s,userdata(Config_DontSave)=  "1"
+	PopupMenu popup_Hardware_AvailITC1600s,userdata(Config_DontRestore)=  "1"
 	PopupMenu popup_Hardware_AvailITC1600s,mode=1,popvalue="",value= #"DAP_ListOfITCDevices()"
 	Button button_Hardware_AddFollower,pos={141.00,240.00},size={78.00,21.00},disable=3,proc=DAP_ButtonProc_Follow,title="Follow"
 	Button button_Hardware_AddFollower,help={"For ITC1600 devices only. Sets locked ITC device as a follower. Select leader from other locked ITC1600s panel. This will disable data aquistion directly from this panel."}
@@ -2328,7 +2713,7 @@ Window DA_Ephys() : Panel
 	Button button_Hardware_AddFollower,userdata(ResizeControlsInfo)= A"!!,Fr!!#B*!!#?Y!!#<`z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	Button button_Hardware_AddFollower,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	Button button_Hardware_AddFollower,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
-	TitleBox title_hardware_1600inst,pos={27.00,174.00},size={231.00,15.00},disable=3,title="To yoke devices go to panel: ITC1600_Dev_0"
+	TitleBox title_hardware_1600inst,pos={27.00,174.00},size={229.00,15.00},disable=3,title="To yoke devices go to panel: ITC1600_Dev_0"
 	TitleBox title_hardware_1600inst,help={"If the device is designated to follow, the test pulse and data aquisition will be triggered from the lead panel."}
 	TitleBox title_hardware_1600inst,userdata(tabnum)=  "6"
 	TitleBox title_hardware_1600inst,userdata(tabcontrol)=  "ADC"
@@ -2347,10 +2732,12 @@ Window DA_Ephys() : Panel
 	SetVariable setvar_Hardware_Status,userdata(ResizeControlsInfo)= A"!!,G\"!!#De!!#AL!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable setvar_Hardware_Status,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable setvar_Hardware_Status,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
-	SetVariable setvar_Hardware_Status,frame=0,fStyle=1,fColor=(65280,0,0)
+	SetVariable setvar_Hardware_Status,userdata(Config_DontSave)=  "1"
+	SetVariable setvar_Hardware_Status,userdata(Config_DontRestore)=  "1",frame=0
+	SetVariable setvar_Hardware_Status,fStyle=1,fColor=(65280,0,0)
 	SetVariable setvar_Hardware_Status,valueBackColor=(60928,60928,60928)
 	SetVariable setvar_Hardware_Status,value= _STR:"Independent",noedit= 1
-	TitleBox title_hardware_Follow,pos={27.00,222.00},size={177.00,15.00},disable=3,title="Assign ITC1600 DACs as followers"
+	TitleBox title_hardware_Follow,pos={27.00,222.00},size={176.00,15.00},disable=3,title="Assign ITC1600 DACs as followers"
 	TitleBox title_hardware_Follow,help={"If the device is designated to follow, the test pulse and data aquisition will be triggered from the lead panel."}
 	TitleBox title_hardware_Follow,userdata(tabnum)=  "6"
 	TitleBox title_hardware_Follow,userdata(tabcontrol)=  "ADC"
@@ -2364,6 +2751,8 @@ Window DA_Ephys() : Panel
 	SetVariable setvar_Hardware_YokeList,userdata(ResizeControlsInfo)= A"!!,CL!!#BB!!#BP!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable setvar_Hardware_YokeList,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable setvar_Hardware_YokeList,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable setvar_Hardware_YokeList,userdata(Config_DontSave)=  "1"
+	SetVariable setvar_Hardware_YokeList,userdata(Config_DontRestore)=  "1"
 	SetVariable setvar_Hardware_YokeList,labelBack=(60928,60928,60928),frame=0
 	SetVariable setvar_Hardware_YokeList,value= _STR:"No Yoked Devices",noedit= 1
 	Button button_Hardware_RemoveYoke,pos={333.00,240.00},size={78.00,21.00},disable=3,proc=DAP_ButtonProc_YokeRelease,title="Release"
@@ -2378,8 +2767,10 @@ Window DA_Ephys() : Panel
 	PopupMenu popup_Hardware_YokedDACs,userdata(ResizeControlsInfo)= A"!!,Go!!#B*!!#@@!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu popup_Hardware_YokedDACs,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	PopupMenu popup_Hardware_YokedDACs,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	PopupMenu popup_Hardware_YokedDACs,userdata(Config_DontSave)=  "1"
+	PopupMenu popup_Hardware_YokedDACs,userdata(Config_DontRestore)=  "1"
 	PopupMenu popup_Hardware_YokedDACs,mode=0,value= #"DAP_GUIListOfYokedDevices()"
-	TitleBox title_hardware_Release,pos={225.00,222.00},size={162.00,15.00},disable=3,title="Release follower ITC1600 DACs"
+	TitleBox title_hardware_Release,pos={225.00,222.00},size={161.00,15.00},disable=3,title="Release follower ITC1600 DACs"
 	TitleBox title_hardware_Release,help={"If the device is designated to follow, the test pulse and data aquisition will be triggered from the lead panel."}
 	TitleBox title_hardware_Release,userdata(tabnum)=  "6"
 	TitleBox title_hardware_Release,userdata(tabcontrol)=  "ADC"
@@ -2393,8 +2784,9 @@ Window DA_Ephys() : Panel
 	TabControl tab_DataAcq_Amp,userdata(ResizeControlsInfo)= A"!!,Cd!!#A#!!#C9J,hq*z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	TabControl tab_DataAcq_Amp,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	TabControl tab_DataAcq_Amp,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	TabControl tab_DataAcq_Amp,userdata(Config_RestorePriority)=  "40"
 	TabControl tab_DataAcq_Amp,labelBack=(60928,60928,60928),fSize=10
-	TabControl tab_DataAcq_Amp,tabLabel(0)="\f01\Z11V-Clamp",tabLabel(1)="I-Clamp"
+	TabControl tab_DataAcq_Amp,tabLabel(0)="V-Clamp",tabLabel(1)="\f01\Z11I-Clamp"
 	TabControl tab_DataAcq_Amp,tabLabel(2)="I = 0",value= 0
 	TitleBox Title_DataAcq_Hold_IC,pos={96.00,186.00},size={69.00,15.00},disable=1,title="Holding (pA)"
 	TitleBox Title_DataAcq_Hold_IC,userdata(tabnum)=  "1"
@@ -2416,6 +2808,7 @@ Window DA_Ephys() : Panel
 	SetVariable setvar_DataAcq_Hold_IC,userdata(ResizeControlsInfo)= A"!!,G7!!#AH!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable setvar_DataAcq_Hold_IC,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable setvar_DataAcq_Hold_IC,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable setvar_DataAcq_Hold_IC,userdata(Config_RestorePriority)=  "40"
 	SetVariable setvar_DataAcq_Hold_IC,value= _NUM:0
 	SetVariable setvar_DataAcq_BB,pos={160.00,207.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVarProc_AmpCntrls
 	SetVariable setvar_DataAcq_BB,userdata(tabnum)=  "1"
@@ -2423,6 +2816,7 @@ Window DA_Ephys() : Panel
 	SetVariable setvar_DataAcq_BB,userdata(ResizeControlsInfo)= A"!!,G7!!#A_!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable setvar_DataAcq_BB,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable setvar_DataAcq_BB,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable setvar_DataAcq_BB,userdata(Config_RestorePriority)=  "40"
 	SetVariable setvar_DataAcq_BB,limits={0,inf,1},value= _NUM:0
 	SetVariable setvar_DataAcq_CN,pos={160.00,231.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVarProc_AmpCntrls
 	SetVariable setvar_DataAcq_CN,userdata(tabnum)=  "1"
@@ -2430,6 +2824,7 @@ Window DA_Ephys() : Panel
 	SetVariable setvar_DataAcq_CN,userdata(ResizeControlsInfo)= A"!!,G7!!#B!!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable setvar_DataAcq_CN,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable setvar_DataAcq_CN,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable setvar_DataAcq_CN,userdata(Config_RestorePriority)=  "40"
 	SetVariable setvar_DataAcq_CN,limits={-8,16,1},value= _NUM:0
 	CheckBox check_DatAcq_HoldEnable,pos={222.00,186.00},size={14.00,14.00},disable=1,proc=DAP_CheckProc_AmpCntrls,title=""
 	CheckBox check_DatAcq_HoldEnable,userdata(tabnum)=  "1"
@@ -2437,6 +2832,7 @@ Window DA_Ephys() : Panel
 	CheckBox check_DatAcq_HoldEnable,userdata(ResizeControlsInfo)= A"!!,Go!!#AJ!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox check_DatAcq_HoldEnable,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	CheckBox check_DatAcq_HoldEnable,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	CheckBox check_DatAcq_HoldEnable,userdata(Config_RestorePriority)=  "40"
 	CheckBox check_DatAcq_HoldEnable,value= 0
 	CheckBox check_DatAcq_BBEnable,pos={222.00,210.00},size={14.00,14.00},disable=1,proc=DAP_CheckProc_AmpCntrls,title=""
 	CheckBox check_DatAcq_BBEnable,userdata(tabnum)=  "1"
@@ -2444,14 +2840,14 @@ Window DA_Ephys() : Panel
 	CheckBox check_DatAcq_BBEnable,userdata(ResizeControlsInfo)= A"!!,Go!!#Aa!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox check_DatAcq_BBEnable,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	CheckBox check_DatAcq_BBEnable,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
-	CheckBox check_DatAcq_BBEnable,value= 0
+	CheckBox check_DatAcq_BBEnable,userdata(Config_RestorePriority)=  "40",value= 0
 	CheckBox check_DatAcq_CNEnable,pos={222.00,231.00},size={14.00,14.00},disable=1,proc=DAP_CheckProc_AmpCntrls,title=""
 	CheckBox check_DatAcq_CNEnable,userdata(tabnum)=  "1"
 	CheckBox check_DatAcq_CNEnable,userdata(tabcontrol)=  "tab_DataAcq_Amp"
 	CheckBox check_DatAcq_CNEnable,userdata(ResizeControlsInfo)= A"!!,Go!!#B#!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox check_DatAcq_CNEnable,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	CheckBox check_DatAcq_CNEnable,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
-	CheckBox check_DatAcq_CNEnable,value= 0
+	CheckBox check_DatAcq_CNEnable,userdata(Config_RestorePriority)=  "40",value= 0
 	TitleBox Title_DataAcq_CN,pos={42.00,231.00},size={122.00,15.00},disable=1,title="Cap Neutralization (pF)"
 	TitleBox Title_DataAcq_CN,userdata(tabnum)=  "1"
 	TitleBox Title_DataAcq_CN,userdata(tabcontrol)=  "tab_DataAcq_Amp"
@@ -2473,6 +2869,7 @@ Window DA_Ephys() : Panel
 	SetVariable setvar_DataAcq_AutoBiasV,userdata(ResizeControlsInfo)= A"!!,HJJ,hr?!!#@.!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable setvar_DataAcq_AutoBiasV,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable setvar_DataAcq_AutoBiasV,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable setvar_DataAcq_AutoBiasV,userdata(Config_RestorePriority)=  "40"
 	SetVariable setvar_DataAcq_AutoBiasV,limits={-99,99,1},value= _NUM:-70
 	CheckBox check_DataAcq_AutoBias,pos={321.00,198.00},size={66.00,15.00},disable=1,proc=DAP_CheckProc_AmpCntrls,title="Auto Bias"
 	CheckBox check_DataAcq_AutoBias,help={"Just prior to a sweep the Vm is checked and the bias current is adjusted to maintain desired Vm."}
@@ -2481,13 +2878,15 @@ Window DA_Ephys() : Panel
 	CheckBox check_DataAcq_AutoBias,userdata(ResizeControlsInfo)= A"!!,H[J,hr+!!#?;!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox check_DataAcq_AutoBias,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	CheckBox check_DataAcq_AutoBias,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	CheckBox check_DataAcq_AutoBias,userdata(Config_RestorePriority)=  "40"
 	CheckBox check_DataAcq_AutoBias,value= 0,side= 1
-	SetVariable setvar_DataAcq_IbiasMax,pos={289.00,240.00},size={137.00,20.00},bodyWidth=50,disable=1,proc=DAP_SetVarProc_AmpCntrls,title="max I \\Bbias\\M (pA) ±"
+	SetVariable setvar_DataAcq_IbiasMax,pos={290.00,240.00},size={136.00,20.00},bodyWidth=50,disable=1,proc=DAP_SetVarProc_AmpCntrls,title="max I \\Bbias\\M (pA) ±"
 	SetVariable setvar_DataAcq_IbiasMax,userdata(tabcontrol)=  "tab_DataAcq_Amp"
 	SetVariable setvar_DataAcq_IbiasMax,userdata(tabnum)=  "1"
 	SetVariable setvar_DataAcq_IbiasMax,userdata(ResizeControlsInfo)= A"!!,HP!!#B+!!#@l!!#<Xz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable setvar_DataAcq_IbiasMax,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable setvar_DataAcq_IbiasMax,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable setvar_DataAcq_IbiasMax,userdata(Config_RestorePriority)=  "40"
 	SetVariable setvar_DataAcq_IbiasMax,limits={1,1500,1},value= _NUM:200
 	SetVariable setvar_DataAcq_AutoBiasVrange,pos={385.00,216.00},size={62.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVarProc_AmpCntrls,title="±"
 	SetVariable setvar_DataAcq_AutoBiasVrange,userdata(tabcontrol)=  "tab_DataAcq_Amp"
@@ -2495,6 +2894,7 @@ Window DA_Ephys() : Panel
 	SetVariable setvar_DataAcq_AutoBiasVrange,userdata(ResizeControlsInfo)= A"!!,I*!!#Ai!!#?1!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable setvar_DataAcq_AutoBiasVrange,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable setvar_DataAcq_AutoBiasVrange,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable setvar_DataAcq_AutoBiasVrange,userdata(Config_RestorePriority)=  "40"
 	SetVariable setvar_DataAcq_AutoBiasVrange,limits={0,inf,1},value= _NUM:0.5
 	TitleBox Title_DataAcq_Hold_VC,pos={0.00,207.00},size={48.00,18.00},disable=1
 	TitleBox Title_DataAcq_Hold_VC,userdata(tabnum)=  "0"
@@ -2509,6 +2909,7 @@ Window DA_Ephys() : Panel
 	SetVariable setvar_DataAcq_Hold_VC,userdata(ResizeControlsInfo)= A"!!,D7!!#A<!!#?s!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable setvar_DataAcq_Hold_VC,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable setvar_DataAcq_Hold_VC,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable setvar_DataAcq_Hold_VC,userdata(Config_RestorePriority)=  "40"
 	SetVariable setvar_DataAcq_Hold_VC,value= _NUM:0
 	TitleBox Title_DataAcq_PipOffset_VC,pos={243.00,174.00},size={101.00,15.00},disable=1,title="Pipette Offset (mV)"
 	TitleBox Title_DataAcq_PipOffset_VC,userdata(tabnum)=  "0"
@@ -2523,6 +2924,7 @@ Window DA_Ephys() : Panel
 	SetVariable setvar_DataAcq_PipetteOffset_VC,userdata(ResizeControlsInfo)= A"!!,Hi!!#A>!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable setvar_DataAcq_PipetteOffset_VC,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable setvar_DataAcq_PipetteOffset_VC,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable setvar_DataAcq_PipetteOffset_VC,userdata(Config_RestorePriority)=  "40"
 	SetVariable setvar_DataAcq_PipetteOffset_VC,value= _NUM:0
 	Button button_DataAcq_AutoPipOffset_VC,pos={399.00,174.00},size={39.00,18.00},disable=1,proc=DAP_ButtonProc_AmpCntrls,title="Auto"
 	Button button_DataAcq_AutoPipOffset_VC,help={"Automatically calculate the pipette offset"}
@@ -2531,18 +2933,21 @@ Window DA_Ephys() : Panel
 	Button button_DataAcq_AutoPipOffset_VC,userdata(ResizeControlsInfo)= A"!!,I.J,hqi!!#>.!!#<Xz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	Button button_DataAcq_AutoPipOffset_VC,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	Button button_DataAcq_AutoPipOffset_VC,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	Button button_DataAcq_AutoPipOffset_VC,userdata(Config_RestorePriority)=  "41"
 	GroupBox group_pipette_offset_VC,pos={237.00,171.00},size={210.00,27.00},disable=1
 	GroupBox group_pipette_offset_VC,userdata(tabnum)=  "0"
 	GroupBox group_pipette_offset_VC,userdata(tabcontrol)=  "tab_DataAcq_Amp"
 	GroupBox group_pipette_offset_VC,userdata(ResizeControlsInfo)= A"!!,H)!!#A:!!#Aa!!#=Cz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	GroupBox group_pipette_offset_VC,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	GroupBox group_pipette_offset_VC,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	GroupBox group_pipette_offset_VC,userdata(Config_RestorePriority)=  "40"
 	GroupBox group_pipette_offset_IC,pos={243.00,171.00},size={210.00,27.00},disable=1
 	GroupBox group_pipette_offset_IC,userdata(tabnum)=  "1"
 	GroupBox group_pipette_offset_IC,userdata(tabcontrol)=  "tab_DataAcq_Amp"
 	GroupBox group_pipette_offset_IC,userdata(ResizeControlsInfo)= A"!!,H/!!#A:!!#Aa!!#=Cz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	GroupBox group_pipette_offset_IC,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	GroupBox group_pipette_offset_IC,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	GroupBox group_pipette_offset_IC,userdata(Config_RestorePriority)=  "40"
 	Button button_DataAcq_AutoPipOffset_IC,pos={405.00,174.00},size={39.00,18.00},disable=1,proc=DAP_ButtonProc_AmpCntrls,title="Auto"
 	Button button_DataAcq_AutoPipOffset_IC,help={"Automatically calculate the pipette offset"}
 	Button button_DataAcq_AutoPipOffset_IC,userdata(tabnum)=  "1"
@@ -2550,6 +2955,7 @@ Window DA_Ephys() : Panel
 	Button button_DataAcq_AutoPipOffset_IC,userdata(ResizeControlsInfo)= A"!!,I1J,hqi!!#>.!!#<Xz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	Button button_DataAcq_AutoPipOffset_IC,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	Button button_DataAcq_AutoPipOffset_IC,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	Button button_DataAcq_AutoPipOffset_IC,userdata(Config_RestorePriority)=  "41"
 	TitleBox Title_DataAcq_PipOffset_IC,pos={249.00,174.00},size={101.00,15.00},disable=1,title="Pipette Offset (mV)"
 	TitleBox Title_DataAcq_PipOffset_IC,userdata(tabnum)=  "1"
 	TitleBox Title_DataAcq_PipOffset_IC,userdata(tabcontrol)=  "tab_DataAcq_Amp"
@@ -2563,13 +2969,15 @@ Window DA_Ephys() : Panel
 	SetVariable setvar_DataAcq_PipetteOffset_IC,userdata(ResizeControlsInfo)= A"!!,Hl!!#A>!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable setvar_DataAcq_PipetteOffset_IC,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable setvar_DataAcq_PipetteOffset_IC,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable setvar_DataAcq_PipetteOffset_IC,userdata(Config_RestorePriority)=  "40"
 	SetVariable setvar_DataAcq_PipetteOffset_IC,value= _NUM:0
-	CheckBox check_DatAcq_HoldEnableVC,pos={137.00,173.00},size={51.00,15.00},disable=1,proc=DAP_CheckProc_AmpCntrls,title="Enable"
+	CheckBox check_DatAcq_HoldEnableVC,pos={137.00,172.00},size={51.00,15.00},disable=1,proc=DAP_CheckProc_AmpCntrls,title="Enable"
 	CheckBox check_DatAcq_HoldEnableVC,userdata(tabnum)=  "0"
 	CheckBox check_DatAcq_HoldEnableVC,userdata(tabcontrol)=  "tab_DataAcq_Amp"
 	CheckBox check_DatAcq_HoldEnableVC,userdata(ResizeControlsInfo)= A"!!,Fs!!#A=!!#>V!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox check_DatAcq_HoldEnableVC,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	CheckBox check_DatAcq_HoldEnableVC,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	CheckBox check_DatAcq_HoldEnableVC,userdata(Config_RestorePriority)=  "40"
 	CheckBox check_DatAcq_HoldEnableVC,value= 0
 	SetVariable setvar_DataAcq_WCR,pos={112.00,219.00},size={74.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVarProc_AmpCntrls,title="MΩ"
 	SetVariable setvar_DataAcq_WCR,userdata(tabnum)=  "0"
@@ -2577,6 +2985,7 @@ Window DA_Ephys() : Panel
 	SetVariable setvar_DataAcq_WCR,userdata(ResizeControlsInfo)= A"!!,FE!!#Aj!!#?M!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable setvar_DataAcq_WCR,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable setvar_DataAcq_WCR,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable setvar_DataAcq_WCR,userdata(Config_RestorePriority)=  "40"
 	SetVariable setvar_DataAcq_WCR,value= _NUM:0
 	CheckBox check_DatAcq_WholeCellEnable,pos={63.00,198.00},size={14.00,14.00},disable=1,proc=DAP_CheckProc_AmpCntrls,title=""
 	CheckBox check_DatAcq_WholeCellEnable,userdata(tabnum)=  "0"
@@ -2584,6 +2993,7 @@ Window DA_Ephys() : Panel
 	CheckBox check_DatAcq_WholeCellEnable,userdata(ResizeControlsInfo)= A"!!,E6!!#AV!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox check_DatAcq_WholeCellEnable,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	CheckBox check_DatAcq_WholeCellEnable,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	CheckBox check_DatAcq_WholeCellEnable,userdata(Config_RestorePriority)=  "40"
 	CheckBox check_DatAcq_WholeCellEnable,value= 0
 	SetVariable setvar_DataAcq_WCC,pos={41.00,219.00},size={67.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVarProc_AmpCntrls,title="pF"
 	SetVariable setvar_DataAcq_WCC,userdata(tabnum)=  "0"
@@ -2591,6 +3001,7 @@ Window DA_Ephys() : Panel
 	SetVariable setvar_DataAcq_WCC,userdata(ResizeControlsInfo)= A"!!,D;!!#Ak!!#??!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable setvar_DataAcq_WCC,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable setvar_DataAcq_WCC,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable setvar_DataAcq_WCC,userdata(Config_RestorePriority)=  "40"
 	SetVariable setvar_DataAcq_WCC,limits={1,inf,1},value= _NUM:0
 	Button button_DataAcq_WCAuto,pos={108.00,237.00},size={39.00,15.00},disable=1,proc=DAP_ButtonProc_AmpCntrls,title="Auto"
 	Button button_DataAcq_WCAuto,userdata(tabnum)=  "0"
@@ -2598,18 +3009,21 @@ Window DA_Ephys() : Panel
 	Button button_DataAcq_WCAuto,userdata(ResizeControlsInfo)= A"!!,F'!!#B)!!#>.!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	Button button_DataAcq_WCAuto,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	Button button_DataAcq_WCAuto,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	Button button_DataAcq_WCAuto,userdata(Config_RestorePriority)=  "41"
 	GroupBox group_DataAcq_RsCompensation,pos={198.00,198.00},size={183.00,60.00},disable=1,title="       Rs Compensation"
 	GroupBox group_DataAcq_RsCompensation,userdata(tabnum)=  "0"
 	GroupBox group_DataAcq_RsCompensation,userdata(tabcontrol)=  "tab_DataAcq_Amp"
 	GroupBox group_DataAcq_RsCompensation,userdata(ResizeControlsInfo)= A"!!,GX!!#AW!!#AH!!#?1z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	GroupBox group_DataAcq_RsCompensation,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	GroupBox group_DataAcq_RsCompensation,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	GroupBox group_DataAcq_RsCompensation,userdata(Config_RestorePriority)=  "40"
 	CheckBox check_DatAcq_RsCompEnable,pos={222.00,198.00},size={14.00,14.00},disable=1,proc=DAP_CheckProc_AmpCntrls,title=""
 	CheckBox check_DatAcq_RsCompEnable,userdata(tabnum)=  "0"
 	CheckBox check_DatAcq_RsCompEnable,userdata(tabcontrol)=  "tab_DataAcq_Amp"
 	CheckBox check_DatAcq_RsCompEnable,userdata(ResizeControlsInfo)= A"!!,Go!!#AV!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox check_DatAcq_RsCompEnable,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	CheckBox check_DatAcq_RsCompEnable,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	CheckBox check_DatAcq_RsCompEnable,userdata(Config_RestorePriority)=  "40"
 	CheckBox check_DatAcq_RsCompEnable,value= 0
 	SetVariable setvar_DataAcq_RsCorr,pos={200.00,216.00},size={121.00,18.00},bodyWidth=40,disable=1,proc=DAP_SetVarProc_AmpCntrls,title="Correction (%)"
 	SetVariable setvar_DataAcq_RsCorr,userdata(tabnum)=  "0"
@@ -2617,6 +3031,7 @@ Window DA_Ephys() : Panel
 	SetVariable setvar_DataAcq_RsCorr,userdata(ResizeControlsInfo)= A"!!,G^!!#Ai!!#@V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable setvar_DataAcq_RsCorr,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable setvar_DataAcq_RsCorr,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable setvar_DataAcq_RsCorr,userdata(Config_RestorePriority)=  "40"
 	SetVariable setvar_DataAcq_RsCorr,limits={0,100,1},value= _NUM:0
 	SetVariable setvar_DataAcq_RsPred,pos={202.00,237.00},size={119.00,18.00},bodyWidth=40,disable=1,proc=DAP_SetVarProc_AmpCntrls,title="Prediction (%)"
 	SetVariable setvar_DataAcq_RsPred,userdata(tabnum)=  "0"
@@ -2624,6 +3039,7 @@ Window DA_Ephys() : Panel
 	SetVariable setvar_DataAcq_RsPred,userdata(ResizeControlsInfo)= A"!!,G`!!#B(!!#@R!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable setvar_DataAcq_RsPred,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable setvar_DataAcq_RsPred,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	SetVariable setvar_DataAcq_RsPred,userdata(Config_RestorePriority)=  "40"
 	SetVariable setvar_DataAcq_RsPred,limits={0,100,1},value= _NUM:0
 	Button button_DataAcq_FastComp_VC,pos={393.00,213.00},size={54.00,18.00},disable=1,proc=DAP_ButtonProc_AmpCntrls,title="Cp Fast"
 	Button button_DataAcq_FastComp_VC,help={"Activates MCC auto fast capacitance compensation"}
@@ -2632,6 +3048,7 @@ Window DA_Ephys() : Panel
 	Button button_DataAcq_FastComp_VC,userdata(ResizeControlsInfo)= A"!!,I+!!#Ae!!#>j!!#<Xz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	Button button_DataAcq_FastComp_VC,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	Button button_DataAcq_FastComp_VC,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	Button button_DataAcq_FastComp_VC,userdata(Config_RestorePriority)=  "41"
 	Button button_Hardware_AutoGainAndUnit,pos={399.00,408.00},size={39.00,45.00},proc=DAP_ButtonProc_AutoFillGain,title="Auto\rFill"
 	Button button_Hardware_AutoGainAndUnit,help={"Queries the MultiClamp Commander for the gains of all connected amplifiers of this device."}
 	Button button_Hardware_AutoGainAndUnit,userdata(tabnum)=  "6"
@@ -2675,6 +3092,7 @@ Window DA_Ephys() : Panel
 	CheckBox check_Settings_SyncMiesToMCC,userdata(ResizeControlsInfo)= A"!!,Cl!!#D*^]6_=!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox check_Settings_SyncMiesToMCC,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	CheckBox check_Settings_SyncMiesToMCC,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	CheckBox check_Settings_SyncMiesToMCC,userdata(Config_RestorePriority)=  "25"
 	CheckBox check_Settings_SyncMiesToMCC,value= 0
 	CheckBox check_DataAcq_Amp_Chain,pos={330.00,228.00},size={47.00,15.00},disable=1,proc=DAP_CheckProc_AmpCntrls,title="Chain"
 	CheckBox check_DataAcq_Amp_Chain,userdata(tabnum)=  "0"
@@ -2682,6 +3100,7 @@ Window DA_Ephys() : Panel
 	CheckBox check_DataAcq_Amp_Chain,userdata(ResizeControlsInfo)= A"!!,H`J,hrK!!#>F!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox check_DataAcq_Amp_Chain,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	CheckBox check_DataAcq_Amp_Chain,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	CheckBox check_DataAcq_Amp_Chain,userdata(Config_RestorePriority)=  "40"
 	CheckBox check_DataAcq_Amp_Chain,value= 0
 	GroupBox group_Settings_MDSupport,pos={21.00,24.00},size={444.00,39.00},disable=1,title="Multiple Device Support"
 	GroupBox group_Settings_MDSupport,help={"Multiple device support includes yoking and multiple independent devices"}
@@ -2696,7 +3115,7 @@ Window DA_Ephys() : Panel
 	CheckBox check_Settings_MD,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	CheckBox check_Settings_MD,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
 	CheckBox check_Settings_MD,userdata(oldDisabledState)=  "2",value= 1
-	CheckBox Check_Settings_InsertTP,pos={168.00,84.00},size={61.00,15.00},disable=1,proc=DAP_CheckProc_InsertTP,title="Insert TP"
+	CheckBox Check_Settings_InsertTP,pos={168.00,84.00},size={62.00,15.00},disable=1,proc=DAP_CheckProc_InsertTP,title="Insert TP"
 	CheckBox Check_Settings_InsertTP,help={"Inserts a test pulse at the front of each sweep in a set."}
 	CheckBox Check_Settings_InsertTP,userdata(tabnum)=  "5"
 	CheckBox Check_Settings_InsertTP,userdata(tabcontrol)=  "ADC"
@@ -2704,7 +3123,7 @@ Window DA_Ephys() : Panel
 	CheckBox Check_Settings_InsertTP,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	CheckBox Check_Settings_InsertTP,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
 	CheckBox Check_Settings_InsertTP,value= 1
-	CheckBox Check_DataAcq_Get_Set_ITI,pos={141.00,705.00},size={46.00,30.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="Get\rset ITI"
+	CheckBox Check_DataAcq_Get_Set_ITI,pos={141.00,705.00},size={47.00,30.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="Get\rset ITI"
 	CheckBox Check_DataAcq_Get_Set_ITI,help={"When checked the stimulus set ITIs are used. The ITI is calculated as the maximum of all active stimulus set ITIs."}
 	CheckBox Check_DataAcq_Get_Set_ITI,userdata(tabnum)=  "0"
 	CheckBox Check_DataAcq_Get_Set_ITI,userdata(tabcontrol)=  "ADC"
@@ -2712,7 +3131,7 @@ Window DA_Ephys() : Panel
 	CheckBox Check_DataAcq_Get_Set_ITI,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	CheckBox Check_DataAcq_Get_Set_ITI,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
 	CheckBox Check_DataAcq_Get_Set_ITI,value= 1
-	SetVariable setvar_Settings_TPBuffer,pos={334.00,108.00},size={124.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState,title="TP Buffer size"
+	SetVariable setvar_Settings_TPBuffer,pos={333.00,108.00},size={125.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState,title="TP Buffer size"
 	SetVariable setvar_Settings_TPBuffer,userdata(tabnum)=  "5"
 	SetVariable setvar_Settings_TPBuffer,userdata(tabcontrol)=  "ADC"
 	SetVariable setvar_Settings_TPBuffer,userdata(ResizeControlsInfo)= A"!!,H]J,hpi!!#@^!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
@@ -2742,6 +3161,7 @@ Window DA_Ephys() : Panel
 	Button button_DataAcq_AutoBridgeBal_IC,userdata(ResizeControlsInfo)= A"!!,H+!!#A`!!#>.!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	Button button_DataAcq_AutoBridgeBal_IC,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	Button button_DataAcq_AutoBridgeBal_IC,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	Button button_DataAcq_AutoBridgeBal_IC,userdata(Config_RestorePriority)=  "41"
 	CheckBox Check_DataAcq_SendToAllAmp,pos={339.00,147.00},size={105.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="Send to all Amps"
 	CheckBox Check_DataAcq_SendToAllAmp,userdata(tabnum)=  "0"
 	CheckBox Check_DataAcq_SendToAllAmp,userdata(tabcontrol)=  "ADC"
@@ -2815,6 +3235,8 @@ Window DA_Ephys() : Panel
 	PopupMenu popup_Settings_Pressure_dev,userdata(ResizeControlsInfo)= A"!!,DC!!#C\\J,hr@!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu popup_Settings_Pressure_dev,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	PopupMenu popup_Settings_Pressure_dev,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	PopupMenu popup_Settings_Pressure_dev,userdata(Config_DontRestore)=  "1"
+	PopupMenu popup_Settings_Pressure_dev,userdata(Config_DontSave)=  "1"
 	PopupMenu popup_Settings_Pressure_dev,mode=1,popvalue="- none -",value= #"\"- none -\""
 	TitleBox Title_settings_Hardware_Pressur,pos={45.00,474.00},size={44.00,15.00},title="Pressure"
 	TitleBox Title_settings_Hardware_Pressur,userdata(tabnum)=  "6"
@@ -2829,6 +3251,8 @@ Window DA_Ephys() : Panel
 	PopupMenu Popup_Settings_Pressure_DA,userdata(ResizeControlsInfo)= A"!!,D[!!#Ch!!#>J!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu Popup_Settings_Pressure_DA,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	PopupMenu Popup_Settings_Pressure_DA,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	PopupMenu Popup_Settings_Pressure_DA,userdata(Config_DontRestore)=  "1"
+	PopupMenu Popup_Settings_Pressure_DA,userdata(Config_DontSave)=  "1"
 	PopupMenu Popup_Settings_Pressure_DA,mode=1,popvalue="0",value= #"\"0;1;2;3;4;5;6;7\""
 	PopupMenu Popup_Settings_Pressure_AD,pos={48.00,555.00},size={47.00,19.00},proc=DAP_PopMenuProc_CAA,title="AD"
 	PopupMenu Popup_Settings_Pressure_AD,userdata(tabnum)=  "6"
@@ -2836,6 +3260,8 @@ Window DA_Ephys() : Panel
 	PopupMenu Popup_Settings_Pressure_AD,userdata(ResizeControlsInfo)= A"!!,D[!!#Cn5QF,5!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu Popup_Settings_Pressure_AD,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	PopupMenu Popup_Settings_Pressure_AD,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	PopupMenu Popup_Settings_Pressure_AD,userdata(Config_DontRestore)=  "1"
+	PopupMenu Popup_Settings_Pressure_AD,userdata(Config_DontSave)=  "1"
 	PopupMenu Popup_Settings_Pressure_AD,mode=1,popvalue="0",value= #"\"0;1;2;3;4;5;6;7;8;9;10;11;12;13;14;15\""
 	SetVariable setvar_Settings_Pressure_DAgain,pos={111.00,528.00},size={48.00,18.00},proc=DAP_SetVarProc_CAA
 	SetVariable setvar_Settings_Pressure_DAgain,userdata(tabnum)=  "6"
@@ -2879,14 +3305,16 @@ Window DA_Ephys() : Panel
 	TitleBox Title_Hardware_Pressure_AD_Div,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	TitleBox Title_Hardware_Pressure_AD_Div,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
 	TitleBox Title_Hardware_Pressure_AD_Div,frame=0
-	PopupMenu Popup_Settings_Pressure_TTLA,pos={220.00,528.00},size={102.00,19.00},bodyWidth=70,proc=DAP_PopMenuProc_CAA,title="TTL A"
+	PopupMenu Popup_Settings_Pressure_TTLA,pos={218.00,528.00},size={104.00,19.00},bodyWidth=70,proc=DAP_PopMenuProc_CAA,title="TTL A"
 	PopupMenu Popup_Settings_Pressure_TTLA,help={"Select TTL channel for solenoid command"}
 	PopupMenu Popup_Settings_Pressure_TTLA,userdata(tabnum)=  "6"
 	PopupMenu Popup_Settings_Pressure_TTLA,userdata(tabcontrol)=  "ADC"
 	PopupMenu Popup_Settings_Pressure_TTLA,userdata(ResizeControlsInfo)= A"!!,H#!!#Cg^]6^J!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu Popup_Settings_Pressure_TTLA,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	PopupMenu Popup_Settings_Pressure_TTLA,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
-	PopupMenu Popup_Settings_Pressure_TTLA,mode=2,popvalue="0",value= #"\"\\\\M1(\\u200B- none -;0;1;2;3;4;5;6;7\""
+	PopupMenu Popup_Settings_Pressure_TTLA,userdata(Config_DontRestore)=  "1"
+	PopupMenu Popup_Settings_Pressure_TTLA,userdata(Config_DontSave)=  "1"
+	PopupMenu Popup_Settings_Pressure_TTLA,mode=2,popvalue="0",value= #"\"- none -;0;1;2;3;4;5;6;7\""
 	GroupBox group_Settings_Pressure,pos={21.00,750.00},size={444.00,99.00},disable=1,title="Pressure"
 	GroupBox group_Settings_Pressure,userdata(tabnum)=  "5"
 	GroupBox group_Settings_Pressure,userdata(tabcontrol)=  "ADC"
@@ -2933,7 +3361,7 @@ Window DA_Ephys() : Panel
 	SetVariable setvar_Settings_SealStartP,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	SetVariable setvar_Settings_SealStartP,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
 	SetVariable setvar_Settings_SealStartP,limits={-10,0,0.1},value= _NUM:-0.2
-	SetVariable setvar_Settings_SealMaxP,pos={319.00,798.00},size={137.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVarProc_CAA,title="Seal max P (psi)"
+	SetVariable setvar_Settings_SealMaxP,pos={320.00,798.00},size={136.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVarProc_CAA,title="Seal max P (psi)"
 	SetVariable setvar_Settings_SealMaxP,help={"Set the maximum negative pressure used to form a seal."}
 	SetVariable setvar_Settings_SealMaxP,userdata(tabnum)=  "5"
 	SetVariable setvar_Settings_SealMaxP,userdata(tabcontrol)=  "ADC"
@@ -2964,6 +3392,7 @@ Window DA_Ephys() : Panel
 	Button button_Settings_UpdateDACList,userdata(ResizeControlsInfo)= A"!!,HBJ,ht2!!#AN!!#<hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	Button button_Settings_UpdateDACList,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	Button button_Settings_UpdateDACList,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	Button button_Settings_UpdateDACList,userdata(Config_RestorePriority)=  "25"
 	Button button_Hardware_P_Enable,pos={336.00,528.00},size={60.00,45.00},proc=P_ButtonProc_Enable,title="Enable"
 	Button button_Hardware_P_Enable,help={"Enable ITC devices used for pressure regulation."}
 	Button button_Hardware_P_Enable,userdata(tabnum)=  "6"
@@ -2986,8 +3415,9 @@ Window DA_Ephys() : Panel
 	ValDisplay valdisp_DataAcq_P_0,userdata(ResizeControlsInfo)= A"!!,DG!!#BiJ,hpU!!#<`z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	ValDisplay valdisp_DataAcq_P_0,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	ValDisplay valdisp_DataAcq_P_0,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
-	ValDisplay valdisp_DataAcq_P_0,fSize=14,frame=0,fStyle=0
-	ValDisplay valdisp_DataAcq_P_0,valueColor=(65000,65000,65000)
+	ValDisplay valdisp_DataAcq_P_0,userdata(ControlArray)=  "valdisp_DataAcq_P"
+	ValDisplay valdisp_DataAcq_P_0,userdata(ControlArrayIndex)=  "0",fSize=14
+	ValDisplay valdisp_DataAcq_P_0,frame=0,fStyle=0
 	ValDisplay valdisp_DataAcq_P_0,valueBackColor=(65535,65535,65535,0)
 	ValDisplay valdisp_DataAcq_P_0,limits={0,0,0},barmisc={0,1000},value= #"0.00"
 	ValDisplay valdisp_DataAcq_P_1,pos={149.00,351.00},size={35.00,21.00},bodyWidth=35,disable=1
@@ -2995,8 +3425,9 @@ Window DA_Ephys() : Panel
 	ValDisplay valdisp_DataAcq_P_1,userdata(ResizeControlsInfo)= A"!!,G)!!#BiJ,hnE!!#<`z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	ValDisplay valdisp_DataAcq_P_1,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	ValDisplay valdisp_DataAcq_P_1,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
-	ValDisplay valdisp_DataAcq_P_1,fSize=14,frame=0,fStyle=0
-	ValDisplay valdisp_DataAcq_P_1,valueColor=(65000,65000,65000)
+	ValDisplay valdisp_DataAcq_P_1,userdata(ControlArray)=  "valdisp_DataAcq_P"
+	ValDisplay valdisp_DataAcq_P_1,userdata(ControlArrayIndex)=  "1",fSize=14
+	ValDisplay valdisp_DataAcq_P_1,frame=0,fStyle=0,valueColor=(65000,65000,65000)
 	ValDisplay valdisp_DataAcq_P_1,valueBackColor=(65535,65535,65535,0)
 	ValDisplay valdisp_DataAcq_P_1,limits={0,0,0},barmisc={0,1000},value= #"0.00"
 	ValDisplay valdisp_DataAcq_P_2,pos={193.00,351.00},size={35.00,21.00},bodyWidth=35,disable=1
@@ -3005,7 +3436,9 @@ Window DA_Ephys() : Panel
 	ValDisplay valdisp_DataAcq_P_2,userdata(ResizeControlsInfo)= A"!!,GT!!#BiJ,hnE!!#<`z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	ValDisplay valdisp_DataAcq_P_2,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	ValDisplay valdisp_DataAcq_P_2,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
-	ValDisplay valdisp_DataAcq_P_2,fSize=14,frame=0,fStyle=0
+	ValDisplay valdisp_DataAcq_P_2,userdata(ControlArray)=  "valdisp_DataAcq_P"
+	ValDisplay valdisp_DataAcq_P_2,userdata(ControlArrayIndex)=  "2",fSize=14
+	ValDisplay valdisp_DataAcq_P_2,frame=0,fStyle=0
 	ValDisplay valdisp_DataAcq_P_2,valueBackColor=(65535,65535,65535,0)
 	ValDisplay valdisp_DataAcq_P_2,limits={0,0,0},barmisc={0,1000},value= #"0.00"
 	ValDisplay valdisp_DataAcq_P_4,pos={280.00,351.00},size={35.00,21.00},bodyWidth=35,disable=1
@@ -3014,7 +3447,9 @@ Window DA_Ephys() : Panel
 	ValDisplay valdisp_DataAcq_P_4,userdata(ResizeControlsInfo)= A"!!,HH!!#BiJ,hnE!!#<`z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	ValDisplay valdisp_DataAcq_P_4,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	ValDisplay valdisp_DataAcq_P_4,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
-	ValDisplay valdisp_DataAcq_P_4,fSize=14,frame=0,fStyle=0
+	ValDisplay valdisp_DataAcq_P_4,userdata(ControlArray)=  "valdisp_DataAcq_P"
+	ValDisplay valdisp_DataAcq_P_4,userdata(ControlArrayIndex)=  "4",fSize=14
+	ValDisplay valdisp_DataAcq_P_4,frame=0,fStyle=0
 	ValDisplay valdisp_DataAcq_P_4,valueBackColor=(65535,65535,65535,0)
 	ValDisplay valdisp_DataAcq_P_4,limits={0,0,0},barmisc={0,1000},value= #"0.00"
 	ValDisplay valdisp_DataAcq_P_5,pos={322.00,351.00},size={35.00,21.00},bodyWidth=35,disable=1
@@ -3022,7 +3457,9 @@ Window DA_Ephys() : Panel
 	ValDisplay valdisp_DataAcq_P_5,userdata(ResizeControlsInfo)= A"!!,H]J,hs?J,hnE!!#<`z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	ValDisplay valdisp_DataAcq_P_5,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	ValDisplay valdisp_DataAcq_P_5,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
-	ValDisplay valdisp_DataAcq_P_5,fSize=14,frame=0,fStyle=0
+	ValDisplay valdisp_DataAcq_P_5,userdata(ControlArray)=  "valdisp_DataAcq_P"
+	ValDisplay valdisp_DataAcq_P_5,userdata(ControlArrayIndex)=  "5",fSize=14
+	ValDisplay valdisp_DataAcq_P_5,frame=0,fStyle=0
 	ValDisplay valdisp_DataAcq_P_5,valueBackColor=(65535,65535,65535,0)
 	ValDisplay valdisp_DataAcq_P_5,limits={0,0,0},barmisc={0,1000},value= #"0.00"
 	ValDisplay valdisp_DataAcq_P_6,pos={367.00,351.00},size={35.00,21.00},bodyWidth=35,disable=1
@@ -3031,7 +3468,9 @@ Window DA_Ephys() : Panel
 	ValDisplay valdisp_DataAcq_P_6,userdata(ResizeControlsInfo)= A"!!,Hs!!#BiJ,hnE!!#<`z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	ValDisplay valdisp_DataAcq_P_6,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	ValDisplay valdisp_DataAcq_P_6,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
-	ValDisplay valdisp_DataAcq_P_6,fSize=14,frame=0,fStyle=0
+	ValDisplay valdisp_DataAcq_P_6,userdata(ControlArray)=  "valdisp_DataAcq_P"
+	ValDisplay valdisp_DataAcq_P_6,userdata(ControlArrayIndex)=  "6",fSize=14
+	ValDisplay valdisp_DataAcq_P_6,frame=0,fStyle=0
 	ValDisplay valdisp_DataAcq_P_6,valueBackColor=(65535,65535,65535,0)
 	ValDisplay valdisp_DataAcq_P_6,limits={0,0,0},barmisc={0,1000},value= #"0.00"
 	ValDisplay valdisp_DataAcq_P_7,pos={409.00,351.00},size={35.00,21.00},bodyWidth=35,disable=1
@@ -3039,7 +3478,9 @@ Window DA_Ephys() : Panel
 	ValDisplay valdisp_DataAcq_P_7,userdata(ResizeControlsInfo)= A"!!,I3J,hs?J,hnE!!#<`z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	ValDisplay valdisp_DataAcq_P_7,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	ValDisplay valdisp_DataAcq_P_7,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
-	ValDisplay valdisp_DataAcq_P_7,fSize=14,frame=0,fStyle=0
+	ValDisplay valdisp_DataAcq_P_7,userdata(ControlArray)=  "valdisp_DataAcq_P"
+	ValDisplay valdisp_DataAcq_P_7,userdata(ControlArrayIndex)=  "7",fSize=14
+	ValDisplay valdisp_DataAcq_P_7,frame=0,fStyle=0
 	ValDisplay valdisp_DataAcq_P_7,valueBackColor=(65535,65535,65535,0)
 	ValDisplay valdisp_DataAcq_P_7,limits={0,0,0},barmisc={0,1000},value= #"0.00"
 	TabControl tab_DataAcq_Pressure,pos={31.00,269.00},size={423.00,108.00},disable=1,proc=ACL_DisplayTab
@@ -3123,6 +3564,7 @@ Window DA_Ephys() : Panel
 	Button button_DataAcq_SlowComp_VC,userdata(ResizeControlsInfo)= A"!!,I+!!#B&!!#>j!!#<Xz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	Button button_DataAcq_SlowComp_VC,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	Button button_DataAcq_SlowComp_VC,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
+	Button button_DataAcq_SlowComp_VC,userdata(Config_RestorePriority)=  "41"
 	CheckBox check_DatAcq_SealAtm,pos={186.00,327.00},size={42.00,15.00},disable=1,proc=P_Check_SealAtm,title="Atm."
 	CheckBox check_DatAcq_SealAtm,help={"Seals all headstates with active test pulse"}
 	CheckBox check_DatAcq_SealAtm,userdata(tabnum)=  "0"
@@ -3178,7 +3620,7 @@ Window DA_Ephys() : Panel
 	Button button_DataAcq_OpenCommentNB,userdata(ResizeControlsInfo)= A"!!,I3!!#DR^]6\\4!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	Button button_DataAcq_OpenCommentNB,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	Button button_DataAcq_OpenCommentNB,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox check_Settings_TPAfterDAQ,pos={168.00,108.00},size={130.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="Activate TP after DAQ"
+	CheckBox check_Settings_TPAfterDAQ,pos={168.00,108.00},size={131.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="Activate TP after DAQ"
 	CheckBox check_Settings_TPAfterDAQ,help={"Immediately start a test pulse after DAQ finishes"}
 	CheckBox check_Settings_TPAfterDAQ,userdata(tabnum)=  "5"
 	CheckBox check_Settings_TPAfterDAQ,userdata(tabcontrol)=  "ADC"
@@ -3194,7 +3636,7 @@ Window DA_Ephys() : Panel
 	PopupMenu Popup_Settings_SampIntMult,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu Popup_Settings_SampIntMult,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
 	PopupMenu Popup_Settings_SampIntMult,mode=1,popvalue="1",value= #"DAP_GetSamplingMultiplier()"
-	CheckBox Check_Settings_NwbExport,pos={33.00,231.00},size={104.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="Export into NWB"
+	CheckBox Check_Settings_NwbExport,pos={33.00,231.00},size={103.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="Export into NWB"
 	CheckBox Check_Settings_NwbExport,help={"Export all data including sweeps into a file in the NeurodataWithoutBorders fornat,"}
 	CheckBox Check_Settings_NwbExport,userdata(tabnum)=  "5"
 	CheckBox Check_Settings_NwbExport,userdata(tabcontrol)=  "ADC"
@@ -3257,7 +3699,7 @@ Window DA_Ephys() : Panel
 	CheckBox Check_AD_All,userdata(ResizeControlsInfo)= A"!!,BQ!!#C?J,hm>!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_AD_All,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_AD_All,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_AD_All,value= 0,side= 1
+	CheckBox Check_AD_All,userdata(Config_RestorePriority)=  "60",value= 0,side= 1
 	GroupBox Group_AD_all,pos={18.00,426.00},size={309.00,4.00},disable=1
 	GroupBox Group_AD_all,userdata(tabnum)=  "2",userdata(tabcontrol)=  "ADC"
 	GroupBox Group_AD_all,userdata(ResizeControlsInfo)= A"!!,BY!!#C;!!#BU!!#97z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
@@ -3268,31 +3710,33 @@ Window DA_Ephys() : Panel
 	CheckBox Check_DA_ALL,userdata(ResizeControlsInfo)= A"!!,BQ!!#CKJ,hm>!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_DA_ALL,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_DA_ALL,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_DA_ALL,value= 0,side= 1
+	CheckBox Check_DA_ALL,userdata(Config_RestorePriority)=  "60",value= 0,side= 1
 	PopupMenu Wave_DA_All,pos={145.00,456.00},size={125.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList
 	PopupMenu Wave_DA_All,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	PopupMenu Wave_DA_All,userdata(ResizeControlsInfo)= A"!!,G)!!#CJ!!#@^!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu Wave_DA_All,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu Wave_DA_All,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	PopupMenu Wave_DA_All,fSize=10
+	PopupMenu Wave_DA_All,userdata(Config_RestorePriority)=  "60",fSize=10
 	PopupMenu Wave_DA_All,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(0,\"*DA*\")"
 	SetVariable Search_DA_All,pos={153.00,480.00},size={123.00,18.00},disable=1,proc=DAP_SetVarProc_Channel_Search,title="Search filter"
 	SetVariable Search_DA_All,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Search_DA_All,userdata(ResizeControlsInfo)= A"!!,G)!!#CV!!#@\\!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Search_DA_All,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Search_DA_All,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable Search_DA_All,value= _STR:""
+	SetVariable Search_DA_All,userdata(Config_RestorePriority)=  "60",value= _STR:""
 	SetVariable Scale_DA_All,pos={283.00,456.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVarProc_DA_Scale
 	SetVariable Scale_DA_All,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	SetVariable Scale_DA_All,userdata(ResizeControlsInfo)= A"!!,HL!!#CJ!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Scale_DA_All,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Scale_DA_All,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Scale_DA_All,userdata(Config_RestorePriority)=  "60"
 	SetVariable Scale_DA_All,limits={-inf,inf,10},value= _NUM:1
 	PopupMenu IndexEnd_DA_All,pos={346.00,456.00},size={125.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList
 	PopupMenu IndexEnd_DA_All,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	PopupMenu IndexEnd_DA_All,userdata(ResizeControlsInfo)= A"!!,HkJ,hsu!!#@^!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu IndexEnd_DA_All,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu IndexEnd_DA_All,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu IndexEnd_DA_All,userdata(Config_RestorePriority)=  "60"
 	PopupMenu IndexEnd_DA_All,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(0,\"*DA*\")"
 	GroupBox Group_TTL_all,pos={18.00,447.00},size={345.00,4.00},disable=1
 	GroupBox Group_TTL_all,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
@@ -3304,7 +3748,7 @@ Window DA_Ephys() : Panel
 	PopupMenu Wave_TTL_All,userdata(ResizeControlsInfo)= A"!!,F3!!#CK!!#@^!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu Wave_TTL_All,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu Wave_TTL_All,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	PopupMenu Wave_TTL_All,fSize=10
+	PopupMenu Wave_TTL_All,userdata(Config_RestorePriority)=  "60",fSize=10
 	PopupMenu Wave_TTL_All,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(1,\"*TTL*\")"
 	SetVariable Search_TTL_All,pos={102.00,480.00},size={123.00,18.00},disable=1,proc=DAP_SetVarProc_Channel_Search,title="Search filter"
 	SetVariable Search_TTL_All,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
@@ -3317,13 +3761,14 @@ Window DA_Ephys() : Panel
 	PopupMenu IndexEnd_TTL_All,userdata(ResizeControlsInfo)= A"!!,H.!!#CK!!#@^!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu IndexEnd_TTL_All,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu IndexEnd_TTL_All,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu IndexEnd_TTL_All,userdata(Config_RestorePriority)=  "60"
 	PopupMenu IndexEnd_TTL_All,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(1,\"*TTL*\")"
 	CheckBox Check_TTL_ALL,pos={18.00,459.00},size={23.00,15.00},disable=1,proc=DAP_CheckProc_Channel_All,title="X"
 	CheckBox Check_TTL_ALL,userdata(tabnum)=  "3",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_TTL_ALL,userdata(ResizeControlsInfo)= A"!!,BY!!#CKJ,hm>!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_TTL_ALL,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_TTL_ALL,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_TTL_ALL,value= 0
+	CheckBox Check_TTL_ALL,userdata(Config_RestorePriority)=  "60",value= 0
 	CheckBox check_settings_show_power,pos={27.00,157.00},size={134.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="Show power spectrum"
 	CheckBox check_settings_show_power,help={"Show the power spectrum (Fourier Transform) of the testpulse"}
 	CheckBox check_settings_show_power,userdata(tabnum)=  "5"
@@ -3332,13 +3777,15 @@ Window DA_Ephys() : Panel
 	CheckBox check_settings_show_power,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	CheckBox check_settings_show_power,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
 	CheckBox check_settings_show_power,value= 0
-	PopupMenu Popup_Settings_Pressure_TTLB,pos={226.00,555.00},size={101.00,19.00},bodyWidth=70,proc=DAP_PopMenuProc_CAA,title="TTL B"
+	PopupMenu Popup_Settings_Pressure_TTLB,pos={224.00,555.00},size={103.00,19.00},bodyWidth=70,proc=DAP_PopMenuProc_CAA,title="TTL B"
 	PopupMenu Popup_Settings_Pressure_TTLB,help={"Select TTL channel for solenoid command"}
 	PopupMenu Popup_Settings_Pressure_TTLB,userdata(tabnum)=  "6"
 	PopupMenu Popup_Settings_Pressure_TTLB,userdata(tabcontrol)=  "ADC"
 	PopupMenu Popup_Settings_Pressure_TTLB,userdata(ResizeControlsInfo)= A"!!,H!!!#Cn5QF-r!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu Popup_Settings_Pressure_TTLB,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu Popup_Settings_Pressure_TTLB,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu Popup_Settings_Pressure_TTLB,userdata(Config_DontRestore)=  "1"
+	PopupMenu Popup_Settings_Pressure_TTLB,userdata(Config_DontSave)=  "1"
 	PopupMenu Popup_Settings_Pressure_TTLB,mode=1,popvalue="- none -",value= #"\"- none -;0;1;2;3;4;5;6;7\""
 	CheckBox check_Settings_UserP_Approach,pos={228.00,321.00},size={68.00,15.00},disable=1,proc=DAP_CheckProc_Settings_PUser,title="Approach"
 	CheckBox check_Settings_UserP_Approach,help={"User applied pressure during approach mode "}
@@ -3404,13 +3851,14 @@ Window DA_Ephys() : Panel
 	CheckBox Check_DA_AllVClamp,userdata(ResizeControlsInfo)= A"!!,BQ!!#Cl^]6[)!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_DA_AllVClamp,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_DA_AllVClamp,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	CheckBox Check_DA_AllVClamp,userdata(Config_RestorePriority)=  "60"
 	CheckBox Check_DA_AllVClamp,value= 0,side= 1
 	PopupMenu Wave_DA_AllVClamp,pos={145.00,543.00},size={125.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList
 	PopupMenu Wave_DA_AllVClamp,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	PopupMenu Wave_DA_AllVClamp,userdata(ResizeControlsInfo)= A"!!,G)!!#Cm5QF.I!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu Wave_DA_AllVClamp,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu Wave_DA_AllVClamp,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	PopupMenu Wave_DA_AllVClamp,fSize=10
+	PopupMenu Wave_DA_AllVClamp,userdata(Config_RestorePriority)=  "60",fSize=10
 	PopupMenu Wave_DA_AllVClamp,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(0,\"*DA*\")"
 	SetVariable Search_DA_AllVClamp,pos={153.00,567.00},size={123.00,18.00},disable=1,proc=DAP_SetVarProc_Channel_Search,title="Search filter"
 	SetVariable Search_DA_AllVClamp,userdata(tabnum)=  "1"
@@ -3418,6 +3866,7 @@ Window DA_Ephys() : Panel
 	SetVariable Search_DA_AllVClamp,userdata(ResizeControlsInfo)= A"!!,G*!!#Cs5QF.G!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Search_DA_AllVClamp,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Search_DA_AllVClamp,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Search_DA_AllVClamp,userdata(Config_RestorePriority)=  "60"
 	SetVariable Search_DA_AllVClamp,value= _STR:""
 	SetVariable Scale_DA_AllVClamp,pos={280.00,543.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVarProc_DA_Scale
 	SetVariable Scale_DA_AllVClamp,userdata(tabnum)=  "1"
@@ -3425,6 +3874,7 @@ Window DA_Ephys() : Panel
 	SetVariable Scale_DA_AllVClamp,userdata(ResizeControlsInfo)= A"!!,HK!!#Cm5QF,A!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Scale_DA_AllVClamp,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Scale_DA_AllVClamp,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Scale_DA_AllVClamp,userdata(Config_RestorePriority)=  "60"
 	SetVariable Scale_DA_AllVClamp,limits={-inf,inf,10},value= _NUM:1
 	PopupMenu IndexEnd_DA_AllVClamp,pos={346.00,543.00},size={125.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList
 	PopupMenu IndexEnd_DA_AllVClamp,userdata(tabnum)=  "1"
@@ -3432,6 +3882,7 @@ Window DA_Ephys() : Panel
 	PopupMenu IndexEnd_DA_AllVClamp,userdata(ResizeControlsInfo)= A"!!,HkJ,htC5QF.I!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu IndexEnd_DA_AllVClamp,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu IndexEnd_DA_AllVClamp,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu IndexEnd_DA_AllVClamp,userdata(Config_RestorePriority)=  "60"
 	PopupMenu IndexEnd_DA_AllVClamp,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(0,\"*DA*\")"
 	GroupBox group_DA_AllVClamp,pos={12.00,522.00},size={471.00,72.00},disable=1,title="V-Clamp"
 	GroupBox group_DA_AllVClamp,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
@@ -3443,13 +3894,14 @@ Window DA_Ephys() : Panel
 	CheckBox Check_DA_AllIClamp,userdata(ResizeControlsInfo)= A"!!,BQ!!#D,J,hm>!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_DA_AllIClamp,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_DA_AllIClamp,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	CheckBox Check_DA_AllIClamp,userdata(Config_RestorePriority)=  "60"
 	CheckBox Check_DA_AllIClamp,value= 0,side= 1
 	PopupMenu Wave_DA_AllIClamp,pos={145.00,627.00},size={125.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList
 	PopupMenu Wave_DA_AllIClamp,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
 	PopupMenu Wave_DA_AllIClamp,userdata(ResizeControlsInfo)= A"!!,G)!!#D-!!#@^!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu Wave_DA_AllIClamp,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu Wave_DA_AllIClamp,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	PopupMenu Wave_DA_AllIClamp,fSize=10
+	PopupMenu Wave_DA_AllIClamp,userdata(Config_RestorePriority)=  "60",fSize=10
 	PopupMenu Wave_DA_AllIClamp,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(0,\"*DA*\")"
 	SetVariable Search_DA_AllIClamp,pos={153.00,651.00},size={123.00,18.00},disable=1,proc=DAP_SetVarProc_Channel_Search,title="Search filter"
 	SetVariable Search_DA_AllIClamp,userdata(tabnum)=  "1"
@@ -3457,6 +3909,7 @@ Window DA_Ephys() : Panel
 	SetVariable Search_DA_AllIClamp,userdata(ResizeControlsInfo)= A"!!,G*!!#D3!!#@\\!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Search_DA_AllIClamp,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Search_DA_AllIClamp,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Search_DA_AllIClamp,userdata(Config_RestorePriority)=  "60"
 	SetVariable Search_DA_AllIClamp,value= _STR:""
 	SetVariable Scale_DA_AllIClamp,pos={280.00,627.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVarProc_DA_Scale
 	SetVariable Scale_DA_AllIClamp,userdata(tabnum)=  "1"
@@ -3464,6 +3917,7 @@ Window DA_Ephys() : Panel
 	SetVariable Scale_DA_AllIClamp,userdata(ResizeControlsInfo)= A"!!,HK!!#D-!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Scale_DA_AllIClamp,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable Scale_DA_AllIClamp,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	SetVariable Scale_DA_AllIClamp,userdata(Config_RestorePriority)=  "60"
 	SetVariable Scale_DA_AllIClamp,limits={-inf,inf,10},value= _NUM:1
 	PopupMenu IndexEnd_DA_AllIClamp,pos={346.00,627.00},size={125.00,19.00},bodyWidth=125,disable=1,proc=DAP_PopMenuChkProc_StimSetList
 	PopupMenu IndexEnd_DA_AllIClamp,userdata(tabnum)=  "1"
@@ -3471,6 +3925,7 @@ Window DA_Ephys() : Panel
 	PopupMenu IndexEnd_DA_AllIClamp,userdata(ResizeControlsInfo)= A"!!,Hl!!#D-!!#@^!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	PopupMenu IndexEnd_DA_AllIClamp,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu IndexEnd_DA_AllIClamp,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	PopupMenu IndexEnd_DA_AllIClamp,userdata(Config_RestorePriority)=  "60"
 	PopupMenu IndexEnd_DA_AllIClamp,mode=1,popvalue="- none -",value= #"\"- none -;\"+ReturnListOfAllStimSets(0,\"*DA*\")"
 	GroupBox group_DA_AllIClamp,pos={12.00,606.00},size={471.00,72.00},disable=1,title="I-Clamp"
 	GroupBox group_DA_AllIClamp,userdata(tabnum)=  "1",userdata(tabcontrol)=  "ADC"
@@ -3483,6 +3938,8 @@ Window DA_Ephys() : Panel
 	CheckBox Radio_ClampMode_AllVClamp,userdata(ResizeControlsInfo)= A"!!,I.!!#?1!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Radio_ClampMode_AllVClamp,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Radio_ClampMode_AllVClamp,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	CheckBox Radio_ClampMode_AllVClamp,userdata(Config_RestorePriority)=  "29"
+	CheckBox Radio_ClampMode_AllVClamp,userdata(Config_NiceName)=  "Headstage_All_VC"
 	CheckBox Radio_ClampMode_AllVClamp,value= 0,mode=1
 	CheckBox Radio_ClampMode_AllIClamp,pos={399.00,111.00},size={14.00,14.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
 	CheckBox Radio_ClampMode_AllIClamp,userdata(tabnum)=  "0"
@@ -3490,20 +3947,24 @@ Window DA_Ephys() : Panel
 	CheckBox Radio_ClampMode_AllIClamp,userdata(ResizeControlsInfo)= A"!!,I.!!#@B!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Radio_ClampMode_AllIClamp,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Radio_ClampMode_AllIClamp,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	CheckBox Radio_ClampMode_AllIClamp,userdata(Config_RestorePriority)=  "29"
+	CheckBox Radio_ClampMode_AllIClamp,userdata(Config_NiceName)=  "Headstage_All_IC"
 	CheckBox Radio_ClampMode_AllIClamp,value= 0,mode=1
-	CheckBox Radio_ClampMode_AllIZero,pos={399.00,180.00},size={12.00,12.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
+	CheckBox Radio_ClampMode_AllIZero,pos={399.00,180.00},size={14.00,14.00},disable=1,proc=DAP_CheckProc_ClampMode,title=""
 	CheckBox Radio_ClampMode_AllIZero,userdata(tabnum)=  "2"
 	CheckBox Radio_ClampMode_AllIZero,userdata(tabcontrol)=  "tab_DataAcq_Amp"
 	CheckBox Radio_ClampMode_AllIZero,userdata(ResizeControlsInfo)= A"!!,I6!!#AF!!#;]!!#;]z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Radio_ClampMode_AllIZero,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Radio_ClampMode_AllIZero,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
+	CheckBox Radio_ClampMode_AllIZero,userdata(Config_RestorePriority)=  "29"
+	CheckBox Radio_ClampMode_AllIZero,userdata(Config_NiceName)=  "Headstage_All_IZero"
 	CheckBox Radio_ClampMode_AllIZero,value= 0,mode=1
 	CheckBox Check_DataAcqHS_All,pos={399.00,84.00},size={30.00,15.00},disable=1,proc=DAP_CheckProc_HedstgeChck,title="All"
 	CheckBox Check_DataAcqHS_All,userdata(tabnum)=  "0",userdata(tabcontrol)=  "ADC"
 	CheckBox Check_DataAcqHS_All,userdata(ResizeControlsInfo)= A"!!,I.!!#?c!!#=K!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	CheckBox Check_DataAcqHS_All,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	CheckBox Check_DataAcqHS_All,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	CheckBox Check_DataAcqHS_All,value= 0
+	CheckBox Check_DataAcqHS_All,userdata(Config_RestorePriority)=  "60",value= 0
 	CheckBox check_Settings_TP_SaveTP,pos={340.00,132.00},size={118.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="Save each testpulse"
 	CheckBox check_Settings_TP_SaveTP,help={"Store the complete scaled testpulse for each run (requires loads of RAM)"}
 	CheckBox check_Settings_TP_SaveTP,userdata(tabnum)=  "5"
@@ -3543,7 +4004,7 @@ Window DA_Ephys() : Panel
 	SetVariable setvar_Settings_AutoBiasInt,userdata(tabnum)=  "5"
 	SetVariable setvar_Settings_AutoBiasInt,userdata(tabcontrol)=  "ADC"
 	SetVariable setvar_Settings_AutoBiasInt,limits={0.25,1000,0.25},value= _NUM:1
-	CheckBox Check_Settings_ITImanualStart,pos={33.00,300.00},size={200.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="Respect ITI for manual initialization"
+	CheckBox Check_Settings_ITImanualStart,pos={33.00,300.00},size={201.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState,title="Respect ITI for manual initialization"
 	CheckBox Check_Settings_ITImanualStart,help={"Ensure that the ITI is reached even when manually stopping and starting sweeps."}
 	CheckBox Check_Settings_ITImanualStart,userdata(tabnum)=  "5"
 	CheckBox Check_Settings_ITImanualStart,userdata(tabcontrol)=  "ADC",value= 0
@@ -3559,10 +4020,15 @@ Window DA_Ephys() : Panel
 	PopupMenu popup_Settings_UserPressure,help={"List of available DAC devices for pressure control"}
 	PopupMenu popup_Settings_UserPressure,userdata(tabnum)=  "6"
 	PopupMenu popup_Settings_UserPressure,userdata(tabcontrol)=  "ADC"
-	PopupMenu popup_Settings_UserPressure,mode=1,popvalue="- none -",value= #"\"- none -;;Dev1;;\""
+	PopupMenu popup_Settings_UserPressure,userdata(Config_RestorePriority)=  "60"
+	PopupMenu popup_Settings_UserPressure,userdata(Config_DontSave)=  "1"
+	PopupMenu popup_Settings_UserPressure,userdata(Config_DontRestore)=  "1"
+	PopupMenu popup_Settings_UserPressure,mode=1,popvalue="- none -",value= #"\"- none -;\""
 	PopupMenu Popup_Settings_UserPressure_ADC,pos={267.00,618.00},size={47.00,19.00},proc=DAP_PopMenuProc_UpdateGuiState,title="AD"
 	PopupMenu Popup_Settings_UserPressure_ADC,userdata(tabnum)=  "6"
 	PopupMenu Popup_Settings_UserPressure_ADC,userdata(tabcontrol)=  "ADC"
+	PopupMenu Popup_Settings_UserPressure_ADC,userdata(Config_DontSave)=  "1"
+	PopupMenu Popup_Settings_UserPressure_ADC,userdata(Config_DontRestore)=  "1"
 	PopupMenu Popup_Settings_UserPressure_ADC,mode=1,popvalue="0",value= #"\"0;1;2;3;4;5;6;7;8;9;10;11;12;13;14;15\""
 	Button button_Hardware_PUser_Enable,pos={336.00,597.00},size={60.00,45.00},proc=P_ButtonProc_UserPressure,title="Enable"
 	Button button_Hardware_PUser_Enable,help={"Enable device for user pressure acquisition"}
@@ -3582,7 +4048,7 @@ Window DA_Ephys() : Panel
 	SetVariable setvar_Settings_OsciUpdInt,userdata(tabnum)=  "5"
 	SetVariable setvar_Settings_OsciUpdInt,userdata(tabcontrol)=  "ADC"
 	SetVariable setvar_Settings_OsciUpdInt,limits={0,60000,50},value= _NUM:500
-	SetVariable setvar_Settings_OsciUpdExt,pos={260.00,597.00},size={183.00,18.00},bodyWidth=45,disable=1,proc=DAP_SetVar_UpdateGuiState,title="Y axis scale extension [%]"
+	SetVariable setvar_Settings_OsciUpdExt,pos={262.00,597.00},size={181.00,18.00},bodyWidth=45,disable=1,proc=DAP_SetVar_UpdateGuiState,title="Y axis scale extension [%]"
 	SetVariable setvar_Settings_OsciUpdExt,help={"Oscilloscope update axis extension for Interval mode"}
 	SetVariable setvar_Settings_OsciUpdExt,userdata(tabnum)=  "5"
 	SetVariable setvar_Settings_OsciUpdExt,userdata(tabcontrol)=  "ADC"
@@ -3605,6 +4071,7 @@ Window DA_Ephys() : Panel
 	Button button_hardware_rescan,help={"Rescan the PC for ITC and NI DAQ hardware"}
 	Button button_hardware_rescan,userdata(tabnum)=  "6"
 	Button button_hardware_rescan,userdata(tabcontrol)=  "ADC"
+	Button button_hardware_rescan,userdata(Config_RestorePriority)=  "1"
 	Button button_hardware_rescan,fColor=(65535,65535,65535)
 	Button button_hardware_rescan,picture= ProcGlobal#HardwareScanButton
 	DefineGuide UGV0={FR,-25},UGH0={FB,-27},UGV1={FL,481}
@@ -3616,4 +4083,6 @@ Window DA_Ephys() : Panel
 	SetWindow kwTopWin,userdata(ResizeControlsInfoUGV0)=  "NAME:UGV0;WIN:ITC1600_Dev_0;TYPE:User;HORIZONTAL:0;POSITION:459.00;GUIDE1:FR;GUIDE2:;RELPOSITION:-25;"
 	SetWindow kwTopWin,userdata(ResizeControlsInfoUGH0)=  "NAME:UGH0;WIN:ITC1600_Dev_0;TYPE:User;HORIZONTAL:1;POSITION:854.00;GUIDE1:FB;GUIDE2:;RELPOSITION:-27;"
 	SetWindow kwTopWin,userdata(ResizeControlsInfoUGV1)=  "NAME:UGV1;WIN:ITC1600_Dev_0;TYPE:User;HORIZONTAL:0;POSITION:481.00;GUIDE1:FL;GUIDE2:;RELPOSITION:481;"
+	SetWindow kwTopWin,userdata(Config_PanelType)=  "DA_Ephys"
+	SetWindow kwTopWin,userdata(Config_RadioCouplingFunc)=  "DAP_GetRadioButtonCoupling"
 EndMacro

--- a/Packages/MIES/MIES_DataBrowser_Macro.ipf
+++ b/Packages/MIES/MIES_DataBrowser_Macro.ipf
@@ -21,6 +21,7 @@ Window DataBrowser() : Graph
 	SetWindow kwTopWin,hook(ResizeControls)=ResizeControls#ResizeControlsHook
 	SetWindow kwTopWin,userdata(BROWSER)=  "D"
 	SetWindow kwTopWin,userdata(DEVICE)=  "- none -"
+	SetWindow kwTopWin,userdata(Config_PanelType)=  "DataBrowser"
 	SetWindow kwTopWin,userdata(ResizeControlsInfo)= A"!!*'\"z!!#C=?iWQ]TE\"rlzzzzzzzzzzzzzzzzzzzz"
 	SetWindow kwTopWin,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzzzzzzzzzzzzzzz"
 	SetWindow kwTopWin,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzzzzzzzzz!!!"

--- a/Packages/MIES/MIES_DataConfiguratorITC.ipf
+++ b/Packages/MIES/MIES_DataConfiguratorITC.ipf
@@ -1326,6 +1326,8 @@ static Function DC_PlaceDataInHardwareDataWave(panelTitle, numActiveChannels, da
 	DC_DocumentChannelProperty(panelTitle, "MIES version", INDEP_HEADSTAGE, NaN, NaN, str=GetMIESVersionAsString())
 	DC_DocumentChannelProperty(panelTitle, "Igor Pro version", INDEP_HEADSTAGE, NaN, NaN, str=GetIgorProVersion())
 	DC_DocumentChannelProperty(panelTitle, "Igor Pro bitness", INDEP_HEADSTAGE, NaN, NaN, var=GetArchitectureBits())
+	DC_DocumentChannelProperty(panelTitle, "JSON config file: path", INDEP_HEADSTAGE, NaN, NaN, str=GetUserData(panelTitle, "", EXPCONFIG_UDATA_SOURCEFILE_PATH))
+	DC_DocumentChannelProperty(panelTitle, "JSON config file: SHA-256 hash", INDEP_HEADSTAGE, NaN, NaN, str=GetUserData(panelTitle, "", EXPCONFIG_UDATA_SOURCEFILE_HASH))
 
 	for(i = 0; i < NUM_HEADSTAGES; i += 1)
 

--- a/Packages/MIES/MIES_Menu.ipf
+++ b/Packages/MIES/MIES_Menu.ipf
@@ -23,6 +23,9 @@ Menu "Mies Panels"
 	"-"
 	SubMenu "Automation"
 		"Configure MIES/1"                     , /Q, ExpConfig_ConfigureMIES()
+		"Load Standard Configuration"          , /Q, CONF_AutoLoader()
+		"Load Window Configuration"            , /Q, CONF_RestoreWindow("", usePanelTypeFromFile = 1)
+		"Save Window Configuration"            , /Q, CONF_SaveWindow("")
 		"Blowout/8"                            , /Q, BWO_SelectDevice()
 		"Save and Clear Experiment"            , /Q, SaveExperimentSpecial(SAVE_AND_CLEAR)
 		"Close Mies"                           , /Q, CloseMies()

--- a/Packages/MIES/MIES_Menu.ipf
+++ b/Packages/MIES/MIES_Menu.ipf
@@ -22,8 +22,7 @@ Menu "Mies Panels"
 	End
 	"-"
 	SubMenu "Automation"
-		"Configure MIES/1"                     , /Q, ExpConfig_ConfigureMIES()
-		"Load Standard Configuration"          , /Q, CONF_AutoLoader()
+		"Load Standard Configuration/1"        , /Q, CONF_AutoLoader()
 		"Load Window Configuration"            , /Q, CONF_RestoreWindow("", usePanelTypeFromFile = 1)
 		"Save Window Configuration"            , /Q, CONF_SaveWindow("")
 		"Blowout/8"                            , /Q, BWO_SelectDevice()

--- a/Packages/MIES/MIES_ProgrammaticGUIControl.ipf
+++ b/Packages/MIES/MIES_ProgrammaticGUIControl.ipf
@@ -179,6 +179,8 @@ End
 /// - `val` is mandatory and 0-based.
 /// - `str` must be the name of an entry, can include `*` using wildcard syntax.
 ///
+/// ValDisp: Setting a ValDisp control always changed its mode from 'internal number' to 'global expression'
+///
 /// `switchTab` [optional, defaults to false] Switches tabs so that the control is shown.
 ///
 /// @return 1 if val was modified by control limits, 0 if val was unmodified (only relevant for SetVariable controls)

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -1575,7 +1575,7 @@ Function/WAVE GetLBNidCache(numericalValues)
 	return wv
 End
 
-static Constant SWEEP_SETTINGS_WAVE_VERSION = 24
+static Constant SWEEP_SETTINGS_WAVE_VERSION = 25
 
 /// @brief Uses the parameter names from the `sourceKey` columns and
 ///        write them as dimension into the columns of dest.
@@ -2052,6 +2052,8 @@ End
 /// -26: Digitizer Hardware Name
 /// -27: Digitizer Serial Numbers
 /// -28: Epochs
+/// -29: JSON config file: path
+/// -30: JSON config file: SHA-256 hash
 Function/Wave GetSweepSettingsTextKeyWave(panelTitle)
 	string panelTitle
 
@@ -2070,9 +2072,9 @@ Function/Wave GetSweepSettingsTextKeyWave(panelTitle)
 	if(ExistsWithCorrectLayoutVersion(wv, versionOfNewWave))
 		return wv
 	elseif(WaveExists(wv))
-		Redimension/N=(-1, 29, 0) wv
+		Redimension/N=(-1, 31, 0) wv
 	else
-		Make/T/N=(1, 29) newDFR:$newName/Wave=wv
+		Make/T/N=(1, 31) newDFR:$newName/Wave=wv
 	endif
 
 	SetDimLabel ROWS, 0, Parameter, wv
@@ -2108,6 +2110,8 @@ Function/Wave GetSweepSettingsTextKeyWave(panelTitle)
 	wv[0][26] = "Digitizer Hardware Name"
 	wv[0][27] = "Digitizer Serial Numbers"
 	wv[0][28] = EPOCHS_ENTRY_KEY
+	wv[0][29] = "JSON config file: path"
+	wv[0][30] = "JSON config file: SHA-256 hash"
 
 	SetSweepSettingsDimLabels(wv, wv)
 	SetWaveVersion(wv, versionOfNewWave)

--- a/Packages/MIES_Include.ipf
+++ b/Packages/MIES_Include.ipf
@@ -58,6 +58,7 @@
 #include "MIES_BackgroundWatchdog"
 #include "MIES_Cache"
 #include "MIES_CheckInstallation"
+#include "MIES_Configuration"
 #include "MIES_Constants"
 #include "MIES_DAC-Hardware"
 #include "MIES_DAEphys"

--- a/Packages/Settings/1_DA_Ephys.json
+++ b/Packages/Settings/1_DA_Ephys.json
@@ -1,0 +1,796 @@
+{
+    "Common configuration data": {
+        "Headstage Association": {
+            "0": {
+                "Amplifier Serial": 0,
+                "Amplifier Title": "0,1",
+                "IC AD": 0,
+                "IC DA": 0,
+                "Pressure AD": 0,
+                "Pressure AD Gain": 0.5,
+                "Pressure AD Unit": "psi",
+                "Pressure Constant Negative": 0,
+                "Pressure Constant Positive": 0,
+                "Pressure DA": 0,
+                "Pressure DA Gain": 2,
+                "Pressure DA Unit": "psi",
+                "Pressure Device": "- none -",
+                "Pressure TTLA": 0,
+                "Pressure TTLB": 1,
+                "VC AD": 0,
+                "VC DA": 0
+            },
+            "1": {
+                "Amplifier Serial": 0,
+                "Amplifier Title": "0,1",
+                "IC AD": 1,
+                "IC DA": 1,
+                "Pressure AD": 1,
+                "Pressure AD Gain": 0.5,
+                "Pressure AD Unit": "psi",
+                "Pressure Constant Negative": 0,
+                "Pressure Constant Positive": 0,
+                "Pressure DA": 1,
+                "Pressure DA Gain": 2,
+                "Pressure DA Unit": "psi",
+                "Pressure Device": "- none -",
+                "Pressure TTLA": 2,
+                "Pressure TTLB": 3,
+                "VC AD": 1,
+                "VC DA": 1
+            },
+            "2": null,
+            "3": null,
+            "4": null,
+            "5": null,
+            "6": null,
+            "7": null
+        },
+        "Position MCCs": "- none -",
+        "Save data to": "C:MiesSave",
+        "Stim set file name": "",
+        "User Pressure Devices": {
+            "DAC Device": "- none -",
+            "Pressure DA": 0
+        }
+    },
+    "Dev1": {
+        "Generic ControlGroup": {
+            "ADC": {
+                "NumValue": 0
+            },
+            "Check_AD": {
+                "Values": [
+                    true,
+                    true,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false
+                ]
+            },
+            "Check_AD_All": {
+                "NumValue": false
+            },
+            "Check_AsyncAD": {
+                "Values": [
+                    false,
+                    false,
+                    true,
+                    true,
+                    false,
+                    false,
+                    false,
+                    false
+                ]
+            },
+            "Check_DA": {
+                "Values": [
+                    true,
+                    true,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false
+                ]
+            },
+            "Check_DA_ALL": {
+                "NumValue": false
+            },
+            "Check_DA_AllIClamp": {
+                "NumValue": false
+            },
+            "Check_DA_AllVClamp": {
+                "NumValue": false
+            },
+            "Check_DataAcq1_DistribDaq": {
+                "NumValue": false
+            },
+            "Check_DataAcq1_RepeatAcq": {
+                "NumValue": true
+            },
+            "Check_DataAcq1_dDAQOptOv": {
+                "NumValue": true
+            },
+            "Check_DataAcqHS": {
+                "Values": [
+                    true,
+                    true,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false
+                ]
+            },
+            "Check_DataAcqHS_All": {
+                "NumValue": false
+            },
+            "Check_DataAcq_Get_Set_ITI": {
+                "NumValue": true
+            },
+            "Check_DataAcq_Indexing": {
+                "NumValue": false
+            },
+            "Check_DataAcq_SendToAllAmp": {
+                "NumValue": true
+            },
+            "Check_Settings_AlarmAutoRepeat": {
+                "NumValue": false
+            },
+            "Check_Settings_AlarmPauseAcq": {
+                "NumValue": false
+            },
+            "Check_Settings_Append": {
+                "NumValue": false
+            },
+            "Check_Settings_BackgrndDataAcq": {
+                "NumValue": true
+            },
+            "Check_Settings_BkgTP": {
+                "NumValue": true
+            },
+            "Check_Settings_ITImanualStart": {
+                "NumValue": false
+            },
+            "Check_Settings_InsertTP": {
+                "NumValue": true
+            },
+            "Check_Settings_NwbExport": {
+                "NumValue": false
+            },
+            "Check_Settings_SkipAnalysFuncs": {
+                "NumValue": true
+            },
+            "Check_Settings_TrigIn": {
+                "NumValue": false
+            },
+            "Check_Settings_TrigOut": {
+                "NumValue": false
+            },
+            "Check_Settings_UseDoublePrec": {
+                "NumValue": false
+            },
+            "Check_TTL": {
+                "Values": [
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false
+                ]
+            },
+            "Check_TTL_ALL": {
+                "NumValue": false
+            },
+            "Gain_AD": {
+                "Values": [
+                    0.0005000000237487257,
+                    0.05000000074505806,
+                    1,
+                    1,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                ]
+            },
+            "Gain_AsyncAD": {
+                "Values": [
+                    1,
+                    1,
+                    0.01,
+                    0.01,
+                    1,
+                    1,
+                    1,
+                    1
+                ]
+            },
+            "Gain_DA": {
+                "Values": [
+                    20,
+                    400,
+                    1,
+                    1,
+                    0,
+                    0,
+                    0,
+                    0
+                ]
+            },
+            "Headstage_0_VC": {
+                "NumValue": true
+            },
+            "Headstage_1_IC": {
+                "NumValue": true
+            },
+            "Headstage_2_VC": {
+                "NumValue": true
+            },
+            "Headstage_3_VC": {
+                "NumValue": true
+            },
+            "Headstage_4_VC": {
+                "NumValue": true
+            },
+            "Headstage_5_VC": {
+                "NumValue": true
+            },
+            "Headstage_6_VC": {
+                "NumValue": true
+            },
+            "Headstage_7_VC": {
+                "NumValue": true
+            },
+            "IndexEnd_DA": {
+                "Values": [
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -"
+                ]
+            },
+            "IndexEnd_DA_All": {
+                "StrValue": "- none -"
+            },
+            "IndexEnd_DA_AllIClamp": {
+                "StrValue": "- none -"
+            },
+            "IndexEnd_DA_AllVClamp": {
+                "StrValue": "- none -"
+            },
+            "IndexEnd_TTL": {
+                "Values": [
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -"
+                ]
+            },
+            "IndexEnd_TTL_All": {
+                "StrValue": "- none -"
+            },
+            "Popup_Settings_DecMethod": {
+                "StrValue": "MinMax"
+            },
+            "Popup_Settings_FixedFreq": {
+                "StrValue": "Maximum"
+            },
+            "Popup_Settings_OsciUpdMode": {
+                "StrValue": "Interval"
+            },
+            "Popup_Settings_SampIntMult": {
+                "StrValue": "1"
+            },
+            "Scale_DA": {
+                "Values": [
+                    70,
+                    1500,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1
+                ]
+            },
+            "Scale_DA_All": {
+                "NumValue": 1
+            },
+            "Scale_DA_AllIClamp": {
+                "NumValue": 1500
+            },
+            "Scale_DA_AllVClamp": {
+                "NumValue": 70
+            },
+            "Search_DA": {
+                "Values": [
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    ""
+                ]
+            },
+            "Search_DA_All": {
+                "StrValue": ""
+            },
+            "Search_DA_AllIClamp": {
+                "StrValue": ""
+            },
+            "Search_DA_AllVClamp": {
+                "StrValue": ""
+            },
+            "Search_TTL": {
+                "Values": [
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    ""
+                ]
+            },
+            "Search_TTL_All": {
+                "StrValue": ""
+            },
+            "SetVar_DataAcq_Comment": {
+                "StrValue": ""
+            },
+            "SetVar_DataAcq_ITI": {
+                "NumValue": 0.015
+            },
+            "SetVar_DataAcq_ListRepeats": {
+                "NumValue": 1
+            },
+            "SetVar_DataAcq_SetRepeats": {
+                "NumValue": 5
+            },
+            "SetVar_DataAcq_skipAhead": {
+                "NumValue": 0
+            },
+            "SetVar_Hardware_Pressur_AD_Unit": {
+                "StrValue": "psi"
+            },
+            "SetVar_Hardware_Pressur_DA_Unit": {
+                "StrValue": "psi"
+            },
+            "SetVar_Sweep": {
+                "NumValue": 0
+            },
+            "Setvar_DataAcq_dDAQDelay": {
+                "NumValue": 0
+            },
+            "Title_AsyncAD": {
+                "Values": [
+                    "",
+                    "",
+                    "Set Temperature",
+                    "Bath Temperature",
+                    "",
+                    "",
+                    "",
+                    ""
+                ]
+            },
+            "Unit_AD": {
+                "Values": [
+                    "pA",
+                    "mV",
+                    "pA",
+                    "pA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    ""
+                ]
+            },
+            "Unit_AsyncAD": {
+                "Values": [
+                    "",
+                    "",
+                    "degC",
+                    "degC",
+                    "",
+                    "",
+                    "",
+                    ""
+                ]
+            },
+            "Unit_DA": {
+                "Values": [
+                    "mV",
+                    "pA",
+                    "mV",
+                    "mV",
+                    "",
+                    "",
+                    "",
+                    ""
+                ]
+            },
+            "Wave_DA": {
+                "Values": [
+                    "PulseTrain_20Hz_DA_0",
+                    "PulseTrain_20Hz_DA_0",
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -"
+                ]
+            },
+            "Wave_DA_All": {
+                "StrValue": "- none -"
+            },
+            "Wave_DA_AllIClamp": {
+                "StrValue": "PulseTrain_20Hz_DA_0"
+            },
+            "Wave_DA_AllVClamp": {
+                "StrValue": "PulseTrain_20Hz_DA_0"
+            },
+            "Wave_TTL": {
+                "Values": [
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -"
+                ]
+            },
+            "Wave_TTL_All": {
+                "StrValue": "- none -"
+            },
+            "button_SettingsPlus_LockDevice": {
+                "NumValue": 1
+            },
+            "check_AsyncAlarm": {
+                "Values": [
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false
+                ]
+            },
+            "check_DA_applyOnModeSwitch": {
+                "NumValue": false
+            },
+            "check_DatAcq_ApproachAll": {
+                "NumValue": false
+            },
+            "check_DatAcq_ApproachNear": {
+                "NumValue": false
+            },
+            "check_DatAcq_BBEnable": {
+                "NumValue": false
+            },
+            "check_DatAcq_BreakInAll": {
+                "NumValue": false
+            },
+            "check_DatAcq_CNEnable": {
+                "NumValue": false
+            },
+            "check_DatAcq_ClearEnable": {
+                "NumValue": false
+            },
+            "check_DatAcq_HoldEnable": {
+                "NumValue": false
+            },
+            "check_DatAcq_HoldEnableVC": {
+                "NumValue": false
+            },
+            "check_DatAcq_RsCompEnable": {
+                "NumValue": false
+            },
+            "check_DatAcq_SealALl": {
+                "NumValue": false
+            },
+            "check_DatAcq_SealAtm": {
+                "NumValue": false
+            },
+            "check_DatAcq_WholeCellEnable": {
+                "NumValue": false
+            },
+            "check_DataACq_Pressure_AutoOFF": {
+                "NumValue": false
+            },
+            "check_DataACq_Pressure_User": {
+                "NumValue": false
+            },
+            "check_DataAcq_Amp_Chain": {
+                "NumValue": false
+            },
+            "check_DataAcq_AutoBias": {
+                "NumValue": false
+            },
+            "check_DataAcq_IndexRandom": {
+                "NumValue": false
+            },
+            "check_DataAcq_ManPressureAll": {
+                "NumValue": false
+            },
+            "check_DataAcq_RepAcqRandom": {
+                "NumValue": false
+            },
+            "check_Settings_AmpIEQZstep": {
+                "NumValue": true
+            },
+            "check_Settings_AmpMCCdefault": {
+                "NumValue": false
+            },
+            "check_Settings_DisablePressure": {
+                "NumValue": false
+            },
+            "check_Settings_ITITP": {
+                "NumValue": true
+            },
+            "check_Settings_MD": {
+                "NumValue": true
+            },
+            "check_Settings_Option_3": {
+                "NumValue": false
+            },
+            "check_Settings_RequireAmpConn": {
+                "NumValue": true
+            },
+            "check_Settings_SaveAmpSettings": {
+                "NumValue": true
+            },
+            "check_Settings_ScalingZero": {
+                "NumValue": false
+            },
+            "check_Settings_SetOption_04": {
+                "NumValue": false
+            },
+            "check_Settings_ShowScopeWindow": {
+                "NumValue": true
+            },
+            "check_Settings_SyncMiesToMCC": {
+                "NumValue": false
+            },
+            "check_Settings_TPAfterDAQ": {
+                "NumValue": true
+            },
+            "check_Settings_TP_SaveTP": {
+                "NumValue": false
+            },
+            "check_Settings_UserP_Approach": {
+                "NumValue": false
+            },
+            "check_Settings_UserP_BreakIn": {
+                "NumValue": false
+            },
+            "check_Settings_UserP_Clear": {
+                "NumValue": false
+            },
+            "check_Settings_UserP_Seal": {
+                "NumValue": false
+            },
+            "check_settings_TP_show_peak": {
+                "NumValue": true
+            },
+            "check_settings_TP_show_steady": {
+                "NumValue": true
+            },
+            "check_settings_show_power": {
+                "NumValue": false
+            },
+            "max_AsyncAD": {
+                "Values": [
+                    0,
+                    0,
+                    34,
+                    34,
+                    0,
+                    0,
+                    0,
+                    0
+                ]
+            },
+            "min_AsyncAD": {
+                "Values": [
+                    0,
+                    0,
+                    -1,
+                    -1,
+                    0,
+                    0,
+                    0,
+                    0
+                ]
+            },
+            "popup_MoreSettings_Devices": {
+                "StrValue": "Dev1"
+            },
+            "setvar_DataAcq_AutoBiasV": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_AutoBiasVrange": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_BB": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_CN": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_Hold_IC": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_Hold_VC": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_IbiasMax": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_OnsetDelayUser": {
+                "NumValue": 500
+            },
+            "setvar_DataAcq_PPDuration": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_PPPressure": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_PipetteOffset_IC": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_PipetteOffset_VC": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_RsCorr": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_RsPred": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_SSPressure": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_TerminationDelay": {
+                "NumValue": 1000
+            },
+            "setvar_DataAcq_WCC": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_WCR": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_dDAQOptOvPost": {
+                "NumValue": 150
+            },
+            "setvar_DataAcq_dDAQOptOvPre": {
+                "NumValue": 0
+            },
+            "setvar_Settings_AutoBiasInt": {
+                "NumValue": 1
+            },
+            "setvar_Settings_AutoBiasPerc": {
+                "NumValue": 15
+            },
+            "setvar_Settings_DecMethodFac": {
+                "NumValue": -1
+            },
+            "setvar_Settings_InAirP": {
+                "NumValue": 3.799999952316284
+            },
+            "setvar_Settings_InBathP": {
+                "NumValue": 0.5
+            },
+            "setvar_Settings_InSliceP": {
+                "NumValue": 0.20000000298023224
+            },
+            "setvar_Settings_NearCellP": {
+                "NumValue": 0.6000000238418579
+            },
+            "setvar_Settings_OsciUpdExt": {
+                "NumValue": 10
+            },
+            "setvar_Settings_OsciUpdInt": {
+                "NumValue": 500
+            },
+            "setvar_Settings_Pressure_ADgain": {
+                "NumValue": 0.5
+            },
+            "setvar_Settings_Pressure_DAgain": {
+                "NumValue": 2
+            },
+            "setvar_Settings_SealMaxP": {
+                "NumValue": -1.399999976158142
+            },
+            "setvar_Settings_SealStartP": {
+                "NumValue": -0.10000000149011612
+            },
+            "setvar_Settings_SliceSurfHeight": {
+                "NumValue": 350
+            },
+            "setvar_Settings_SurfaceHeight": {
+                "NumValue": 3500
+            },
+            "setvar_Settings_TPBuffer": {
+                "NumValue": 1
+            },
+            "setvar_Settings_TP_RTolerance": {
+                "NumValue": 1
+            },
+            "slider_DataAcq_ActiveHeadstage": {
+                "NumValue": 1
+            },
+            "tab_DataAcq_Amp": {
+                "NumValue": 1
+            },
+            "tab_DataAcq_Pressure": {
+                "NumValue": 0
+            }
+        },
+        "Test Pulse ControlGroup": {
+            "SetVar_DataAcq_TPAmplitude": {
+                "NumValue": -10
+            },
+            "SetVar_DataAcq_TPAmplitudeIC": {
+                "NumValue": -50
+            },
+            "SetVar_DataAcq_TPBaselinePerc": {
+                "NumValue": 30
+            },
+            "SetVar_DataAcq_TPDuration": {
+                "NumValue": 10
+            }
+        }
+    },
+    "Target Window Type": "DA_Ephys"
+}

--- a/Packages/Settings/2_DataBrowser.json
+++ b/Packages/Settings/2_DataBrowser.json
@@ -1,0 +1,353 @@
+{
+    "DataBrowser": {
+        "Generic ControlGroup": {
+            "button_BSP_open": {
+                "NumValue": 0
+            }
+        }
+    },
+    "DataBrowser#BrowserSettingsPanel": {
+        "Generic ControlGroup": {
+            "SF_InfoTab": {
+                "NumValue": 0,
+                "StrValue": "Formula"
+            },
+            "Settings": {
+                "NumValue": 0,
+                "StrValue": "Settings"
+            },
+            "button_BrowserSettings_Export": {
+                "NumValue": 0
+            },
+            "button_Calculation_RestoreData": {
+                "NumValue": 0
+            },
+            "button_RemoveRanges": {
+                "NumValue": 0
+            },
+            "button_TimeAlignment_Action": {
+                "NumValue": 0
+            },
+            "button_sweepFormula_check": {
+                "NumValue": 0
+            },
+            "button_sweepFormula_display": {
+                "NumValue": 0
+            },
+            "check_BrowserSettings_ADC": {
+                "NumValue": true
+            },
+            "check_BrowserSettings_AR": {
+                "NumValue": false
+            },
+            "check_BrowserSettings_DAC": {
+                "NumValue": false
+            },
+            "check_BrowserSettings_DB_Failed": {
+                "NumValue": false
+            },
+            "check_BrowserSettings_DB_Passed": {
+                "NumValue": false
+            },
+            "check_BrowserSettings_OChan": {
+                "NumValue": false
+            },
+            "check_BrowserSettings_OVS": {
+                "NumValue": false
+            },
+            "check_BrowserSettings_PA": {
+                "NumValue": false
+            },
+            "check_BrowserSettings_TA": {
+                "NumValue": false
+            },
+            "check_BrowserSettings_TTL": {
+                "NumValue": false
+            },
+            "check_BrowserSettings_dDAQ": {
+                "NumValue": false
+            },
+            "check_BrowserSettings_splitTTL": {
+                "NumValue": false
+            },
+            "check_Calculation_AverageTraces": {
+                "NumValue": false
+            },
+            "check_Calculation_ZeroTraces": {
+                "NumValue": false
+            },
+            "check_Display_EqualYignore": {
+                "NumValue": false
+            },
+            "check_Display_EqualYrange": {
+                "NumValue": false
+            },
+            "check_Display_VisibleXrange": {
+                "NumValue": false
+            },
+            "check_SweepControl_HideSweep": {
+                "NumValue": false
+            },
+            "check_auto_remove": {
+                "NumValue": false
+            },
+            "check_channelSel_AD_0": {
+                "NumValue": true
+            },
+            "check_channelSel_AD_1": {
+                "NumValue": true
+            },
+            "check_channelSel_AD_10": {
+                "NumValue": true
+            },
+            "check_channelSel_AD_11": {
+                "NumValue": true
+            },
+            "check_channelSel_AD_12": {
+                "NumValue": true
+            },
+            "check_channelSel_AD_13": {
+                "NumValue": true
+            },
+            "check_channelSel_AD_14": {
+                "NumValue": true
+            },
+            "check_channelSel_AD_15": {
+                "NumValue": true
+            },
+            "check_channelSel_AD_2": {
+                "NumValue": true
+            },
+            "check_channelSel_AD_3": {
+                "NumValue": true
+            },
+            "check_channelSel_AD_4": {
+                "NumValue": true
+            },
+            "check_channelSel_AD_5": {
+                "NumValue": true
+            },
+            "check_channelSel_AD_6": {
+                "NumValue": true
+            },
+            "check_channelSel_AD_7": {
+                "NumValue": true
+            },
+            "check_channelSel_AD_8": {
+                "NumValue": true
+            },
+            "check_channelSel_AD_9": {
+                "NumValue": true
+            },
+            "check_channelSel_DA_0": {
+                "NumValue": true
+            },
+            "check_channelSel_DA_1": {
+                "NumValue": true
+            },
+            "check_channelSel_DA_2": {
+                "NumValue": true
+            },
+            "check_channelSel_DA_3": {
+                "NumValue": true
+            },
+            "check_channelSel_DA_4": {
+                "NumValue": true
+            },
+            "check_channelSel_DA_5": {
+                "NumValue": true
+            },
+            "check_channelSel_DA_6": {
+                "NumValue": true
+            },
+            "check_channelSel_DA_7": {
+                "NumValue": true
+            },
+            "check_channelSel_HEADSTAGE_0": {
+                "NumValue": true
+            },
+            "check_channelSel_HEADSTAGE_1": {
+                "NumValue": true
+            },
+            "check_channelSel_HEADSTAGE_2": {
+                "NumValue": true
+            },
+            "check_channelSel_HEADSTAGE_3": {
+                "NumValue": true
+            },
+            "check_channelSel_HEADSTAGE_4": {
+                "NumValue": true
+            },
+            "check_channelSel_HEADSTAGE_5": {
+                "NumValue": true
+            },
+            "check_channelSel_HEADSTAGE_6": {
+                "NumValue": true
+            },
+            "check_channelSel_HEADSTAGE_7": {
+                "NumValue": true
+            },
+            "check_highlightRanges": {
+                "NumValue": false
+            },
+            "check_overlaySweeps_disableHS": {
+                "NumValue": false
+            },
+            "check_overlaySweeps_non_commula": {
+                "NumValue": false
+            },
+            "check_ovs_clear_on_new_ra_cycle": {
+                "NumValue": false
+            },
+            "check_ovs_clear_on_new_stimset_cycle": {
+                "NumValue": false
+            },
+            "check_pulseAver_deconv": {
+                "NumValue": false
+            },
+            "check_pulseAver_indTraces": {
+                "NumValue": true
+            },
+            "check_pulseAver_multGraphs": {
+                "NumValue": false
+            },
+            "check_pulseAver_showAver": {
+                "NumValue": false
+            },
+            "check_pulseAver_timeAlign": {
+                "NumValue": false
+            },
+            "check_pulseAver_zeroTrac": {
+                "NumValue": false
+            },
+            "list_dashboard": {
+                "DataSource": "",
+                "NumValue": -1,
+                "StrValue": ""
+            },
+            "list_of_ranges": {
+                "DataSource": "",
+                "NumValue": 0,
+                "StrValue": ""
+            },
+            "list_of_ranges1": {
+                "DataSource": "",
+                "NumValue": 0,
+                "StrValue": ""
+            },
+            "popup_DB_lockedDevices": {
+                "NumValue": 1,
+                "StrValue": "- none -"
+            },
+            "popup_TimeAlignment_Master": {
+                "NumValue": 1,
+                "StrValue": "AD0"
+            },
+            "popup_TimeAlignment_Mode": {
+                "NumValue": 1,
+                "StrValue": "Level (Raising)"
+            },
+            "popup_overlaySweeps_select": {
+                "NumValue": 1,
+                "StrValue": "- none -"
+            },
+            "setvar_Display_EqualYlevel": {
+                "NumValue": 0
+            },
+            "setvar_TimeAlignment_LevelCross": {
+                "NumValue": 0
+            },
+            "setvar_cutoff_length_after": {
+                "NumValue": 0.2
+            },
+            "setvar_cutoff_length_before": {
+                "NumValue": 0.1
+            },
+            "setvar_overlaySweeps_offset": {
+                "NumValue": 0
+            },
+            "setvar_overlaySweeps_step": {
+                "NumValue": 1
+            },
+            "setvar_pulseAver_deconv_range": {
+                "NumValue": "Inf"
+            },
+            "setvar_pulseAver_deconv_smth": {
+                "NumValue": 1000
+            },
+            "setvar_pulseAver_deconv_tau": {
+                "NumValue": 15
+            },
+            "setvar_pulseAver_endPulse": {
+                "NumValue": "Inf"
+            },
+            "setvar_pulseAver_fallbackLength": {
+                "NumValue": 100
+            },
+            "setvar_pulseAver_startPulse": {
+                "NumValue": 0
+            },
+            "setvar_sweepFormula_parseResult": {
+                "StrValue": ""
+            },
+            "slider_BrowserSettings_dDAQ": {
+                "DataSource": "",
+                "NumValue": -1,
+                "StrValue": ""
+            },
+            "status_sweepFormula_parser": {
+                "NumValue": 1,
+                "StrValue": "1"
+            }
+        }
+    },
+    "DataBrowser#SettingsHistoryPanel": {
+        "Generic ControlGroup": {
+            "button_DataBrowser_setaxis": {
+                "NumValue": 0
+            },
+            "button_clearlabnotebookgraph": {
+                "NumValue": 0
+            },
+            "button_switchxaxis": {
+                "NumValue": 0
+            },
+            "popup_LBNumericalKeys": {
+                "NumValue": 1,
+                "StrValue": "- none -"
+            },
+            "popup_LBTextualKeys": {
+                "NumValue": 1,
+                "StrValue": "- none -"
+            }
+        }
+    },
+    "DataBrowser#SweepControl": {
+        "Generic ControlGroup": {
+            "Popup_SweepControl_Selector": {
+                "NumValue": 1,
+                "StrValue": " "
+            },
+            "button_SweepControl_NextSweep": {
+                "NumValue": 0
+            },
+            "button_SweepControl_PrevSweep": {
+                "NumValue": 0
+            },
+            "check_SweepControl_AutoUpdate": {
+                "NumValue": false
+            },
+            "setvar_SweepControl_SweepNo": {
+                "NumValue": 0
+            },
+            "setvar_SweepControl_SweepStep": {
+                "NumValue": 1
+            },
+            "valdisp_SweepControl_LastSweep": {
+                "NumValue": 0,
+                "StrValue": "0"
+            }
+        }
+    },
+    "Target Window Type": "DataBrowser"
+}

--- a/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
+++ b/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
@@ -4,6 +4,9 @@
 
 /// @file UTF_BasicHardWareTests.ipf Implement some basic tests using the ITC hardware.
 
+static StrConstant REF_DAEPHYS_CONFIG_FILE = "DA_Ephys.json"
+static StrConstant REF_TMP1_CONFIG_FILE = "UserConfigTemplate_Temp1.txt"
+
 static Function SetAnalysisFunctions_IGNORE()
 
 	WAVE/T wv = root:MIES:WaveBuilder:SavedStimulusSetParameters:DA:WPT_StimulusSetA_DA_0
@@ -3497,4 +3500,28 @@ Function/S RemoveTrailingNumber_IGNORE(str)
 	CHECK_EQUAL_VAR(ItemsInList(str, "_"), 2)
 
 	return StringFromList(0, str, "_")
+End
+
+// UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
+Function RestoreDAEphysPanel([str])
+	string str
+
+	variable jsonID
+	string stimSetPath, jPath, data, fName
+
+	[data, fName] = LoadTextFile(REF_DAEPHYS_CONFIG_FILE)
+
+	jsonID = JSON_Parse(data)
+	PathInfo home
+	jPath = MIES_CONF#CONF_FindControl(jsonID, "popup_MoreSettings_Devices")
+	JSON_SetString(jsonID, jPath + "/StrValue", str)
+	JSON_SetString(jsonID, "/Common configuration data/Save data to", S_path)
+	stimSetPath = S_path + "..:..:Packages:Testing-MIES:_2017_09_01_192934-compressed.nwb"
+	JSON_SetString(jsonID, "/Common configuration data/Stim set file name", stimSetPath)
+
+	CONF_RestoreDAEphys(jsonID, "")
+	MIES_CONF#CONF_SaveDAEphys(REF_TMP1_CONFIG_FILE)
+
+	CONF_RestoreDAEphys(jsonID, "", middleOfExperiment = 1)
+	MIES_CONF#CONF_SaveDAEphys(REF_TMP1_CONFIG_FILE)
 End

--- a/Packages/Testing-MIES/UTF_Configuration.ipf
+++ b/Packages/Testing-MIES/UTF_Configuration.ipf
@@ -1,0 +1,309 @@
+#pragma TextEncoding = "UTF-8"
+#pragma rtGlobals=3 // Use modern global access method and strict wave access.
+#pragma ModuleName=ConfigurationTest
+
+// If this moves to an independend test, uncomment the following line
+//#include "unit-testing"
+
+/// @file UTF_ConfigurationTest.ipf
+/// @brief __CONFIG_Test__ This file holds the tests for the Configuration saving/loading
+
+static StrConstant REF_CONFIG_FILE = "ConfigurationTest.txt"
+static StrConstant REF_CONFIG_FILE_RELEVANT = "ConfigurationTest_Relevant.txt"
+static StrConstant REF_TMP1_CONFIG_FILE = "ConfigurationTest_temp1.txt"
+static StrConstant REF_TMP2_CONFIG_FILE = "ConfigurationTest_temp2.txt"
+static StrConstant REF_DUP1_CONFIG_FILE = "ConfigurationTest_DupCheck1.txt"
+static StrConstant REF_DUP2_CONFIG_FILE = "ConfigurationTest_DupCheck2.txt"
+static Constant CHECKBOX_CLICKED = 1
+static Constant RADIO3_CLICKED = 2
+
+/// @brief Open a fresh template panel
+static Function TEST_CASE_BEGIN_OVERRIDE(testCase)
+	string testCase
+
+	Execute "MainPanel()"
+	variable/G priorityFlag = 0
+End
+
+/// @brief Cleans up failing tests
+static Function TEST_CASE_END_OVERRIDE(testCase)
+	string testCase
+
+	KillWindow/Z MainPanel
+End
+
+Window MainPanel() : Panel
+	PauseUpdate; Silent 1		// building window...
+	NewPanel /W=(1113,368,1711,766)
+	ShowTools/A
+	SetDrawLayer UserBack
+	Button button,pos={0.00,0.00},size={50.00,20.00},title="button"
+	Button button,userdata(Config_PushButtonOnRestore)=  "1"
+	CheckBox CheckBox,pos={60.00,0.00},size={68.00,15.00},title="CheckBox",value= 1
+	CheckBox CheckBox,userdata(Config_RestorePriority)=  "10"
+	CheckBox CheckBox,userdata(Config_NiceName)=  "Check Me"
+	CheckBox CheckBox,userdata(Config_JSONPath)=  "The real important controls"
+	CheckBox CheckBox proc=TCONF_CheckProc
+	PopupMenu popup,pos={138.00,0.00},size={77.00,19.00},title="popup"
+	PopupMenu popup,mode=1,popvalue="Yes",value= #"\"Yes;No;Maybe\""
+	ValDisplay valdisp,pos={225.00,0.00},size={93.00,17.00},title="valdisp"
+	ValDisplay valdisp,limits={0,0,0},barmisc={0,1000},value=1337
+	ValDisplay valdisp,userdata(Config_RestorePriority)=  "10"
+	SetVariable setvar,pos={328.00,0.00},size={137.00,18.00},title="setvar"
+	Slider slider,pos={0.00,25.00},size={589.00,56.00},labelBack=(65535,49151,55704)
+	Slider slider,fColor=(19729,1,39321)
+	Slider slider,userdata(Config_GroupPath)="level1;level2;"
+	Slider slider,limits={0,100,1},value= 25,side= 2,vert= 0,ticks= 7,thumbColor= (65535,0,0)
+	TabControl tab,pos={1.00,86.00},size={266.00,25.00}
+	TabControl tab,labelBack=(49151,65535,49151),fColor=(1,3,39321)
+	TabControl tab,tabLabel(0)="Tab 0",tabLabel(1)="Tab 1",tabLabel(2)="Tab 2"
+	TabControl tab,tabLabel(3)="Tab 3",tabLabel(4)="Tab 4",value= 3
+	TitleBox titlebox,pos={4.00,113.00},size={47.00,23.00},title="titlebox"
+	TitleBox titlebox,labelBack=(49151,65535,49151)
+	GroupBox groupbox,pos={61.00,113.00},size={131.00,73.00},title="groupbox"
+	GroupBox groupbox,labelBack=(65535,65534,49151)
+	ListBox listbox,pos={202.00,113.00},size={159.00,73.00}
+	Chart chart,pos={371.00,113.00},size={108.00,74.00}
+	CustomControl customcontrol,pos={489.00,113.00},size={102.00,74.00}
+	CheckBox Radio1,pos={288.00,206.00},size={52.00,15.00},title="Radio1"
+	CheckBox Radio1,value= 0,mode=1
+	CheckBox Radio2,pos={290.00,232.00},size={52.00,15.00},title="Radio2"
+	CheckBox Radio2,value= 0,mode=1
+	CheckBox Radio3,pos={290.00,259.00},size={52.00,15.00},title="Radio3"
+	CheckBox Radio3,value= 1,mode=1
+	CheckBox Radio3 proc=TCONF_CheckProc
+	NewPanel/W=(11,203,273,387)/HOST=# 
+	ModifyPanel cbRGB=(32768,40777,65535)
+	CheckBox checkbox1,pos={10.00,10.00},size={70.00,15.00},title="TrueColor"
+	CheckBox checkbox1,userdata(ControlArray)=  "ctrlArray"
+	CheckBox checkbox1,userdata(ControlArrayIndex)=  "0",fStyle=1,fColor=(1,3,39321)
+	CheckBox checkbox1,value= 0
+	CheckBox checkbox2,pos={10.00,36.00},size={81.00,15.00},title="Accelerator"
+	CheckBox checkbox2,userdata(ControlArray)=  "ctrlArray"
+	CheckBox checkbox2,userdata(ControlArrayIndex)=  "1",fStyle=1,fColor=(1,3,39321)
+	CheckBox checkbox2,value= 0
+	CheckBox checkbox3,pos={11.00,63.00},size={78.00,15.00},title="superscalar"
+	CheckBox checkbox3,userdata(ControlArray)=  "ctrlArray"
+	CheckBox checkbox3,userdata(ControlArrayIndex)=  "2",fStyle=1,fColor=(1,3,39321)
+	CheckBox checkbox3,value= 0
+	CheckBox checkbox4,pos={11.00,91.00},size={106.00,15.00},title="next generation"
+	CheckBox checkbox4,userdata(ControlArray)=  "ctrlArray"
+	CheckBox checkbox4,userdata(ControlArrayIndex)=  "3",fStyle=1,fColor=(1,3,39321)
+	CheckBox checkbox4,value= 0
+	Button button1,pos={18.00,125.00},size={104.00,55.00},title="Select Best"
+	Button button1,userdata(ControlArray)=  "ctrlArray"
+	Button button1,userdata(ControlArrayIndex)=  "4",labelBack=(65535,0,0)
+	Button button1,font="Trebuchet MS",fSize=18,fStyle=1,fColor=(65535,0,0)
+	Button button1,valueColor=(65535,65535,0)
+	PopupMenu popup,pos={135.00,14.00},size={116.00,19.00},title="Computer"
+	PopupMenu popup,userdata(ControlArray)=  "ctrlArray"
+	PopupMenu popup,userdata(ControlArrayIndex)=  "6",fStyle=1,fColor=(1,3,39321)
+	PopupMenu popup,mode=1,popvalue="Amiga",value= #"\"Amiga;Atari ST\""
+	RenameWindow #,SubPanel
+	SetActiveSubwindow ##
+	SetWindow kwTopWin,userdata(Config_RadioCouplingFunc)=  "ConfigurationTest#TCONF_RadioCoupling"
+EndMacro
+
+/// @brief RadioCoupling function for MainPanel, referred checkboxes are not actually implemented coupled.
+Function/WAVE TCONF_RadioCoupling()
+	
+	Make/FREE/T/N=1 w
+	w[0] = "Radio1;Radio2;Radio3;"
+	return w
+End
+
+/// @brief CheckBox proc helper to check Config_RestorePriority
+Function TCONF_CheckProc(cba) : CheckBoxControl
+	struct WMCheckboxAction &cba
+
+	string ctrlName
+
+	switch( cba.eventCode )
+		case 2: // mouse up
+			NVAR priorityFlag
+			ctrlName = cba.ctrlName
+			if(!CmpStr(ctrlName, "CheckBox"))
+				priorityFlag = CHECKBOX_CLICKED
+			elseif(!CmpStr(ctrlName, "Radio3"))
+				priorityFlag = RADIO3_CLICKED
+			endif
+			break
+	endswitch
+
+	return 0
+End
+
+static Function TCONF_ChangeGUIValues_IGNORE()
+	CheckBox CheckBox value=0
+	PopupMenu popup popvalue="Maybe"
+	ValDisplay valdisp value= _NUM:0
+	TabControl tab value=1
+	CheckBox Radio3 value=0
+	SetVariable setvar value=setvarTest
+	CheckBox checkbox3 win=#SubPanel, value=0
+	PopupMenu popup win=#SubPanel, popvalue="Atari ST"
+End
+
+/// @brief Saves a json to a text file in home path
+static Function TCONF_SaveJSON(jsonID, fName)
+	variable jsonID
+	string fName
+
+	string out
+	variable fnum
+
+	out = JSON_Dump(jsonID, indent = 2)
+	SaveTextFile(out, fName)
+End
+
+/// @brief helper function to compare two text files
+static Function TCONF_CompareTextFiles(fName1, fName2)
+	string fName1, fName2
+
+	string s1, s2
+
+	[s1, fName1] = LoadTextFile(fName1)
+	[s2, fName2] = LoadTextFile(fName2)
+
+	Make/FREE/T w1 = { TrimString(s1) }
+	Make/FREE/T w2 = { TrimString(s2) }
+
+	CHECK_EQUAL_WAVES(w1, w2)
+End
+
+/// @brief Save Test Panel and check against reference template
+static Function TCONF_Save()
+
+	string fName1 = "ConfigurationTest_compare1.txt"
+	
+	CONF_SaveWindow(fName1)
+
+	TCONF_CompareTextFiles(fName1, REF_CONFIG_FILE)
+End
+
+/// @brief Change Test Panel and Load, then save and check against reference template
+static Function TCONF_Load()
+
+	string fName1 = "ConfigurationTest_compare1.txt"
+	
+	variable/G setvarTest
+	
+	TCONF_ChangeGUIValues_IGNORE()
+	
+	CONF_RestoreWindow(REF_CONFIG_FILE)
+
+	NVAR priorityFlag
+	CHECK_EQUAL_VAR(priorityFlag, RADIO3_CLICKED)
+
+	CONF_SaveWindow(fName1)
+
+	TCONF_CompareTextFiles(fName1, REF_CONFIG_FILE)
+End
+
+
+/// @brief Save Window with all relevant mask bits - Change Window - Restore it, compare to initial state
+static Function TCONF_AllStates()
+
+	string wName
+	variable jsonID, jsonID2, saveMask
+
+	wName = GetMainWindow(GetCurrentWindow())
+	saveMask = EXPCONFIG_SAVE_VALUE | EXPCONFIG_SAVE_POSITION | EXPCONFIG_SAVE_USERDATA | EXPCONFIG_SAVE_DISABLED | EXPCONFIG_SAVE_CTRLTYPE
+	ModifyControl valdisp win=$wName, userdata(testdata)="testdata"
+	ModifyControl valdisp win=$wName, userdata(testdatabase64)="\u0000"
+	jsonID = CONF_AllWindowsToJSON(wName, saveMask)
+
+	ModifyControl valdisp win=$wName, align=1, size={100, 100}, pos={10, 10}
+	DisableControl(wName, "valdisp")
+	CONF_JSONToWindow(wName, saveMask, jsonID)
+	jsonID2 = CONF_AllWindowsToJSON(wName, saveMask)
+	TCONF_SaveJSON(jsonID, REF_TMP1_CONFIG_FILE)
+	TCONF_SaveJSON(jsonID2, REF_TMP2_CONFIG_FILE)
+	TCONF_CompareTextFiles(REF_TMP2_CONFIG_FILE, REF_TMP1_CONFIG_FILE)
+End
+
+/// @brief RoundTrip with Save Only Relevant, compared to initial template file
+static Function TCONF_RelevantValues()
+
+	string wName
+	variable jsonID, jsonID2, saveMask
+
+	wName = GetMainWindow(GetCurrentWindow())
+	saveMask = EXPCONFIG_SAVE_ONLY_RELEVANT | EXPCONFIG_SAVE_VALUE
+	jsonID = CONF_AllWindowsToJSON(wName, saveMask)
+
+	TCONF_ChangeGUIValues_IGNORE()
+
+	CONF_JSONToWindow(wName, saveMask, jsonID)
+	jsonID2 = CONF_AllWindowsToJSON(wName, saveMask)
+	TCONF_SaveJSON(jsonID, REF_TMP1_CONFIG_FILE)
+	TCONF_SaveJSON(jsonID2, REF_TMP2_CONFIG_FILE)
+	TCONF_CompareTextFiles(REF_TMP2_CONFIG_FILE, REF_CONFIG_FILE_RELEVANT)
+End
+
+/// @brief Check for Duplicate NiceNames on Save
+static Function TCONF_DupNiceName()
+
+	string wName
+
+	wName = GetMainWindow(GetCurrentWindow())
+	CheckBox CheckBox win=$wName, userdata(Config_NiceName)=  "BUTTON"
+	try
+		CONF_SaveWindow(REF_TMP1_CONFIG_FILE)
+		FAIL()
+	catch
+		PASS()
+	endtry
+End
+
+/// @brief Check for Reserved NiceNames - CtrlGroup Suffix on Save
+static Function TCONF_ReservedNiceName()
+
+	string wName
+
+	wName = GetMainWindow(GetCurrentWindow())
+	CheckBox CheckBox win=$wName, userdata(Config_NiceName)=  "BUTTON ControlGroup"
+	try
+		CONF_SaveWindow(REF_TMP1_CONFIG_FILE)
+		FAIL()
+	catch
+		PASS()
+	endtry
+End
+
+/// @brief Check for Duplicate CtrlArrayNames on Save
+static Function TCONF_DupCtrlArrayName()
+
+	string wName
+
+	wName = GetMainWindow(GetCurrentWindow())
+	CheckBox CheckBox win=$wName, userdata(ControlArray)=  "BUTTON"
+	try
+		CONF_SaveWindow(REF_TMP1_CONFIG_FILE)
+		FAIL()
+	catch
+		PASS()
+	endtry
+End
+
+/// @brief Check for Duplicate NiceNames on Restore
+static Function TCONF_DupNiceNameRestore()
+
+	try
+		CONF_RestoreWindow(REF_DUP1_CONFIG_FILE)
+		FAIL()
+	catch
+		PASS()
+	endtry
+End
+
+/// @brief Check for Duplicate CtrlArrayNames on Restore
+static Function TCONF_DupCtrlArrayNameRestore()
+
+	try
+		CONF_RestoreWindow(REF_DUP2_CONFIG_FILE)
+		FAIL()
+	catch
+		PASS()
+	endtry
+End

--- a/Packages/Testing-MIES/UTF_Main.ipf
+++ b/Packages/Testing-MIES/UTF_Main.ipf
@@ -14,6 +14,7 @@
 #include "UTF_WaveVersioning"
 #include "UTF_AsynFrameworkTest"
 #include "UTF_SweepFormula"
+#include "UTF_Configuration"
 
 Function run()
 	// speeds up testing to start with a fresh copy
@@ -23,7 +24,7 @@ Function run()
 	string procList = ""
 	procList += "UTF_AnalysisFunctionHelpers.ipf;UTF_WaveVersioning.ipf;UTF_UpgradeWaveLocationAndGetIt.ipf;"
 	procList += "UTF_Utils.ipf;UTF_Labnotebook.ipf;UTF_WaveBuilder.ipf;UTF_PGCSetAndActivateControl.ipf;"
-	procList += "UTF_UpgradeDataFolderLocation.ipf;UTF_AsynFrameworkTest.ipf;UTF_SweepFormula.ipf;"
+	procList += "UTF_UpgradeDataFolderLocation.ipf;UTF_AsynFrameworkTest.ipf;UTF_SweepFormula.ipf;UTF_Configuration.ipf;"
 
 	RunTest(procList, enableJU = 1)
 End

--- a/tools/unit-testing/ConfigurationTest.txt
+++ b/tools/unit-testing/ConfigurationTest.txt
@@ -1,0 +1,64 @@
+{
+    "MainPanel": {
+        "Generic ControlGroup": {
+            "Check Me": {
+                "NumValue": true
+            },
+            "Radio3": {
+                "NumValue": true
+            },
+            "button": {
+                "NumValue": 0
+            },
+            "chart": {
+                "NumValue": 0,
+                "StrValue": "FNAME:;NCHANS:0;PPSTRIP:1;RHSAMP:0;LHSAMP:-100;"
+            },
+            "listbox": {
+                "DataSource": "",
+                "NumValue": 0,
+                "StrValue": ""
+            },
+            "popup": {
+                "NumValue": 1,
+                "StrValue": "Yes"
+            },
+            "setvar": {
+                "DataSource": ""
+            },
+            "tab": {
+                "NumValue": 3,
+                "StrValue": "Tab 3"
+            },
+            "valdisp": {
+                "NumValue": 1337,
+                "StrValue": "1337"
+            }
+        },
+        "level1 ControlGroup": {
+            "level2 ControlGroup": {
+                "slider": {
+                    "DataSource": "",
+                    "NumValue": 25,
+                    "StrValue": ""
+                }
+            }
+        }
+    },
+    "MainPanel#SubPanel": {
+        "Generic ControlGroup": {
+            "ctrlArray": {
+                "Values": [
+                    false,
+                    false,
+                    false,
+                    false,
+                    0,
+                    null,
+                    "Amiga"
+                ]
+            }
+        }
+    },
+    "Target Window Type": ""
+}

--- a/tools/unit-testing/ConfigurationTest_DupCheck1.txt
+++ b/tools/unit-testing/ConfigurationTest_DupCheck1.txt
@@ -1,0 +1,66 @@
+{
+  "MainPanel": {
+    "Generic ControlGroup": {
+      "checkbox": {
+        "NumValue": true
+      },
+      "button": {
+        "NumValue": 0
+      },
+      "chart": {
+        "NumValue": 0,
+        "StrValue": "FNAME:;NCHANS:0;PPSTRIP:1;RHSAMP:0;LHSAMP:-100;"
+      },
+      "listbox": {
+        "DataSource": "",
+        "NumValue": 0,
+        "StrValue": ""
+      },
+      "popup": {
+        "NumValue": 1,
+        "StrValue": "Yes"
+      },
+      "setvar": {
+        "DataSource": ""
+      },
+      "slider": {
+        "DataSource": "",
+        "NumValue": 25,
+        "StrValue": ""
+      },
+      "tab": {
+        "NumValue": 3,
+        "StrValue": "Tab 3"
+      },
+      "valdisp": {
+        "NumValue": 1337,
+        "StrValue": "1337"
+      }
+    },
+    "The real important controls ControlGroup": {
+      "Check Me": {
+        "NumValue": 123
+      }
+    },
+    "The not important controls ControlGroup": {
+      "Check Me": {
+        "NumValue": true
+      }
+    }
+  },
+  "MainPanel#SubPanel": {
+    "Generic": {
+      "ctrlArray": {
+        "Values": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          null,
+          "Amiga"
+        ]
+      }
+    }
+  }
+}

--- a/tools/unit-testing/ConfigurationTest_DupCheck2.txt
+++ b/tools/unit-testing/ConfigurationTest_DupCheck2.txt
@@ -1,0 +1,66 @@
+{
+  "MainPanel": {
+    "Generic ControlGroup": {
+      "Radio3": {
+        "NumValue": true
+      },
+      "button": {
+        "NumValue": 0
+      },
+      "chart": {
+        "NumValue": 0,
+        "StrValue": "FNAME:;NCHANS:0;PPSTRIP:1;RHSAMP:0;LHSAMP:-100;"
+      },
+      "listbox": {
+        "DataSource": "",
+        "NumValue": 0,
+        "StrValue": ""
+      },
+      "popup": {
+        "NumValue": 1,
+        "StrValue": "Yes"
+      },
+      "setvar": {
+        "DataSource": ""
+      },
+      "slider": {
+        "DataSource": "",
+        "NumValue": 25,
+        "StrValue": ""
+      },
+      "tab": {
+        "NumValue": 3,
+        "StrValue": "Tab 3"
+      },
+      "valdisp": {
+        "NumValue": 1337,
+        "StrValue": "1337"
+      }
+    },
+    "The real important controls ControlGroup": {
+      "Check Me": {
+        "NumValue": true
+      }
+    }
+  },
+  "MainPanel#SubPanel": {
+    "Generic ControlGroup": {
+      "button": {
+        "Values": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          null,
+          "Amiga"
+        ]
+      }
+    },
+    "The real important controls ControlGroup": {
+      "button": {
+        "NumValue": true
+      }
+    }
+  }
+}

--- a/tools/unit-testing/ConfigurationTest_Relevant.txt
+++ b/tools/unit-testing/ConfigurationTest_Relevant.txt
@@ -1,0 +1,65 @@
+{
+  "MainPanel": {
+    "Generic ControlGroup": {
+      "Check Me": {
+        "NumValue": true
+      },
+      "Radio3": {
+        "NumValue": true
+      },
+      "button": {
+        "NumValue": 1
+      },
+      "chart": {
+        "StrValue": "FNAME:;NCHANS:0;PPSTRIP:1;RHSAMP:0;LHSAMP:-100;"
+      },
+      "customcontrol": {
+        "NumValue": 0
+      },
+      "groupbox": {
+        "StrValue": "groupbox"
+      },
+      "listbox": {
+        "DataSource": ""
+      },
+      "popup": {
+        "StrValue": "Yes"
+      },
+      "setvar": {
+        "DataSource": ""
+      },
+      "tab": {
+        "NumValue": 3
+      },
+      "titlebox": {
+        "DataSource": ""
+      },
+      "valdisp": {
+        "NumValue": 1337
+      }
+    },
+    "level1 ControlGroup": {
+      "level2 ControlGroup": {
+        "slider": {
+          "NumValue": 25
+        }
+      }
+    }
+  },
+  "MainPanel#SubPanel": {
+    "Generic ControlGroup": {
+      "ctrlArray": {
+        "Values": [
+          false,
+          false,
+          false,
+          false,
+          1,
+          null,
+          "Amiga"
+        ]
+      }
+    }
+  },
+  "Target Window Type": ""
+}

--- a/tools/unit-testing/DA_Ephys.json
+++ b/tools/unit-testing/DA_Ephys.json
@@ -1,0 +1,796 @@
+{
+    "Common configuration data": {
+        "Headstage Association": {
+            "0": {
+                "Amplifier Serial": 0,
+                "Amplifier Title": "0,1",
+                "IC AD": 0,
+                "IC DA": 0,
+                "Pressure AD": 0,
+                "Pressure AD Gain": 0.5,
+                "Pressure AD Unit": "psi",
+                "Pressure Constant Negative": 0,
+                "Pressure Constant Positive": 0,
+                "Pressure DA": 0,
+                "Pressure DA Gain": 2,
+                "Pressure DA Unit": "psi",
+                "Pressure Device": "- none -",
+                "Pressure TTLA": 0,
+                "Pressure TTLB": 1,
+                "VC AD": 0,
+                "VC DA": 0
+            },
+            "1": {
+                "Amplifier Serial": 0,
+                "Amplifier Title": "0,1",
+                "IC AD": 1,
+                "IC DA": 1,
+                "Pressure AD": 1,
+                "Pressure AD Gain": 0.5,
+                "Pressure AD Unit": "psi",
+                "Pressure Constant Negative": 0,
+                "Pressure Constant Positive": 0,
+                "Pressure DA": 1,
+                "Pressure DA Gain": 2,
+                "Pressure DA Unit": "psi",
+                "Pressure Device": "- none -",
+                "Pressure TTLA": 2,
+                "Pressure TTLB": 3,
+                "VC AD": 1,
+                "VC DA": 1
+            },
+            "2": null,
+            "3": null,
+            "4": null,
+            "5": null,
+            "6": null,
+            "7": null
+        },
+        "Position MCCs": "- none -",
+        "Save data to": "C:MiesSave",
+        "Stim set file name": "",
+        "User Pressure Devices": {
+            "DAC Device": "- none -",
+            "Pressure DA": 0
+        }
+    },
+    "Dev1": {
+        "Generic ControlGroup": {
+            "ADC": {
+                "NumValue": 0
+            },
+            "Check_AD": {
+                "Values": [
+                    true,
+                    true,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false
+                ]
+            },
+            "Check_AD_All": {
+                "NumValue": false
+            },
+            "Check_AsyncAD": {
+                "Values": [
+                    false,
+                    false,
+                    true,
+                    true,
+                    false,
+                    false,
+                    false,
+                    false
+                ]
+            },
+            "Check_DA": {
+                "Values": [
+                    true,
+                    true,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false
+                ]
+            },
+            "Check_DA_ALL": {
+                "NumValue": false
+            },
+            "Check_DA_AllIClamp": {
+                "NumValue": false
+            },
+            "Check_DA_AllVClamp": {
+                "NumValue": false
+            },
+            "Check_DataAcq1_DistribDaq": {
+                "NumValue": false
+            },
+            "Check_DataAcq1_RepeatAcq": {
+                "NumValue": true
+            },
+            "Check_DataAcq1_dDAQOptOv": {
+                "NumValue": true
+            },
+            "Check_DataAcqHS": {
+                "Values": [
+                    true,
+                    true,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false
+                ]
+            },
+            "Check_DataAcqHS_All": {
+                "NumValue": false
+            },
+            "Check_DataAcq_Get_Set_ITI": {
+                "NumValue": true
+            },
+            "Check_DataAcq_Indexing": {
+                "NumValue": false
+            },
+            "Check_DataAcq_SendToAllAmp": {
+                "NumValue": true
+            },
+            "Check_Settings_AlarmAutoRepeat": {
+                "NumValue": false
+            },
+            "Check_Settings_AlarmPauseAcq": {
+                "NumValue": false
+            },
+            "Check_Settings_Append": {
+                "NumValue": false
+            },
+            "Check_Settings_BackgrndDataAcq": {
+                "NumValue": true
+            },
+            "Check_Settings_BkgTP": {
+                "NumValue": true
+            },
+            "Check_Settings_ITImanualStart": {
+                "NumValue": false
+            },
+            "Check_Settings_InsertTP": {
+                "NumValue": true
+            },
+            "Check_Settings_NwbExport": {
+                "NumValue": false
+            },
+            "Check_Settings_SkipAnalysFuncs": {
+                "NumValue": true
+            },
+            "Check_Settings_TrigIn": {
+                "NumValue": false
+            },
+            "Check_Settings_TrigOut": {
+                "NumValue": false
+            },
+            "Check_Settings_UseDoublePrec": {
+                "NumValue": false
+            },
+            "Check_TTL": {
+                "Values": [
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false
+                ]
+            },
+            "Check_TTL_ALL": {
+                "NumValue": false
+            },
+            "Gain_AD": {
+                "Values": [
+                    0.0005000000237487257,
+                    0.05000000074505806,
+                    1,
+                    1,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                ]
+            },
+            "Gain_AsyncAD": {
+                "Values": [
+                    1,
+                    1,
+                    0.01,
+                    0.01,
+                    1,
+                    1,
+                    1,
+                    1
+                ]
+            },
+            "Gain_DA": {
+                "Values": [
+                    20,
+                    400,
+                    1,
+                    1,
+                    0,
+                    0,
+                    0,
+                    0
+                ]
+            },
+            "Headstage_0_VC": {
+                "NumValue": true
+            },
+            "Headstage_1_IC": {
+                "NumValue": true
+            },
+            "Headstage_2_VC": {
+                "NumValue": true
+            },
+            "Headstage_3_VC": {
+                "NumValue": true
+            },
+            "Headstage_4_VC": {
+                "NumValue": true
+            },
+            "Headstage_5_VC": {
+                "NumValue": true
+            },
+            "Headstage_6_VC": {
+                "NumValue": true
+            },
+            "Headstage_7_VC": {
+                "NumValue": true
+            },
+            "IndexEnd_DA": {
+                "Values": [
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -"
+                ]
+            },
+            "IndexEnd_DA_All": {
+                "StrValue": "- none -"
+            },
+            "IndexEnd_DA_AllIClamp": {
+                "StrValue": "- none -"
+            },
+            "IndexEnd_DA_AllVClamp": {
+                "StrValue": "- none -"
+            },
+            "IndexEnd_TTL": {
+                "Values": [
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -"
+                ]
+            },
+            "IndexEnd_TTL_All": {
+                "StrValue": "- none -"
+            },
+            "Popup_Settings_DecMethod": {
+                "StrValue": "MinMax"
+            },
+            "Popup_Settings_FixedFreq": {
+                "StrValue": "Maximum"
+            },
+            "Popup_Settings_OsciUpdMode": {
+                "StrValue": "Interval"
+            },
+            "Popup_Settings_SampIntMult": {
+                "StrValue": "1"
+            },
+            "Scale_DA": {
+                "Values": [
+                    70,
+                    1500,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1
+                ]
+            },
+            "Scale_DA_All": {
+                "NumValue": 1
+            },
+            "Scale_DA_AllIClamp": {
+                "NumValue": 1500
+            },
+            "Scale_DA_AllVClamp": {
+                "NumValue": 70
+            },
+            "Search_DA": {
+                "Values": [
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    ""
+                ]
+            },
+            "Search_DA_All": {
+                "StrValue": ""
+            },
+            "Search_DA_AllIClamp": {
+                "StrValue": ""
+            },
+            "Search_DA_AllVClamp": {
+                "StrValue": ""
+            },
+            "Search_TTL": {
+                "Values": [
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    ""
+                ]
+            },
+            "Search_TTL_All": {
+                "StrValue": ""
+            },
+            "SetVar_DataAcq_Comment": {
+                "StrValue": ""
+            },
+            "SetVar_DataAcq_ITI": {
+                "NumValue": 0.015
+            },
+            "SetVar_DataAcq_ListRepeats": {
+                "NumValue": 1
+            },
+            "SetVar_DataAcq_SetRepeats": {
+                "NumValue": 5
+            },
+            "SetVar_DataAcq_skipAhead": {
+                "NumValue": 0
+            },
+            "SetVar_Hardware_Pressur_AD_Unit": {
+                "StrValue": "psi"
+            },
+            "SetVar_Hardware_Pressur_DA_Unit": {
+                "StrValue": "psi"
+            },
+            "SetVar_Sweep": {
+                "NumValue": 0
+            },
+            "Setvar_DataAcq_dDAQDelay": {
+                "NumValue": 0
+            },
+            "Title_AsyncAD": {
+                "Values": [
+                    "",
+                    "",
+                    "Set Temperature",
+                    "Bath Temperature",
+                    "",
+                    "",
+                    "",
+                    ""
+                ]
+            },
+            "Unit_AD": {
+                "Values": [
+                    "pA",
+                    "mV",
+                    "pA",
+                    "pA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    ""
+                ]
+            },
+            "Unit_AsyncAD": {
+                "Values": [
+                    "",
+                    "",
+                    "degC",
+                    "degC",
+                    "",
+                    "",
+                    "",
+                    ""
+                ]
+            },
+            "Unit_DA": {
+                "Values": [
+                    "mV",
+                    "pA",
+                    "mV",
+                    "mV",
+                    "",
+                    "",
+                    "",
+                    ""
+                ]
+            },
+            "Wave_DA": {
+                "Values": [
+                    "PulseTrain_20Hz_DA_0",
+                    "PulseTrain_20Hz_DA_0",
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -"
+                ]
+            },
+            "Wave_DA_All": {
+                "StrValue": "- none -"
+            },
+            "Wave_DA_AllIClamp": {
+                "StrValue": "PulseTrain_20Hz_DA_0"
+            },
+            "Wave_DA_AllVClamp": {
+                "StrValue": "PulseTrain_20Hz_DA_0"
+            },
+            "Wave_TTL": {
+                "Values": [
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -",
+                    "- none -"
+                ]
+            },
+            "Wave_TTL_All": {
+                "StrValue": "- none -"
+            },
+            "button_SettingsPlus_LockDevice": {
+                "NumValue": 1
+            },
+            "check_AsyncAlarm": {
+                "Values": [
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false
+                ]
+            },
+            "check_DA_applyOnModeSwitch": {
+                "NumValue": false
+            },
+            "check_DatAcq_ApproachAll": {
+                "NumValue": false
+            },
+            "check_DatAcq_ApproachNear": {
+                "NumValue": false
+            },
+            "check_DatAcq_BBEnable": {
+                "NumValue": false
+            },
+            "check_DatAcq_BreakInAll": {
+                "NumValue": false
+            },
+            "check_DatAcq_CNEnable": {
+                "NumValue": false
+            },
+            "check_DatAcq_ClearEnable": {
+                "NumValue": false
+            },
+            "check_DatAcq_HoldEnable": {
+                "NumValue": false
+            },
+            "check_DatAcq_HoldEnableVC": {
+                "NumValue": false
+            },
+            "check_DatAcq_RsCompEnable": {
+                "NumValue": false
+            },
+            "check_DatAcq_SealALl": {
+                "NumValue": false
+            },
+            "check_DatAcq_SealAtm": {
+                "NumValue": false
+            },
+            "check_DatAcq_WholeCellEnable": {
+                "NumValue": false
+            },
+            "check_DataACq_Pressure_AutoOFF": {
+                "NumValue": false
+            },
+            "check_DataACq_Pressure_User": {
+                "NumValue": false
+            },
+            "check_DataAcq_Amp_Chain": {
+                "NumValue": false
+            },
+            "check_DataAcq_AutoBias": {
+                "NumValue": false
+            },
+            "check_DataAcq_IndexRandom": {
+                "NumValue": false
+            },
+            "check_DataAcq_ManPressureAll": {
+                "NumValue": false
+            },
+            "check_DataAcq_RepAcqRandom": {
+                "NumValue": false
+            },
+            "check_Settings_AmpIEQZstep": {
+                "NumValue": true
+            },
+            "check_Settings_AmpMCCdefault": {
+                "NumValue": false
+            },
+            "check_Settings_DisablePressure": {
+                "NumValue": false
+            },
+            "check_Settings_ITITP": {
+                "NumValue": true
+            },
+            "check_Settings_MD": {
+                "NumValue": true
+            },
+            "check_Settings_Option_3": {
+                "NumValue": false
+            },
+            "check_Settings_RequireAmpConn": {
+                "NumValue": true
+            },
+            "check_Settings_SaveAmpSettings": {
+                "NumValue": true
+            },
+            "check_Settings_ScalingZero": {
+                "NumValue": false
+            },
+            "check_Settings_SetOption_04": {
+                "NumValue": false
+            },
+            "check_Settings_ShowScopeWindow": {
+                "NumValue": true
+            },
+            "check_Settings_SyncMiesToMCC": {
+                "NumValue": false
+            },
+            "check_Settings_TPAfterDAQ": {
+                "NumValue": true
+            },
+            "check_Settings_TP_SaveTP": {
+                "NumValue": false
+            },
+            "check_Settings_UserP_Approach": {
+                "NumValue": false
+            },
+            "check_Settings_UserP_BreakIn": {
+                "NumValue": false
+            },
+            "check_Settings_UserP_Clear": {
+                "NumValue": false
+            },
+            "check_Settings_UserP_Seal": {
+                "NumValue": false
+            },
+            "check_settings_TP_show_peak": {
+                "NumValue": true
+            },
+            "check_settings_TP_show_steady": {
+                "NumValue": true
+            },
+            "check_settings_show_power": {
+                "NumValue": false
+            },
+            "max_AsyncAD": {
+                "Values": [
+                    0,
+                    0,
+                    34,
+                    34,
+                    0,
+                    0,
+                    0,
+                    0
+                ]
+            },
+            "min_AsyncAD": {
+                "Values": [
+                    0,
+                    0,
+                    -1,
+                    -1,
+                    0,
+                    0,
+                    0,
+                    0
+                ]
+            },
+            "popup_MoreSettings_Devices": {
+                "StrValue": "Dev1"
+            },
+            "setvar_DataAcq_AutoBiasV": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_AutoBiasVrange": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_BB": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_CN": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_Hold_IC": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_Hold_VC": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_IbiasMax": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_OnsetDelayUser": {
+                "NumValue": 500
+            },
+            "setvar_DataAcq_PPDuration": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_PPPressure": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_PipetteOffset_IC": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_PipetteOffset_VC": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_RsCorr": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_RsPred": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_SSPressure": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_TerminationDelay": {
+                "NumValue": 1000
+            },
+            "setvar_DataAcq_WCC": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_WCR": {
+                "NumValue": 0
+            },
+            "setvar_DataAcq_dDAQOptOvPost": {
+                "NumValue": 150
+            },
+            "setvar_DataAcq_dDAQOptOvPre": {
+                "NumValue": 0
+            },
+            "setvar_Settings_AutoBiasInt": {
+                "NumValue": 1
+            },
+            "setvar_Settings_AutoBiasPerc": {
+                "NumValue": 15
+            },
+            "setvar_Settings_DecMethodFac": {
+                "NumValue": -1
+            },
+            "setvar_Settings_InAirP": {
+                "NumValue": 3.799999952316284
+            },
+            "setvar_Settings_InBathP": {
+                "NumValue": 0.5
+            },
+            "setvar_Settings_InSliceP": {
+                "NumValue": 0.20000000298023224
+            },
+            "setvar_Settings_NearCellP": {
+                "NumValue": 0.6000000238418579
+            },
+            "setvar_Settings_OsciUpdExt": {
+                "NumValue": 10
+            },
+            "setvar_Settings_OsciUpdInt": {
+                "NumValue": 500
+            },
+            "setvar_Settings_Pressure_ADgain": {
+                "NumValue": 0.5
+            },
+            "setvar_Settings_Pressure_DAgain": {
+                "NumValue": 2
+            },
+            "setvar_Settings_SealMaxP": {
+                "NumValue": -1.399999976158142
+            },
+            "setvar_Settings_SealStartP": {
+                "NumValue": -0.10000000149011612
+            },
+            "setvar_Settings_SliceSurfHeight": {
+                "NumValue": 350
+            },
+            "setvar_Settings_SurfaceHeight": {
+                "NumValue": 3500
+            },
+            "setvar_Settings_TPBuffer": {
+                "NumValue": 1
+            },
+            "setvar_Settings_TP_RTolerance": {
+                "NumValue": 1
+            },
+            "slider_DataAcq_ActiveHeadstage": {
+                "NumValue": 1
+            },
+            "tab_DataAcq_Amp": {
+                "NumValue": 1
+            },
+            "tab_DataAcq_Pressure": {
+                "NumValue": 0
+            }
+        },
+        "Test Pulse ControlGroup": {
+            "SetVar_DataAcq_TPAmplitude": {
+                "NumValue": -10
+            },
+            "SetVar_DataAcq_TPAmplitudeIC": {
+                "NumValue": -50
+            },
+            "SetVar_DataAcq_TPBaselinePerc": {
+                "NumValue": 30
+            },
+            "SetVar_DataAcq_TPDuration": {
+                "NumValue": 10
+            }
+        }
+    },
+    "Target Window Type": "DA_Ephys"
+}


### PR DESCRIPTION
- New file MIES_Configuration.ipf with functions to serialize the state of a
  GUI window to a file with generic function CONF_SaveWindow/CONF_RestoreWindow

- Specialized function for DA_Ephys panel save/restore that additionally stores
  the configuration information of the old ExpConfig approach.
  CONF_SaveDAEphys/CONF_RestoreDAEphys

- public functions to save a control, window or window with all its subwindows
  to json

- Restore of controls is configurable by setting userdata properties
  - human readable nice names for each control
  - flag to ignore control on save
  - flag to ignore control on restore
  - priority value that allows to define the order of control restore
  - flag for buttons if they should be activated on restore
  - flag that buttons get only saved if they should be activated on restore
  - flag to hide window while controls get restored
  - flag to disable saving of the control type
  - flag to select value/string/value+string for saving popupmenustate

- Special handling of coupled CheckBoxes (aka RadioButtons) requires a optional
  utility function. This function can be set in userdata of window with these
  radiobuttons.

- Grouping of controls of various types in ControlArrays

- Each grouped element can have its own type

- Disable fields are now ignored if not present on restore

- New Menu entries for save/restore of window states

- Excluded ValDisplay controls for DAEphys panel for save/restore

- Reduced non-GUI parameters for DA_Ephys panel

- Window can be minimized on restore.

closes https://github.com/AllenInstitute/MIES/issues/261