### PR TITLE
P_PressureControl: Do nothing if the panel is not locked

### DIFF
--- a/Packages/MIES/MIES_PressureControl.ipf
+++ b/Packages/MIES/MIES_PressureControl.ipf
@@ -65,6 +65,11 @@ Function P_PressureControl(panelTitle)
 	string panelTitle
 
 	variable headStage, manPressureAll
+
+	if(DAP_DeviceIsUnlocked(panelTitle))
+		return NaN
+	endif
+
 	WAVE PressureDataWv = P_GetPressureDataWaveRef(panelTitle)
 
 	manPressureAll = DAG_GetNumericalValue(panelTitle, "check_DataAcq_ManPressureAll")


### PR DESCRIPTION
Followup fix from b6b031ab (fix for AbortTP test failing,
DQ_ApplyAutoBias referred to non existing panel, 2019-11-08).

This situation can happen if we called from TP_ROAnalysis which is the
readout function from the async framework.