### PR TITLE
Require latest IP8 nightly

### DIFF
--- a/Packages/MIES_Include.ipf
+++ b/Packages/MIES_Include.ipf
@@ -3,13 +3,13 @@
 #pragma rtFunctionErrors=1
 
 // Igor Pro nightly installation:
-// - Download from https://www.byte-physics.de/Downloads/WinIgor8_05DEC2019.zip
+// - Download from https://www.byte-physics.de/Downloads/WinIgor8_10DEC2019.zip
 // - Close Igor Pro 8
 // - Extract the contents into C:\Program Files\WaveMetrics\Igor Pro 8 Folder (overwriting existing files, requires Administrator access)
 // - Restart Igor Pro 8
 //
 // By ignoring the error and *commenting out* the below check you will certainly break MIES.
-#if (NumberByKey("BUILD", IgorInfo(0)) < 34795)
+#if (NumberByKey("BUILD", IgorInfo(0)) < 34845)
 #define *** Too old Igor Pro 8 version, click "Edit procedure" for instructions
 #pragma IgorVersion=8.04
 #endif


### PR DESCRIPTION
This fixes a bug for IP 32bit where

make wv = {1}
MatrixOP/P=1 out = sumCols((-1) * wv)^t

gave 0 instead of -1.

And that is used in the sweep formula code itself and was uncovered by
one of the tests.

Close #390.