### PR TITLE
Document specialities about unassociated entries from more

### DIFF
--- a/Packages/MIES/MIES_DataConfiguratorITC.ipf
+++ b/Packages/MIES/MIES_DataConfiguratorITC.ipf
@@ -828,7 +828,7 @@ static Function DC_PlaceDataInHardwareDataWave(panelTitle, numActiveChannels, da
 		ASSERT(IsFinite(raCycleID), "Uninitialized raCycleID detected")
 	endif
 
-	DC_DocumentChannelProperty(panelTitle, RA_ACQ_CYCLE_ID_KEY, INDEP_HEADSTAGE, NaN, var=raCycleID)
+	DC_DocumentChannelProperty(panelTitle, RA_ACQ_CYCLE_ID_KEY, INDEP_HEADSTAGE, NaN, NaN, var=raCycleID)
 
 	headstageDAC[] = channelClampMode[DACList[p]][%DAC][%Headstage]
 
@@ -924,13 +924,13 @@ static Function DC_PlaceDataInHardwareDataWave(panelTitle, numActiveChannels, da
 			ASSERT(0, "unknown mode")
 		endif
 
-		DC_DocumentChannelProperty(panelTitle, "DAC", headstage, channel, var=channel)
+		DC_DocumentChannelProperty(panelTitle, "DAC", headstage, channel, ITC_XOP_CHANNEL_TYPE_DAC, var=channel)
 		ctrl = GetSpecialControlLabel(CHANNEL_TYPE_DAC, CHANNEL_CONTROL_GAIN)
-		DC_DocumentChannelProperty(panelTitle, "DA GAIN", headstage, channel, var=DAG_GetNumericalValue(panelTitle, ctrl, index = channel))
-		DC_DocumentChannelProperty(panelTitle, "DA ChannelType", headstage, channel, var = config[i][%DAQChannelType])
+		DC_DocumentChannelProperty(panelTitle, "DA GAIN", headstage, channel, ITC_XOP_CHANNEL_TYPE_DAC, var=DAG_GetNumericalValue(panelTitle, ctrl, index = channel))
+		DC_DocumentChannelProperty(panelTitle, "DA ChannelType", headstage, channel, ITC_XOP_CHANNEL_TYPE_DAC, var = config[i][%DAQChannelType])
 
-		DC_DocumentChannelProperty(panelTitle, STIM_WAVE_NAME_KEY, headstage, channel, str=setName[i])
-		DC_DocumentChannelProperty(panelTitle, STIMSET_WAVE_NOTE_KEY, headstage, channel, str=NormalizeToEOL(RemoveEnding(note(stimSet[i]), "\r"), "\n"))
+		DC_DocumentChannelProperty(panelTitle, STIM_WAVE_NAME_KEY, headstage, channel, ITC_XOP_CHANNEL_TYPE_DAC, str=setName[i])
+		DC_DocumentChannelProperty(panelTitle, STIMSET_WAVE_NOTE_KEY, headstage, channel, ITC_XOP_CHANNEL_TYPE_DAC, str=NormalizeToEOL(RemoveEnding(note(stimSet[i]), "\r"), "\n"))
 
 		for(j = 0; j < TOTAL_NUM_EVENTS; j += 1)
 			if(IsFinite(headstage)) // associated channel
@@ -939,7 +939,7 @@ static Function DC_PlaceDataInHardwareDataWave(panelTitle, numActiveChannels, da
 				func = ""
 			endif
 
-			DC_DocumentChannelProperty(panelTitle, StringFromList(j, EVENT_NAME_LIST_LBN), headstage, channel, str=func)
+			DC_DocumentChannelProperty(panelTitle, StringFromList(j, EVENT_NAME_LIST_LBN), headstage, channel, ITC_XOP_CHANNEL_TYPE_DAC, str=func)
 		endfor
 
 		if(IsFinite(headstage)) // associated channel
@@ -948,37 +948,37 @@ static Function DC_PlaceDataInHardwareDataWave(panelTitle, numActiveChannels, da
 			str = ""
 		endif
 
-		DC_DocumentChannelProperty(panelTitle, ANALYSIS_FUNCTION_PARAMS_LBN, headstage, channel, str=str)
+		DC_DocumentChannelProperty(panelTitle, ANALYSIS_FUNCTION_PARAMS_LBN, headstage, channel, ITC_XOP_CHANNEL_TYPE_DAC, str=str)
 
 		ctrl = GetSpecialControlLabel(CHANNEL_TYPE_DAC, CHANNEL_CONTROL_UNIT)
-		DC_DocumentChannelProperty(panelTitle, "DA Unit", headstage, channel, str=DAG_GetTextualValue(panelTitle, ctrl, index = channel))
+		DC_DocumentChannelProperty(panelTitle, "DA Unit", headstage, channel, ITC_XOP_CHANNEL_TYPE_DAC, str=DAG_GetTextualValue(panelTitle, ctrl, index = channel))
 
-		DC_DocumentChannelProperty(panelTitle, STIMSET_SCALE_FACTOR_KEY, headstage, channel, var = dataAcqOrTP == DATA_ACQUISITION_MODE && config[i][%DAQChannelType] == DAQ_CHANNEL_TYPE_DAQ ? DACAmp[i][%DASCALE] : DACAmp[i][%TPAMP])
-		DC_DocumentChannelProperty(panelTitle, "Set Sweep Count", headstage, channel, var=setColumn[i])
-		DC_DocumentChannelProperty(panelTitle, "Electrode", headstage, channel, str=cellElectrodeNames[headstage])
-		DC_DocumentChannelProperty(panelTitle, "Set Cycle Count", headstage, channel, var=setCycleCount)
+		DC_DocumentChannelProperty(panelTitle, STIMSET_SCALE_FACTOR_KEY, headstage, channel, ITC_XOP_CHANNEL_TYPE_DAC, var = dataAcqOrTP == DATA_ACQUISITION_MODE && config[i][%DAQChannelType] == DAQ_CHANNEL_TYPE_DAQ ? DACAmp[i][%DASCALE] : DACAmp[i][%TPAMP])
+		DC_DocumentChannelProperty(panelTitle, "Set Sweep Count", headstage, channel, ITC_XOP_CHANNEL_TYPE_DAC, var=setColumn[i])
+		DC_DocumentChannelProperty(panelTitle, "Electrode", headstage, channel, ITC_XOP_CHANNEL_TYPE_DAC, str=cellElectrodeNames[headstage])
+		DC_DocumentChannelProperty(panelTitle, "Set Cycle Count", headstage, channel, ITC_XOP_CHANNEL_TYPE_DAC, var=setCycleCount)
 
 		setChecksum = WB_GetStimsetChecksum(stimSet[i], setName[i], dataAcqOrTP)
-		DC_DocumentChannelProperty(panelTitle, "Stim Wave Checksum", headstage, channel, var=setChecksum)
+		DC_DocumentChannelProperty(panelTitle, "Stim Wave Checksum", headstage, channel, ITC_XOP_CHANNEL_TYPE_DAC, var=setChecksum)
 
 		if(dataAcqOrTP == DATA_ACQUISITION_MODE && config[i][%DAQChannelType] == DAQ_CHANNEL_TYPE_DAQ)
 			fingerprint = DC_GenerateStimsetFingerprint(raCycleID, setName[i], setCycleCount, setChecksum, dataAcqOrTP)
 			stimsetCycleID = DC_GetStimsetAcqCycleID(panelTitle, fingerprint, channel)
 
 			setEventFlag[i][] = (setColumn[i] + 1 == IDX_NumberOfSweepsInSet(setName[i]))
-			DC_DocumentChannelProperty(panelTitle, STIMSET_ACQ_CYCLE_ID_KEY, headstage, channel, var=stimsetCycleID)
+			DC_DocumentChannelProperty(panelTitle, STIMSET_ACQ_CYCLE_ID_KEY, headstage, channel, ITC_XOP_CHANNEL_TYPE_DAC, var=stimsetCycleID)
 		endif
 
 		if(dataAcqOrTP == DATA_ACQUISITION_MODE)
 			isoodDAQMember = (distributedDAQOptOv && config[i][%DAQChannelType] == DAQ_CHANNEL_TYPE_DAQ && IsFinite(headstage))
-			DC_DocumentChannelProperty(panelTitle, "oodDAQ member", headstage, channel, var=isoodDAQMember)
+			DC_DocumentChannelProperty(panelTitle, "oodDAQ member", headstage, channel, ITC_XOP_CHANNEL_TYPE_DAC, var=isoodDAQMember)
 		endif
 	endfor
 
 	NVAR maxITIGlobal = $GetMaxIntertrialInterval(panelTitle)
 	ASSERT(IsFinite(maxITI), "Invalid maxITI")
 	maxITIGlobal = maxITI
-	DC_DocumentChannelProperty(panelTitle, "Inter-trial interval", INDEP_HEADSTAGE, NaN, var=maxITIGlobal)
+	DC_DocumentChannelProperty(panelTitle, "Inter-trial interval", INDEP_HEADSTAGE, NaN, NaN, var=maxITIGlobal)
 
 	// for distributedDAQOptOv create temporary reduced input waves holding DAQ types channels only (removing TP typed channels from TPwhileDAQ), put results back to unreduced waves
 	if(distributedDAQOptOv && dataAcqOrTP == DATA_ACQUISITION_MODE)
@@ -1277,65 +1277,65 @@ static Function DC_PlaceDataInHardwareDataWave(panelTitle, numActiveChannels, da
 	for(i = 0; i < numDACEntries; i += 1)
 		channel = DACList[i]
 		headstage = headstageDAC[i]
-		DC_DocumentChannelProperty(panelTitle, "Stim set length", headstage, channel, var=setLength[i])
-		DC_DocumentChannelProperty(panelTitle, "Delay onset oodDAQ", headstage, channel, var=offsets[i])
-		DC_DocumentChannelProperty(panelTitle, "oodDAQ regions", headstage, channel, str=regions[i])
+		DC_DocumentChannelProperty(panelTitle, "Stim set length", headstage, channel, ITC_XOP_CHANNEL_TYPE_DAC, var=setLength[i])
+		DC_DocumentChannelProperty(panelTitle, "Delay onset oodDAQ", headstage, channel, ITC_XOP_CHANNEL_TYPE_DAC, var=offsets[i])
+		DC_DocumentChannelProperty(panelTitle, "oodDAQ regions", headstage, channel, ITC_XOP_CHANNEL_TYPE_DAC, str=regions[i])
 
 		WAVE/T epochWave = GetEpochsWave(panelTitle)
 		Duplicate/FREE/RMD=[][][channel] epochWave, epochChannel
 		Redimension/N=(-1, -1, 0) epochChannel
-		DC_DocumentChannelProperty(panelTitle, EPOCHS_ENTRY_KEY, headstage, channel, str=TextWaveToList(epochChannel, ":", colSep = ",", stopOnEmpty = 1))
+		DC_DocumentChannelProperty(panelTitle, EPOCHS_ENTRY_KEY, headstage, channel, ITC_XOP_CHANNEL_TYPE_DAC, str=TextWaveToList(epochChannel, ":", colSep = ",", stopOnEmpty = 1))
 	endfor
 
-	DC_DocumentChannelProperty(panelTitle, "Sampling interval multiplier", INDEP_HEADSTAGE, NaN, var=str2num(DAG_GetTextualValue(panelTitle, "Popup_Settings_SampIntMult")))
-	DC_DocumentChannelProperty(panelTitle, "Fixed frequency acquisition", INDEP_HEADSTAGE, NaN, var=str2numSafe(DAG_GetTextualValue(panelTitle, "Popup_Settings_FixedFreq")))
-	DC_DocumentChannelProperty(panelTitle, "Sampling interval", INDEP_HEADSTAGE, NaN, var=samplingInterval * 1e-3)
+	DC_DocumentChannelProperty(panelTitle, "Sampling interval multiplier", INDEP_HEADSTAGE, NaN, NaN, var=str2num(DAG_GetTextualValue(panelTitle, "Popup_Settings_SampIntMult")))
+	DC_DocumentChannelProperty(panelTitle, "Fixed frequency acquisition", INDEP_HEADSTAGE, NaN, NaN, var=str2numSafe(DAG_GetTextualValue(panelTitle, "Popup_Settings_FixedFreq")))
+	DC_DocumentChannelProperty(panelTitle, "Sampling interval", INDEP_HEADSTAGE, NaN, NaN, var=samplingInterval * 1e-3)
 
-	DC_DocumentChannelProperty(panelTitle, "Delay onset user", INDEP_HEADSTAGE, NaN, var=DAG_GetNumericalValue(panelTitle, "setvar_DataAcq_OnsetDelayUser"))
-	DC_DocumentChannelProperty(panelTitle, "Delay onset auto", INDEP_HEADSTAGE, NaN, var=GetValDisplayAsNum(panelTitle, "valdisp_DataAcq_OnsetDelayAuto"))
-	DC_DocumentChannelProperty(panelTitle, "Delay termination", INDEP_HEADSTAGE, NaN, var=DAG_GetNumericalValue(panelTitle, "setvar_DataAcq_TerminationDelay"))
-	DC_DocumentChannelProperty(panelTitle, "Delay distributed DAQ", INDEP_HEADSTAGE, NaN, var=DAG_GetNumericalValue(panelTitle, "setvar_DataAcq_dDAQDelay"))
-	DC_DocumentChannelProperty(panelTitle, "oodDAQ Pre Feature", INDEP_HEADSTAGE, NaN, var=DAG_GetNumericalValue(panelTitle, "Setvar_DataAcq_dDAQOptOvPre"))
-	DC_DocumentChannelProperty(panelTitle, "oodDAQ Post Feature", INDEP_HEADSTAGE, NaN, var=DAG_GetNumericalValue(panelTitle, "Setvar_DataAcq_dDAQOptOvPost"))
-	DC_DocumentChannelProperty(panelTitle, "oodDAQ Resolution", INDEP_HEADSTAGE, NaN, var=WAVEBUILDER_MIN_SAMPINT)
+	DC_DocumentChannelProperty(panelTitle, "Delay onset user", INDEP_HEADSTAGE, NaN, NaN, var=DAG_GetNumericalValue(panelTitle, "setvar_DataAcq_OnsetDelayUser"))
+	DC_DocumentChannelProperty(panelTitle, "Delay onset auto", INDEP_HEADSTAGE, NaN, NaN, var=GetValDisplayAsNum(panelTitle, "valdisp_DataAcq_OnsetDelayAuto"))
+	DC_DocumentChannelProperty(panelTitle, "Delay termination", INDEP_HEADSTAGE, NaN, NaN, var=DAG_GetNumericalValue(panelTitle, "setvar_DataAcq_TerminationDelay"))
+	DC_DocumentChannelProperty(panelTitle, "Delay distributed DAQ", INDEP_HEADSTAGE, NaN, NaN, var=DAG_GetNumericalValue(panelTitle, "setvar_DataAcq_dDAQDelay"))
+	DC_DocumentChannelProperty(panelTitle, "oodDAQ Pre Feature", INDEP_HEADSTAGE, NaN, NaN, var=DAG_GetNumericalValue(panelTitle, "Setvar_DataAcq_dDAQOptOvPre"))
+	DC_DocumentChannelProperty(panelTitle, "oodDAQ Post Feature", INDEP_HEADSTAGE, NaN, NaN, var=DAG_GetNumericalValue(panelTitle, "Setvar_DataAcq_dDAQOptOvPost"))
+	DC_DocumentChannelProperty(panelTitle, "oodDAQ Resolution", INDEP_HEADSTAGE, NaN, NaN, var=WAVEBUILDER_MIN_SAMPINT)
 
-	DC_DocumentChannelProperty(panelTitle, "TP Insert Checkbox", INDEP_HEADSTAGE, NaN, var=GlobalTPInsert)
-	DC_DocumentChannelProperty(panelTitle, "Distributed DAQ", INDEP_HEADSTAGE, NaN, var=distributedDAQ)
-	DC_DocumentChannelProperty(panelTitle, "Optimized Overlap dDAQ", INDEP_HEADSTAGE, NaN, var=distributedDAQOptOv)
-	DC_DocumentChannelProperty(panelTitle, "Repeat Sets", INDEP_HEADSTAGE, NaN, var=DAG_GetNumericalValue(panelTitle, "SetVar_DataAcq_SetRepeats"))
-	DC_DocumentChannelProperty(panelTitle, "Scaling zero", INDEP_HEADSTAGE, NaN, var=scalingZero)
-	DC_DocumentChannelProperty(panelTitle, "Indexing", INDEP_HEADSTAGE, NaN, var=indexing)
-	DC_DocumentChannelProperty(panelTitle, "Locked indexing", INDEP_HEADSTAGE, NaN, var=indexingLocked)
-	DC_DocumentChannelProperty(panelTitle, "Repeated Acquisition", INDEP_HEADSTAGE, NaN, var=DAG_GetNumericalValue(panelTitle, "Check_DataAcq1_RepeatAcq"))
-	DC_DocumentChannelProperty(panelTitle, "Random Repeated Acquisition", INDEP_HEADSTAGE, NaN, var=DAG_GetNumericalValue(panelTitle, "check_DataAcq_RepAcqRandom"))
-	DC_DocumentChannelProperty(panelTitle, "Multi Device mode", INDEP_HEADSTAGE, NaN, var=DAG_GetNumericalValue(panelTitle, "check_Settings_MD"))
-	DC_DocumentChannelProperty(panelTitle, "Background Testpulse", INDEP_HEADSTAGE, NaN, var=DAG_GetNumericalValue(panelTitle, "Check_Settings_BkgTP"))
-	DC_DocumentChannelProperty(panelTitle, "Background DAQ", INDEP_HEADSTAGE, NaN, var=DAG_GetNumericalValue(panelTitle, "Check_Settings_BackgrndDataAcq"))
-	DC_DocumentChannelProperty(panelTitle, "TP buffer size", INDEP_HEADSTAGE, NaN, var=DAG_GetNumericalValue(panelTitle, "setvar_Settings_TPBuffer"))
-	DC_DocumentChannelProperty(panelTitle, "TP during ITI", INDEP_HEADSTAGE, NaN, var=DAG_GetNumericalValue(panelTitle, "check_Settings_ITITP"))
-	DC_DocumentChannelProperty(panelTitle, "Amplifier change via I=0", INDEP_HEADSTAGE, NaN, var=DAG_GetNumericalValue(panelTitle, "check_Settings_AmpIEQZstep"))
-	DC_DocumentChannelProperty(panelTitle, "Skip analysis functions", INDEP_HEADSTAGE, NaN, var=DAG_GetNumericalValue(panelTitle, "Check_Settings_SkipAnalysFuncs"))
-	DC_DocumentChannelProperty(panelTitle, "Repeat sweep on async alarm", INDEP_HEADSTAGE, NaN, var=DAG_GetNumericalValue(panelTitle, "Check_Settings_AlarmAutoRepeat"))
+	DC_DocumentChannelProperty(panelTitle, "TP Insert Checkbox", INDEP_HEADSTAGE, NaN, NaN, var=GlobalTPInsert)
+	DC_DocumentChannelProperty(panelTitle, "Distributed DAQ", INDEP_HEADSTAGE, NaN, NaN, var=distributedDAQ)
+	DC_DocumentChannelProperty(panelTitle, "Optimized Overlap dDAQ", INDEP_HEADSTAGE, NaN, NaN, var=distributedDAQOptOv)
+	DC_DocumentChannelProperty(panelTitle, "Repeat Sets", INDEP_HEADSTAGE, NaN, NaN, var=DAG_GetNumericalValue(panelTitle, "SetVar_DataAcq_SetRepeats"))
+	DC_DocumentChannelProperty(panelTitle, "Scaling zero", INDEP_HEADSTAGE, NaN, NaN, var=scalingZero)
+	DC_DocumentChannelProperty(panelTitle, "Indexing", INDEP_HEADSTAGE, NaN, NaN, var=indexing)
+	DC_DocumentChannelProperty(panelTitle, "Locked indexing", INDEP_HEADSTAGE, NaN, NaN, var=indexingLocked)
+	DC_DocumentChannelProperty(panelTitle, "Repeated Acquisition", INDEP_HEADSTAGE, NaN, NaN, var=DAG_GetNumericalValue(panelTitle, "Check_DataAcq1_RepeatAcq"))
+	DC_DocumentChannelProperty(panelTitle, "Random Repeated Acquisition", INDEP_HEADSTAGE, NaN, NaN, var=DAG_GetNumericalValue(panelTitle, "check_DataAcq_RepAcqRandom"))
+	DC_DocumentChannelProperty(panelTitle, "Multi Device mode", INDEP_HEADSTAGE, NaN, NaN, var=DAG_GetNumericalValue(panelTitle, "check_Settings_MD"))
+	DC_DocumentChannelProperty(panelTitle, "Background Testpulse", INDEP_HEADSTAGE, NaN, NaN, var=DAG_GetNumericalValue(panelTitle, "Check_Settings_BkgTP"))
+	DC_DocumentChannelProperty(panelTitle, "Background DAQ", INDEP_HEADSTAGE, NaN, NaN, var=DAG_GetNumericalValue(panelTitle, "Check_Settings_BackgrndDataAcq"))
+	DC_DocumentChannelProperty(panelTitle, "TP buffer size", INDEP_HEADSTAGE, NaN, NaN, var=DAG_GetNumericalValue(panelTitle, "setvar_Settings_TPBuffer"))
+	DC_DocumentChannelProperty(panelTitle, "TP during ITI", INDEP_HEADSTAGE, NaN, NaN, var=DAG_GetNumericalValue(panelTitle, "check_Settings_ITITP"))
+	DC_DocumentChannelProperty(panelTitle, "Amplifier change via I=0", INDEP_HEADSTAGE, NaN, NaN, var=DAG_GetNumericalValue(panelTitle, "check_Settings_AmpIEQZstep"))
+	DC_DocumentChannelProperty(panelTitle, "Skip analysis functions", INDEP_HEADSTAGE, NaN, NaN, var=DAG_GetNumericalValue(panelTitle, "Check_Settings_SkipAnalysFuncs"))
+	DC_DocumentChannelProperty(panelTitle, "Repeat sweep on async alarm", INDEP_HEADSTAGE, NaN, NaN, var=DAG_GetNumericalValue(panelTitle, "Check_Settings_AlarmAutoRepeat"))
 	DC_DocumentHardwareProperties(panelTitle, hardwareType)
 
 	if(DeviceCanLead(panelTitle))
 		SVAR listOfFollowerDevices = $GetFollowerList(panelTitle)
-		DC_DocumentChannelProperty(panelTitle, "Follower Device", INDEP_HEADSTAGE, NaN, str=listOfFollowerDevices)
+		DC_DocumentChannelProperty(panelTitle, "Follower Device", INDEP_HEADSTAGE, NaN, NaN, str=listOfFollowerDevices)
 	endif
 
-	DC_DocumentChannelProperty(panelTitle, "MIES version", INDEP_HEADSTAGE, NaN, str=GetMIESVersionAsString())
-	DC_DocumentChannelProperty(panelTitle, "Igor Pro version", INDEP_HEADSTAGE, NaN, str=GetIgorProVersion())
-	DC_DocumentChannelProperty(panelTitle, "Igor Pro bitness", INDEP_HEADSTAGE, NaN, var=GetArchitectureBits())
+	DC_DocumentChannelProperty(panelTitle, "MIES version", INDEP_HEADSTAGE, NaN, NaN, str=GetMIESVersionAsString())
+	DC_DocumentChannelProperty(panelTitle, "Igor Pro version", INDEP_HEADSTAGE, NaN, NaN, str=GetIgorProVersion())
+	DC_DocumentChannelProperty(panelTitle, "Igor Pro bitness", INDEP_HEADSTAGE, NaN, NaN, var=GetArchitectureBits())
 
 	for(i = 0; i < NUM_HEADSTAGES; i += 1)
 
-		DC_DocumentChannelProperty(panelTitle, "Headstage Active", i, NaN, var=statusHS[i])
+		DC_DocumentChannelProperty(panelTitle, "Headstage Active", i, NaN, NaN, var=statusHS[i])
 
 		if(!statusHS[i])
 			continue
 		endif
 
-		DC_DocumentChannelProperty(panelTitle, "Clamp Mode", i, NaN, var=DAG_GetHeadstageMode(panelTitle, i))
+		DC_DocumentChannelProperty(panelTitle, "Clamp Mode", i, NaN, NaN, var=DAG_GetHeadstageMode(panelTitle, i))
 	endfor
 
 	if(distributedDAQ)
@@ -1343,7 +1343,7 @@ static Function DC_PlaceDataInHardwareDataWave(panelTitle, numActiveChannels, da
 		// also headstage independent
 		ASSERT(!distributedDAQOptOv, "Unexpected oodDAQ mode")
 		ASSERT(WaveMin(setLength) == WaveMax(setLength), "Unexpected varying stim set length")
-		DC_DocumentChannelProperty(panelTitle, "Stim set length", INDEP_HEADSTAGE, NaN, var=setLength[0])
+		DC_DocumentChannelProperty(panelTitle, "Stim set length", INDEP_HEADSTAGE, NaN, NaN, var=setLength[0])
 	endif
 
 	numADCEntries = DimSize(ADCList, ROWS)
@@ -1351,15 +1351,15 @@ static Function DC_PlaceDataInHardwareDataWave(panelTitle, numActiveChannels, da
 		channel = ADCList[i]
 		headstage = channelClampMode[channel][%ADC][%Headstage]
 
-		DC_DocumentChannelProperty(panelTitle, "ADC", headstage, channel, var=channel)
+		DC_DocumentChannelProperty(panelTitle, "ADC", headstage, channel, ITC_XOP_CHANNEL_TYPE_ADC, var=channel)
 
 		ctrl = GetSpecialControlLabel(CHANNEL_TYPE_ADC, CHANNEL_CONTROL_GAIN)
-		DC_DocumentChannelProperty(panelTitle, "AD Gain", headstage, channel, var=DAG_GetNumericalValue(panelTitle, ctrl, index = channel))
+		DC_DocumentChannelProperty(panelTitle, "AD Gain", headstage, channel, ITC_XOP_CHANNEL_TYPE_ADC, var=DAG_GetNumericalValue(panelTitle, ctrl, index = channel))
 
 		ctrl = GetSpecialControlLabel(CHANNEL_TYPE_ADC, CHANNEL_CONTROL_UNIT)
-		DC_DocumentChannelProperty(panelTitle, "AD Unit", headstage, channel, str=DAG_GetTextualValue(panelTitle, ctrl, index = channel))
+		DC_DocumentChannelProperty(panelTitle, "AD Unit", headstage, channel, ITC_XOP_CHANNEL_TYPE_ADC, str=DAG_GetTextualValue(panelTitle, ctrl, index = channel))
 
-		DC_DocumentChannelProperty(panelTitle, "AD ChannelType", headstage, channel, var = config[numDACEntries + i][%DAQChannelType])
+		DC_DocumentChannelProperty(panelTitle, "AD ChannelType", headstage, channel, ITC_XOP_CHANNEL_TYPE_ADC, var = config[numDACEntries + i][%DAQChannelType])
 	endfor
 
 	if(dataAcqOrTP == DATA_ACQUISITION_MODE)
@@ -1416,7 +1416,7 @@ static Function DC_DocumentHardwareProperties(panelTitle, hardwareType)
 
 	string str, key
 
-	DC_DocumentChannelProperty(panelTitle, "Digitizer Hardware Type", INDEP_HEADSTAGE, NaN, var=hardwareType)
+	DC_DocumentChannelProperty(panelTitle, "Digitizer Hardware Type", INDEP_HEADSTAGE, NaN, NaN, var=hardwareType)
 
 	NVAR ITCDeviceIDGlobal = $GetITCDeviceIDGlobal(panelTitle)
 
@@ -1430,16 +1430,16 @@ static Function DC_DocumentHardwareProperties(panelTitle, hardwareType)
 
 	switch(hardwareType)
 		case HARDWARE_ITC_DAC:
-			DC_DocumentChannelProperty(panelTitle, "Digitizer Hardware Name", INDEP_HEADSTAGE, NaN, str=StringFromList(devInfo[%DeviceType], DEVICE_TYPES_ITC))
+			DC_DocumentChannelProperty(panelTitle, "Digitizer Hardware Name", INDEP_HEADSTAGE, NaN, NaN, str=StringFromList(devInfo[%DeviceType], DEVICE_TYPES_ITC))
 			sprintf str, "Master:%#0X,Secondary:%#0X,Host:%#0X", devInfo[%MasterSerialNumber], devInfo[%SecondarySerialNumber], devInfo[%HostSerialNumber]
-			DC_DocumentChannelProperty(panelTitle, "Digitizer Serial Numbers", INDEP_HEADSTAGE, NaN, str=str)
+			DC_DocumentChannelProperty(panelTitle, "Digitizer Serial Numbers", INDEP_HEADSTAGE, NaN, NaN, str=str)
 			break
 		case HARDWARE_NI_DAC:
 			WAVE/T devInfoText = devInfo
 			sprintf str, "%s %s (%#0X)", devInfoText[%DeviceCategoryStr], devInfoText[%ProductType], str2num(devInfoText[%ProductNumber])
-			DC_DocumentChannelProperty(panelTitle, "Digitizer Hardware Name", INDEP_HEADSTAGE, NaN, str=str)
+			DC_DocumentChannelProperty(panelTitle, "Digitizer Hardware Name", INDEP_HEADSTAGE, NaN, NaN, str=str)
 			sprintf str, "%#0X", str2num(devInfoText[%DeviceSerialNumber])
-			DC_DocumentChannelProperty(panelTitle, "Digitizer Serial Numbers", INDEP_HEADSTAGE, NaN, str=str)
+			DC_DocumentChannelProperty(panelTitle, "Digitizer Serial Numbers", INDEP_HEADSTAGE, NaN, NaN, str=str)
 			break
 		default:
 			ASSERT(0, "Unknown hardware")
@@ -1559,17 +1559,19 @@ End
 
 /// @brief Document channel properties of DA and AD channels
 ///
-/// Knows about unassociated channels and creates the key `$entry UNASSOC_$channelNumber` for them
+/// Knows about unassociated channels and creates the special key returned by
+/// CreateLBNUnassocKey().
 ///
-/// @param panelTitle device
-/// @param entry      name of the property
-/// @param headstage  number of headstage, must be `NaN` for unassociated channels
-/// @param channelNumber number of the channel
+/// @param panelTitle     device
+/// @param entry          name of the property
+/// @param headstage      number of headstage, must be `NaN` for unassociated channels
+/// @param channelNumber  number of the channel
+/// @param channelType    type of the channel
 /// @param var [optional] numeric value
 /// @param str [optional] string value
-static Function DC_DocumentChannelProperty(panelTitle, entry, headstage, channelNumber, [var, str])
+static Function DC_DocumentChannelProperty(panelTitle, entry, headstage, channelNumber, channelType, [var, str])
 	string panelTitle, entry
-	variable headstage, channelNumber
+	variable headstage, channelNumber, channelType
 	variable var
 	string str
 
@@ -1604,7 +1606,7 @@ static Function DC_DocumentChannelProperty(panelTitle, entry, headstage, channel
 	endif
 
 	// headstage is not finite, so the channel is unassociated
-	ua_entry = CreateLBNUnassocKey(entry, channelNumber)
+	ua_entry = CreateLBNUnassocKey(entry, channelNumber, channelType)
 
 	if(!ParamIsDefault(var))
 		colData = FindDimLabel(sweepDataLNB, COLS, ua_entry)

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -4103,10 +4103,10 @@ End
 /// Before dfe2d862 (Make the function AB_SplitTTLWaveIntoComponents available for all, 2015-10-07)
 /// we stored headstage independent data in either all entries or only the first one.
 /// Since that commit we store the data in `INDEP_HEADSTAGE`.
-Function GetIndexForHeadstageIndepData(numericalValues)
-	WAVE numericalValues
+Function GetIndexForHeadstageIndepData(values)
+	WAVE values
 
-	return DimSize(numericalValues, LAYERS) == NUM_HEADSTAGES ? 0 : INDEP_HEADSTAGE
+	return DimSize(values, LAYERS) == NUM_HEADSTAGES ? 0 : INDEP_HEADSTAGE
 End
 
 /// @brief Return a list of TTL stimsets which are indexed by DAEphys TTL channels

--- a/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
+++ b/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
@@ -713,10 +713,10 @@ static Function NWB_AppendSweepLowLevel(locationID, panelTitle, ITCDataWave, ITC
 		// this can be a buggy headstage state
 		// we know that these AD/DA entries really belong to that headstate
 		// if no unassociated entry exists
-		key = CreateLBNUnassocKey("DAC", DACs[i])
+		key = CreateLBNUnassocKey("DAC", DACs[i], NaN)
 		DACUnassoc = GetLastSettingIndep(numericalValues, sweep, key, DATA_ACQUISITION_MODE)
 
-		key = CreateLBNUnassocKey("ADC", ADCs[i])
+		key = CreateLBNUnassocKey("ADC", ADCs[i], NaN)
 		ADCUnassoc = GetLastSettingIndep(numericalValues, sweep, key, DATA_ACQUISITION_MODE)
 
 		if(IsNaN(DACUnassoc) && IsNan(ADCUnassoc))

--- a/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
+++ b/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
@@ -2930,11 +2930,11 @@ Function TPDuringDAQTPAndAssoc_REENTRY([str])
 	WAVE ADChannelTypes = GetLastSetting(numericalValues, sweepNo, "AD ChannelType", DATA_ACQUISITION_MODE)
 	CHECK_EQUAL_WAVES(ADChannelTypes, {DAQ_CHANNEL_TYPE_TP, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode = WAVE_DATA)
 
-	key = CreateLBNUnassocKey("DA ChannelType", 1)
+	key = CreateLBNUnassocKey("DA ChannelType", 1, ITC_XOP_CHANNEL_TYPE_DAC)
 	channelTypeUnassoc = GetLastSettingIndep(numericalValues, sweepNo, key, DATA_ACQUISITION_MODE)
 	CHECK_EQUAL_VAR(channelTypeUnassoc, DAQ_CHANNEL_TYPE_TP)
 
-	key = CreateLBNUnassocKey("AD ChannelType", 1)
+	key = CreateLBNUnassocKey("AD ChannelType", 1, ITC_XOP_CHANNEL_TYPE_ADC)
 	channelTypeUnassoc = GetLastSettingIndep(numericalValues, sweepNo, key, DATA_ACQUISITION_MODE)
 	CHECK_EQUAL_VAR(channelTypeUnassoc, DAQ_CHANNEL_TYPE_DAQ)
 
@@ -2942,14 +2942,14 @@ Function TPDuringDAQTPAndAssoc_REENTRY([str])
 	tpAmplitude = GetLastSettingIndep(numericalValues, sweepNo, "TP Amplitude VC", DATA_ACQUISITION_MODE)
 	CHECK_EQUAL_WAVES(stimScale, {tpAmplitude, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode = WAVE_DATA)
 
-	key = CreateLBNUnassocKey(STIMSET_SCALE_FACTOR_KEY, 1)
+	key = CreateLBNUnassocKey(STIMSET_SCALE_FACTOR_KEY, 1, ITC_XOP_CHANNEL_TYPE_DAC)
 	stimScaleUnassoc = GetLastSettingIndep(numericalValues, sweepNo, key, DATA_ACQUISITION_MODE)
 	CHECK_EQUAL_VAR(stimScaleUnassoc, 0.0)
 
 	WAVE/Z/T stimsets = GetLastSetting(textualValues, sweepNo, STIM_WAVE_NAME_KEY, DATA_ACQUISITION_MODE)
 	CHECK_EQUAL_TEXTWAVES(stimsets, {"TestPulse", "", "", "", "", "", "", "", ""}, mode = WAVE_DATA)
 
-	key = CreateLBNUnassocKey(STIM_WAVE_NAME_KEY, 1)
+	key = CreateLBNUnassocKey(STIM_WAVE_NAME_KEY, 1, ITC_XOP_CHANNEL_TYPE_DAC)
 	stimsetUnassoc = GetLastSettingTextIndep(textualValues, sweepNo, key, DATA_ACQUISITION_MODE)
 	stimsetUnassocRef = "TestPulse"
 	CHECK_EQUAL_STR(stimsetUnassoc, stimsetUnassocRef)
@@ -3461,7 +3461,7 @@ Function UnassocChannelsDuplicatedEntry_REENTRY([str])
 		Duplicate/T/RMD=[0]/FREE wv, singleRow
 		Redimension/N=(DimSize(singleRow, ROWS) * DimSize(singleRow, COLS))/E=1 singleRow
 		Make/FREE/T unassocEntries
-		Grep/E=".* UNASSOC_\d$" singleRow as unassocEntries
+		Grep/E=".* u_(AD|DA)\d$" singleRow as unassocEntries
 		CHECK(!V_Flag)
 		CHECK(V_Value > 0)
 

--- a/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
+++ b/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
@@ -2893,7 +2893,7 @@ Function TPDuringDAQTPAndAssoc_REENTRY([str])
 	string str
 
 	variable sweepNo, col, channelTypeUnassoc, tpAmplitude, stimScaleUnassoc
-	string ctrl, stimsetUnassoc, stimsetUnassocRef
+	string ctrl, stimsetUnassoc, stimsetUnassocRef, key
 
 	CHECK_EQUAL_VAR(GetSetVariable(str, "SetVar_Sweep"), 1)
 
@@ -2930,23 +2930,27 @@ Function TPDuringDAQTPAndAssoc_REENTRY([str])
 	WAVE ADChannelTypes = GetLastSetting(numericalValues, sweepNo, "AD ChannelType", DATA_ACQUISITION_MODE)
 	CHECK_EQUAL_WAVES(ADChannelTypes, {DAQ_CHANNEL_TYPE_TP, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode = WAVE_DATA)
 
-	channelTypeUnassoc = GetLastSettingIndep(numericalValues, sweepNo, "DA ChannelType UNASSOC_1", DATA_ACQUISITION_MODE)
+	key = CreateLBNUnassocKey("DA ChannelType", 1)
+	channelTypeUnassoc = GetLastSettingIndep(numericalValues, sweepNo, key, DATA_ACQUISITION_MODE)
 	CHECK_EQUAL_VAR(channelTypeUnassoc, DAQ_CHANNEL_TYPE_TP)
 
-	channelTypeUnassoc = GetLastSettingIndep(numericalValues, sweepNo, "AD ChannelType UNASSOC_1", DATA_ACQUISITION_MODE)
+	key = CreateLBNUnassocKey("AD ChannelType", 1)
+	channelTypeUnassoc = GetLastSettingIndep(numericalValues, sweepNo, key, DATA_ACQUISITION_MODE)
 	CHECK_EQUAL_VAR(channelTypeUnassoc, DAQ_CHANNEL_TYPE_DAQ)
 
 	WAVE/Z stimScale = GetLastSetting(numericalValues, sweepNo, STIMSET_SCALE_FACTOR_KEY, DATA_ACQUISITION_MODE)
 	tpAmplitude = GetLastSettingIndep(numericalValues, sweepNo, "TP Amplitude VC", DATA_ACQUISITION_MODE)
 	CHECK_EQUAL_WAVES(stimScale, {tpAmplitude, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode = WAVE_DATA)
 
-	stimScaleUnassoc = GetLastSettingIndep(numericalValues, sweepNo, STIMSET_SCALE_FACTOR_KEY + " UNASSOC_1", DATA_ACQUISITION_MODE)
+	key = CreateLBNUnassocKey(STIMSET_SCALE_FACTOR_KEY, 1)
+	stimScaleUnassoc = GetLastSettingIndep(numericalValues, sweepNo, key, DATA_ACQUISITION_MODE)
 	CHECK_EQUAL_VAR(stimScaleUnassoc, 0.0)
 
 	WAVE/Z/T stimsets = GetLastSetting(textualValues, sweepNo, STIM_WAVE_NAME_KEY, DATA_ACQUISITION_MODE)
 	CHECK_EQUAL_TEXTWAVES(stimsets, {"TestPulse", "", "", "", "", "", "", "", ""}, mode = WAVE_DATA)
 
-	stimsetUnassoc = GetLastSettingTextIndep(textualValues, sweepNo, STIM_WAVE_NAME_KEY + " UNASSOC_1", DATA_ACQUISITION_MODE)
+	key = CreateLBNUnassocKey(STIM_WAVE_NAME_KEY, 1)
+	stimsetUnassoc = GetLastSettingTextIndep(textualValues, sweepNo, key, DATA_ACQUISITION_MODE)
 	stimsetUnassocRef = "TestPulse"
 	CHECK_EQUAL_STR(stimsetUnassoc, stimsetUnassocRef)
 End

--- a/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
+++ b/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
@@ -2224,8 +2224,8 @@ End
 Function UnassociatedChannels_REENTRY([str])
 	string str
 
-	string device, sweeps, configs, unit
-	variable numEntries, i, j, numSweeps
+	string device, sweeps, configs, unit, expectedStr
+	variable numEntries, i, j, k, numSweeps, value
 
 	numSweeps = 1
 
@@ -2356,6 +2356,25 @@ Function UnassociatedChannels_REENTRY([str])
 					CHECK_EQUAL_TEXTWAVES(sweepCounts, {"", "", "", "", "", "", "", "", ";0;;0;;;;;"})
 					break
 			endswitch
+
+			// fetch some labnotebook entries, the last channel is unassociated
+			for(k = 0; k < DimSize(ADCs, ROWS); k += 1)
+				value = GetLastSettingChannel(numericalValues, j, "AD ChannelType", ADCs[k], ITC_XOP_CHANNEL_TYPE_ADC, DATA_ACQUISITION_MODE)
+				CHECK_EQUAL_VAR(value, DAQ_CHANNEL_TYPE_DAQ)
+
+				str = GetLastSettingTextChannel(numericalValues, textualValues, j, "AD Unit", ADCs[k], ITC_XOP_CHANNEL_TYPE_ADC, DATA_ACQUISITION_MODE)
+				expectedStr= "pA"
+				CHECK_EQUAL_STR(str, expectedStr)
+			endfor
+
+			for(k = 0; k < DimSize(DACs, ROWS); k += 1)
+				value = GetLastSettingChannel(numericalValues, j, "DA ChannelType", DACs[k], ITC_XOP_CHANNEL_TYPE_DAC, DATA_ACQUISITION_MODE)
+				CHECK_EQUAL_VAR(value, DAQ_CHANNEL_TYPE_DAQ)
+
+				str = GetLastSettingTextChannel(numericalValues, textualValues, j, "DA Unit", DACs[k], ITC_XOP_CHANNEL_TYPE_DAC, DATA_ACQUISITION_MODE)
+				expectedStr= "mV"
+				CHECK_EQUAL_STR(str, expectedStr)
+			endfor
 		endfor
 	endfor
 

--- a/Packages/Testing-MIES/UTF_TestNWBExportV1.ipf
+++ b/Packages/Testing-MIES/UTF_TestNWBExportV1.ipf
@@ -186,7 +186,7 @@ Function/S GetChannelNameFromChannelType(groupID, device, channel, sweep, params
 			channelName += "_" + num2str(params.channelNumber)
 
 			if(IsNaN(params.electrodeNumber))
-				key = CreateLBNUnassocKey("DAC", params.channelNumber)
+				key = CreateLBNUnassocKey("DAC", params.channelNumber, params.channelType)
 				entry = GetLastSettingIndep(numericalValues, sweep, key, DATA_ACQUISITION_MODE)
 			else
 				WAVE/Z settings = GetLastSetting(numericalValues, sweep, "DAC", DATA_ACQUISITION_MODE)
@@ -202,7 +202,7 @@ Function/S GetChannelNameFromChannelType(groupID, device, channel, sweep, params
 			channelName += "_" + num2str(params.channelNumber)
 
 			if(IsNaN(params.electrodeNumber))
-				key = CreateLBNUnassocKey("ADC", params.channelNumber)
+				key = CreateLBNUnassocKey("ADC", params.channelNumber, params.channelType)
 				entry = GetLastSettingIndep(numericalValues, sweep, key, DATA_ACQUISITION_MODE)
 			else
 				WAVE/Z settings = GetLastSetting(numericalValues, sweep, "ADC", DATA_ACQUISITION_MODE)

--- a/Packages/doc/labnotebook-docs.rst
+++ b/Packages/doc/labnotebook-docs.rst
@@ -101,10 +101,9 @@ Caveats
   from the headstage independent layer only.
 * In case unassociated DA/AD channels were used (these are channels which are
   not connected to a headstage) during acquisition there are additional entries
-  present which are formatted like `$entry UNASSOC_$channelNumber` and only
-  have entries in the ninth layer (as it is by definition headstage
-  independent data). The entry names also don't overlap for AD/DA so having
-  only the channel number in the name is enough.
+  present which are formatted like `$entry UNASSOC_$channelNumber` (old style)
+  or `$entry u_(AD|DA)$channelNumber` (new style) and only have entries in the
+  ninth layer (as it is by definition headstage independent data).
 * One important concept is valid entries vs placeholder entries. All non-`NaN`
   or non-empty string entries are valid entries. Therefore only valid entries
   override other placeholder entries. But placeholder entries never override

--- a/Packages/doc/labnotebook-docs.rst
+++ b/Packages/doc/labnotebook-docs.rst
@@ -99,10 +99,12 @@ Caveats
 * Some entries are, for historical reasons, present in both the first layer and
   the headstage independent layer (nineth layer). New code should query the data
   from the headstage independent layer only.
-* In case unassociated DA/AD channels were used during acquisition there are
-  additional entries present which are formatted like `$entry UNASSOC_$channelNumber`
-  and only have entries in the nineth layer (as it is by definition headstage
-  independent data).
+* In case unassociated DA/AD channels were used (these are channels which are
+  not connected to a headstage) during acquisition there are additional entries
+  present which are formatted like `$entry UNASSOC_$channelNumber` and only
+  have entries in the ninth layer (as it is by definition headstage
+  independent data). The entry names also don't overlap for AD/DA so having
+  only the channel number in the name is enough.
 * One important concept is valid entries vs placeholder entries. All non-`NaN`
   or non-empty string entries are valid entries. Therefore only valid entries
   override other placeholder entries. But placeholder entries never override


### PR DESCRIPTION
Unassociated DA/AD labnotebook entries are suffixed with
"UNASSOC_$channelNumber". At first sight this might indicate that the
entries are not distinct if you have multiple unassociated DA/AD
channels with the same channel number.

But it turns out that we don't have labnotebook entries which have the
same name for the DA and AD channels.

In order that it also stays like that we add a small test to check that.

- [x] 'UNASSOC_$channelNumber' -> 'u_$channelType_$channelNumber'
- [x] Add generic wrapper `GetLastSettingChannel` which returns the settings for given channel. Add support for both new and old style entries
- [x] Add documentation, mention in labnotebook.rst
