### PR TITLE
Require latest IP8 nightly version

### DIFF
--- a/Packages/MIES_Include.ipf
+++ b/Packages/MIES_Include.ipf
@@ -2,11 +2,16 @@
 #pragma rtGlobals=3 // Use modern global access method and strict wave access.
 #pragma rtFunctionErrors=1
 
-#pragma IgorVersion=8.04
-
+// Igor Pro nightly installation:
+// - Download from https://www.byte-physics.de/Downloads/WinIgor8_05DEC2019.zip
+// - Close Igor Pro 8
+// - Extract the contents into C:\Program Files\WaveMetrics\Igor Pro 8 Folder (overwriting existing files, requires Administrator access)
+// - Restart Igor Pro 8
+//
 // By ignoring the error and *commenting out* the below check you will certainly break MIES.
-#if (NumberByKey("BUILD", IgorInfo(0)) < 34722)
-#define *** MIES requires a more recent version of Igor Pro 8, please install the latest version. ***
+#if (NumberByKey("BUILD", IgorInfo(0)) < 34795)
+#define *** Too old Igor Pro 8 version, click "Edit procedure" for instructions
+#pragma IgorVersion=8.04
 #endif
 
 /// @file MIES_Include.ipf


### PR DESCRIPTION
This fixes a bug which can be more-or-less easily triggered when the
databrowser/sweepbrowser is open, a formula plot is open and the databrowser/sweepbrowser
is closed.

It does not immediately crash but might also hang on for a while.

The reason is that the following code

Function crash()

	NewDataFolder/O/S foo
	make ddd
	display ddd
	SetDataFolder root:
	killwrapper("root:foo")
End

ThreadSafe Function killwrapper(String dfPath)
	KillDataFolder/Z $dfPath
End

kills the ddd wave for old IP versions. But that wave is displayed and
thus must not be killed.