### PR TITLE
Preserve SweepFormula wave location

### DIFF
--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -781,7 +781,7 @@ Function SF_FormulaPlotter(graph, formula, [dfr])
 		Redimension/N=(-1, dim1X * dim2X)/E=1 wv
 
 		WAVE wvX = GetSweepFormulaX(dfr)
-		MoveWaveWithOverwrite(wvX, wv)
+		Duplicate/O wv $GetWavesDataFolder(wvX, 2)
 		WAVE wvX = GetSweepFormulaX(dfr)
 	endif
 
@@ -792,7 +792,7 @@ Function SF_FormulaPlotter(graph, formula, [dfr])
 	Redimension/N=(-1, dim1Y * dim2Y)/E=1 wv
 
 	WAVE wvY = GetSweepFormulaY(dfr)
-	MoveWaveWithOverwrite(wvY, wv)
+	Duplicate/O wv $GetWavesDataFolder(wvY, 2)
 	WAVE wvY = GetSweepFormulaY(dfr)
 
 	if(!WindowExists(win))


### PR DESCRIPTION
Do not use the `KillOrMoveToTrash` functionality for evaluated sweep
formula waves.

Closes #351