### PR TITLE
Add test for correct readout of TP data after DAEphys panel was closed

### DIFF
--- a/Packages/MIES/MIES_DAEphys_GuiState.ipf
+++ b/Packages/MIES/MIES_DAEphys_GuiState.ipf
@@ -401,12 +401,16 @@ End
 Function/S DAG_GetUniqueSpecCtrlListNum(panelTitle)
 	string panelTitle
 
+	ASSERT(WindowExists(panelTitle), "Missing window")
+
 	return DAG_GetSpecificCtrlNum(panelTitle, DAG_GetUniqueCtrlList(panelTitle))
 End
 
 /// @brief Returns a list of unique and type specific controls with textual values
 Function/S DAG_GetUniqueSpecCtrlListTxT(panelTitle)
 	string panelTitle
+
+	ASSERT(WindowExists(panelTitle), "Missing window")
 
 	return DAG_GetSpecificCtrlTxT(panelTitle, DAG_GetUniqueCtrlList(panelTitle))
 End

--- a/Packages/MIES/MIES_TestPulse.ipf
+++ b/Packages/MIES/MIES_TestPulse.ipf
@@ -414,7 +414,6 @@ static Function TP_RecordTP(panelTitle, BaselineSSAvg, InstResistance, SSResista
 	variable delta, i, ret, lastPressureCtrl
 	WAVE TPStorage = GetTPStorage(panelTitle)
 	WAVE hsProp = GetHSProperties(panelTitle)
-	Wave GUIState  = GetDA_EphysGuiStateNum(panelTitle)
 	variable count = GetNumberFromWaveNote(TPStorage, NOTE_INDEX)
 	variable lastRescaling = GetNumberFromWaveNote(TPStorage, DIMENSION_SCALING_LAST_INVOC)
 

--- a/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
+++ b/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
@@ -1862,6 +1862,43 @@ Function StartDAQDuringTP_IGNORE(device)
 	wv[%$"Analysis function (generic)"][%Set] = "WriteIntoLBNOnPreDAQ"
 End
 
+// UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
+Function AbortTP([str])
+	string str
+
+	STRUCT DAQSettings s
+	InitDAQSettingsFromString(s, "MD1_RA0_I0_L0_BKG_1_RES_0")
+	AcquireData(s, str, startTPInstead=1)
+
+	CtrlNamedBackGround DelayReentry, start=(ticks + 300), period=60, proc=JustDelay_IGNORE
+	RegisterUTFMonitor("DelayReentry", BACKGROUNDMONMODE_AND, "AbortTP_REENTRY", timeout = 600, failOnTimeout = 1)
+End
+
+Function AbortTP_REENTRY([str])
+	string str
+
+	string device
+	variable aborted, err
+
+	device = StringFromList(0, str)
+
+	KillWindow $device
+	try
+		ASYNC_STOP(timeout = 5)
+	catch
+		err = getRTError(1)
+		aborted = 1
+	endtry
+
+	ASYNC_Start(threadprocessorCount, disableTask=1)
+
+	if(aborted)
+		FAIL()
+	else
+		PASS()
+	endif
+End
+
 // UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD0
 Function StartDAQDuringTP([str])
 	string str

--- a/Packages/Testing-MIES/UTF_HardwareMain.ipf
+++ b/Packages/Testing-MIES/UTF_HardwareMain.ipf
@@ -407,6 +407,12 @@ Function StopAcq_IGNORE(s)
 	return 1
 End
 
+Function JustDelay_IGNORE(s)
+	STRUCT WMBackgroundStruct &s
+
+	return 1
+End
+
 Function StopTP_IGNORE(s)
 	STRUCT WMBackgroundStruct &s
 


### PR DESCRIPTION
This test checks if ASYNC_ReadOut treats remaining data properly even if the panel was closed.

Currently the tests fails if there is still data in the readout queue after the DAEphys panel was closed. So the fail is timing dependent and does not happen always.