### PR TITLE
Enhance history storing in nwb

### DIFF
--- a/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
+++ b/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
@@ -324,7 +324,7 @@ Function NWB_ExportAllData([overrideFilePath, writeStoredTestPulses, writeIgorHi
 	endif
 
 	if(ParamIsDefault(writeIgorHistory))
-		writeIgorHistory = 0
+		writeIgorHistory = 1
 	else
 		writeIgorHistory = !!writeIgorHistory
 	endif
@@ -456,7 +456,7 @@ Function NWB_ExportWithDialog(exportType)
 	DeleteFile/Z S_filename
 
 	if(exportType == NWB_EXPORT_DATA)
-		NWB_ExportAllData(overrideFilePath=S_filename, writeStoredTestPulses = 1, writeIgorHistory = 1)
+		NWB_ExportAllData(overrideFilePath=S_filename, writeStoredTestPulses = 1)
 	elseif(exportType == NWB_EXPORT_STIMSETS)
 		NWB_ExportAllStimsets(overrideFilePath=S_filename)
 	else

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -4195,7 +4195,7 @@ End
 ///        a readable copy of the history starting from the time of the
 ///        notebook creation.
 Function CreateHistoryNotebook()
-	NewNotebook/V=0/F=0/N=HistoryCarbonCopy
+	NewNotebook/K=2/V=0/F=0/N=HistoryCarbonCopy
 End
 
 /// @brief Return the text of the history notebook

--- a/Packages/Testing-MIES/UTF_TestNWBExportV1.ipf
+++ b/Packages/Testing-MIES/UTF_TestNWBExportV1.ipf
@@ -7,6 +7,14 @@ Function NoTestSuite()
 	FAIL()
 End
 
+Function TestHistory(fileID)
+	variable fileID
+
+	WAVE/Z/T history = IPNWB#H5_LoadDataSet(fileID, "/general/history")
+	CHECK_WAVE(history, TEXT_WAVE)
+	CHECK(DimSize(history, ROWS) > 0)
+end
+
 Function TestLabnotebooks(fileID, device)
 	variable fileID
 	string device
@@ -601,6 +609,9 @@ Function TestNwbExport()
 	CHECK_WAVE(stimuluses, TEXT_WAVE)
 
 	fileID = IPNWB#H5_OpenFile(discLocation)
+
+	// check history
+	TestHistory(fileID)
 
 	// check LBNs
 	TestLabnotebooks(fileID, device)


### PR DESCRIPTION
Close #375.

I've made the possibility of exporting a NWB file without history much smaller.

We could also remove the `writeIgorHistory` parameter from `NWB_ExportAllData` alltogether and always store the experiment history. I would be in favour of that.