### PR TITLE
Feature/sweepformula unaligned plotting

### DIFF
--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -912,8 +912,9 @@ static Function/WAVE SF_GetSweepForFormula(graph, rangeStart, rangeEnd, channelT
 		return $""
 	endif
 
-	// we want the sweeps sorted with ascending sweep numbers
-	SortColumns/A/DIML/KNDX={FindDimLabel(traces, COLS, "sweepNumber")} sortWaves=traces
+	// This is a 2D-Wave sorted by sweeps and channels
+	// It can be redimensioned to restore channel information in the "3rd" dimension.
+	SortColumns/A/DIML/KNDX={FindDimLabel(traces, COLS, "channelType"), FindDimLabel(traces, COLS, "channelNumber"), FindDimLabel(traces, COLS, "sweepNumber")} sortWaves=traces
 
 	Make/N=(DimSize(traces, ROWS))/FREE sweepListIndex
 	for(i = 0; i < DimSize(traces, ROWS); i += 1)

--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -907,7 +907,7 @@ static Function SF_SplitPlotting(wv, dim, i, split)
 	WAVE wv
 	Variable dim, i, split
 
-	return min(i, floor(DimSize(wv, ROWS) / split) - 1) * split
+	return min(i, floor(DimSize(wv, dim) / split) - 1) * split
 End
 
 static Function/WAVE SF_GetSweepForFormula(graph, rangeStart, rangeEnd, channelType, channelNumber, sweeps)

--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -776,9 +776,9 @@ Function SF_FormulaPlotter(graph, formula, [dfr])
 	if(V_Flag == 2)
 		WAVE/Z wv = SF_FormulaExecutor(SF_FormulaParser(SF_FormulaPreParser(formula1)), graph = graph)
 		SF_FormulaError(dfr, WaveExists(wv), "Error in x part of formula.")
-		dim1X = DimSize(wv, COLS)
-		dim2X = DimSize(wv, LAYERS)
-		Redimension/N=(-1, max(1, DimSize(wv, LAYERS)) * max(1, DimSize(wv, COLS)))/E=1 wv
+		dim1X = max(1, DimSize(wv, COLS))
+		dim2X = max(1, DimSize(wv, LAYERS))
+		Redimension/N=(-1, dim1X * dim2X)/E=1 wv
 
 		WAVE wvX = GetSweepFormulaX(dfr)
 		MoveWaveWithOverwrite(wvX, wv)
@@ -787,9 +787,9 @@ Function SF_FormulaPlotter(graph, formula, [dfr])
 
 	WAVE/Z wv = SF_FormulaExecutor(SF_FormulaParser(SF_FormulaPreParser(formula0)), graph = graph)
 	SF_FormulaError(dfr, WaveExists(wv), "Error in y part of formula.")
-	dim1Y = DimSize(wv, COLS)
-	dim2Y = DimSize(wv, LAYERS)
-	Redimension/N=(-1, max(1, DimSize(wv, LAYERS)) * max(1, DimSize(wv, COLS)))/E=1 wv
+	dim1Y = max(1, DimSize(wv, COLS))
+	dim2Y = max(1, DimSize(wv, LAYERS))
+	Redimension/N=(-1, dim1Y * dim2Y)/E=1 wv
 
 	WAVE wvY = GetSweepFormulaY(dfr)
 	MoveWaveWithOverwrite(wvY, wv)
@@ -815,12 +815,12 @@ Function SF_FormulaPlotter(graph, formula, [dfr])
 	endif
 
 	if(!WaveExists(wvX))
-		numTraces = DimSize(wvY, COLS)
+		numTraces = dim1Y * dim2Y
 		for(i = 0; i < numTraces; i += 1)
 			trace = traceName + num2istr(i)
 			AppendTograph/W=$win wvY[][i]/TN=$trace
 		endfor
-	elseif((DimSize(wvX, COLS) == 1) && (DimSize(wvY, COLS) == 1)) // 1D
+	elseif((dim1X * dim2X == 1) && (dim1Y * dim2Y == 1)) // 1D
 		if(DimSize(wvY, ROWS) == 1) // 0D vs 1D
 			numTraces = DimSize(wvX, ROWS)
 			for(i = 0; i < numTraces; i += 1)
@@ -839,8 +839,8 @@ Function SF_FormulaPlotter(graph, formula, [dfr])
 			trace = traceName + num2istr(i)
 			AppendTograph/W=$win wvY[][0]/TN=$trace vs wvX[][0]
 		endif
-	elseif(DimSize(wvY, COLS) == 1) // 1D vs 2D
-		numTraces = DimSize(wvX, COLS)
+	elseif(dim1Y * dim2Y == 1) // 1D vs 2D
+		numTraces = dim1X * dim2X
 		for(i = 0; i < numTraces; i += 1)
 			trace = traceName + num2istr(i)
 			AppendTograph/W=$win wvY[][0]/TN=$trace vs wvX[][i]
@@ -848,8 +848,8 @@ Function SF_FormulaPlotter(graph, formula, [dfr])
 		if(DimSize(wvY, ROWS) == 1)
 			ModifyGraph/W=$win mode=3
 		endif
-	elseif(DimSize(wvX, COLS) == 1) // 2D vs 1D
-		numTraces = DimSize(wvY, COLS)
+	elseif(dim1X * dim2X == 1) // 2D vs 1D
+		numTraces = dim1Y * dim2Y
 		for(i = 0; i < numTraces; i += 1)
 			trace = traceName + num2istr(i)
 			AppendTograph/W=$win wvY[][i]/TN=$trace vs wvX
@@ -858,7 +858,7 @@ Function SF_FormulaPlotter(graph, formula, [dfr])
 			ModifyGraph/W=$win mode=3
 		endif
 	else // 2D vs 2D
-		numTraces = WaveExists(wvX) ? max(1, max(DimSize(wvY, COLS), DimSize(wvX, COLS))) : max(1, DimSize(wvY, COLS))
+		numTraces = WaveExists(wvX) ? max(1, max(dim1Y * dim2Y, dim1X * dim2X)) : max(1, dim1Y * dim2Y)
 		if(DimSize(wvY, ROWS) == DimSize(wvX, ROWS))
 			DebugPrint("Size missmatch in data rows for plotting waves.")
 		endif
@@ -868,7 +868,7 @@ Function SF_FormulaPlotter(graph, formula, [dfr])
 		for(i = 0; i < numTraces; i += 1)
 			trace = traceName + num2istr(i)
 			if(WaveExists(wvX))
-				AppendTograph/W=$win wvY[][min(max(1, DimSize(wvY, COLS)) - 1, i)]/TN=$trace vs wvX[][min(max(1, DimSize(wvX, COLS)) - 1, i)]
+				AppendTograph/W=$win wvY[][min(dim1Y * dim2Y - 1, i)]/TN=$trace vs wvX[][min(dim1X * dim2X - 1, i)]
 			else
 				AppendTograph/W=$win wvY[][i]/TN=$trace
 			endif

--- a/Packages/Testing-MIES/UTF_SweepFormula.ipf
+++ b/Packages/Testing-MIES/UTF_SweepFormula.ipf
@@ -767,4 +767,14 @@ static Function TestPlotting()
 
 	SF_FormulaPlotter("", strArray0D + " vs " + strArray0D); DoUpdate
 	REQUIRE_EQUAL_VAR(ItemsInList(TraceNameList(win, ";", 0x1)), DimSize(array0D, ROWS))
+
+	// plotting of unaligned data
+	SF_FormulaPlotter("", "range(10) vs range(5)"); DoUpdate
+	REQUIRE_EQUAL_VAR(ItemsInList(TraceNameList(win, ";", 0x1)), floor(10 / 5))
+	SF_FormulaPlotter("", "range(5) vs range(10)"); DoUpdate
+	REQUIRE_EQUAL_VAR(ItemsInList(TraceNameList(win, ";", 0x1)), floor(10 / 5))
+	SF_FormulaPlotter("", "range(3) vs range(90)"); DoUpdate
+	REQUIRE_EQUAL_VAR(ItemsInList(TraceNameList(win, ";", 0x1)), floor(90 / 3))
+	SF_FormulaPlotter("", "range(3) vs range(7)"); DoUpdate
+	REQUIRE_EQUAL_VAR(ItemsInList(TraceNameList(win, ";", 0x1)), floor(7 / 3))
 End

--- a/Packages/doc/SweepFormula.rst
+++ b/Packages/doc/SweepFormula.rst
@@ -375,9 +375,9 @@ Various
 range
 """""
 
-The range function is borrowed from
-[python](https://docs.python.org/3/library/functions.html#func-range). It
-expands values into a new array.
+The range function is borrowed from `python
+<https://docs.python.org/3/library/functions.html#func-range>`_. It expands
+values into a new array.
 
 This function can also be used as an operation with the "…" operator which is
 the Unicode Character 'HORIZONTAL ELLIPSIS' (U+2026).

--- a/Packages/doc/SweepFormula.rst
+++ b/Packages/doc/SweepFormula.rst
@@ -398,7 +398,7 @@ merge
 """""
 
 `merge` reduces a 2-dimensional array to a 1-dimensional array similar to
-removing all sphare brackets:
+removing all inner square brackets:
 
 .. code-block:: bash
 


### PR DESCRIPTION
#328 specifically wants to enable plotting of missaligned 1d waves.

A channel input like `AD` squashes all sweeps of these channels into one dimension. Sorting of such a squashed input was previously only done by sweeps and did not consider channels which lead to misalignments of the data since the usual squashed format is sorted first by channel, then by sweep.

Previous sorting:

```
sweep0[AD0], sweep0[AD1], sweep1[AD0], sweep1[AD1]
```

New Sorting

```
sweep0[AD0], sweep1[AD0], sweep0[AD1], sweep1[AD1]
```

The plotting of 1d waves was adapted to match unsynchronized datasets.