### PR TITLE
fix for AbortTP test failing

### DIFF
--- a/Packages/MIES/MIES_DataAcquisition.ipf
+++ b/Packages/MIES/MIES_DataAcquisition.ipf
@@ -242,10 +242,15 @@ Function DQ_ApplyAutoBias(panelTitle, BaselineSSAvg, SSResistance)
 	Wave BaselineSSAvg, SSResistance
 
 	variable headStage, actualcurrent, current, targetVoltage, targetVoltageTol, setVoltage
-	variable resistance, maximumAutoBiasCurrent
+	variable resistance, maximumAutoBiasCurrent, lastInvocation, curTime
+
+	if(DAP_DeviceIsUnlocked(panelTitle))
+		return NaN
+	endif
+
 	Wave TPStorage = GetTPStorage(panelTitle)
-	variable lastInvocation = GetNumberFromWaveNote(TPStorage, AUTOBIAS_LAST_INVOCATION_KEY)
-	variable curTime = ticks * TICKS_TO_SECONDS
+	lastInvocation = GetNumberFromWaveNote(TPStorage, AUTOBIAS_LAST_INVOCATION_KEY)
+	curTime = ticks * TICKS_TO_SECONDS
 
 	WAVE guiStateWave = GetDA_EphysGuiStateNum(panelTitle)
 


### PR DESCRIPTION
DQ_ApplyAutoBias referred to non existing panel

When the DA_Ephys panel is killed while TP is running or TP is stopped then
on next TP start the remaining data is read out from Async.
This means the panel can already have been closed or reopened.

The fix skips the Auto Bias apply if the window is not present any more.

However, if in regular operation a user opens a new DA_Ephys panel and locks
it to the same device, DQ_ApplyAutoBias will work with the current GUI state
when referring to the old TP data.

closes https://github.com/AllenInstitute/MIES/issues/361