### PR TITLE
🎃 StartZeroMQMessageHandler: Use more trials for finding an unused port

### DIFF
--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -679,7 +679,7 @@ Constant NO_SLIDER_MOVEMENT    = 0x2
 /// @}
 
 /// Number of trials to find a suitable port for binding a ZeroMQ service
-Constant ZEROMQ_NUM_BIND_TRIALS = 4
+Constant ZEROMQ_NUM_BIND_TRIALS = 32
 
 Constant ZEROMQ_BIND_REP_PORT = 5670
 


### PR DESCRIPTION
Until now we only try four times to get an open port. But some users have
a lot of different Igor instances open, so in order to not annoy them we
now try harder.