### PR TITLE
Loading split configuration files

### DIFF
--- a/Packages/MIES/MIES_BackgroundWatchdog.ipf
+++ b/Packages/MIES/MIES_BackgroundWatchdog.ipf
@@ -14,6 +14,8 @@
 #include ":MIES_Structures"
 #include ":MIES_Async"
 #include ":MIES_Utilities"
+// JSON XOP
+#include "json_functions"
 
 /// @endcond
 

--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -347,7 +347,7 @@ Function CONF_RestoreWindow(fName[, usePanelTypeFromFile, rigFile])
 			endif
 		endif
 
-		CONF_AddConfigFileUserData(wName, fullFilePath)
+		CONF_AddConfigFileUserData(wName, fullFilePath, rigFile)
 	catch
 		errMsg = getRTErrMessage()
 		if(!IsNaN(jsonID))
@@ -532,12 +532,17 @@ Function/S CONF_RestoreDAEphys(jsonID, fullFilePath, [middleOfExperiment, forceN
 	endtry
 End
 
-/// @brief Add the config file path and SHA-256 hash to the panel as user data
-static Function CONF_AddConfigFileUserData(win, fullFilePath)
-	string win, fullFilePath
+/// @brief Add the config file paths and SHA-256 hashes to the panel as user data
+static Function CONF_AddConfigFileUserData(win, fullFilePath, rigFile)
+	string win, fullFilePath, rigFile
 
-	SetWindow $win, userData($EXPCONFIG_UDATA_SOURCEFILE_PATH)=fullFilePath
-	SetWindow $win, userData($EXPCONFIG_UDATA_SOURCEFILE_HASH)=CalcHashForFile(fullFilePath)
+	SetWindow $win, userData($EXPCONFIG_UDATA_SOURCEFILE_PATH)=fullFilePath + "|" + rigFile
+
+	if(FileExists(rigFile))
+		SetWindow $win, userData($EXPCONFIG_UDATA_SOURCEFILE_HASH)=CalcHashForFile(fullFilePath) + "|" + CalcHashForFile(rigFile)
+	else
+		SetWindow $win, userData($EXPCONFIG_UDATA_SOURCEFILE_HASH)=CalcHashForFile(fullFilePath) + "|"
+	endif
 End
 
 /// @brief Parses a json formatted string to a json object. This function shows a helpful error message if the parse fails

--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -318,8 +318,6 @@ Function CONF_RestoreWindow(fName[, usePanelTypeFromFile, rigFile])
 			elseif(!CmpStr(panelType, PANELTAG_DATABROWSER))
 				DB_OpenDataBrowser()
 				wName = GetMainWindow(GetCurrentWindow())
-				SetWindow $wName, userData($EXPCONFIG_UDATA_SOURCEFILE_PATH)=""
-				SetWindow $wName, userData($EXPCONFIG_UDATA_SOURCEFILE_HASH)=""
 				wName = CONF_JSONToWindow(wName, restoreMask, jsonID)
 				CONF_AddConfigFileUserData(wName, fullFilePath)
 				print "Configuration restored for " + wName
@@ -345,8 +343,6 @@ Function CONF_RestoreWindow(fName[, usePanelTypeFromFile, rigFile])
 					return 0
 				endif
 				jsonID = CONF_ParseJSON(input)
-				SetWindow $wName, userData($EXPCONFIG_UDATA_SOURCEFILE_PATH)=""
-				SetWindow $wName, userData($EXPCONFIG_UDATA_SOURCEFILE_HASH)=""
 				wName = CONF_JSONToWindow(wName, restoreMask, jsonID)
 				CONF_AddConfigFileUserData(wName, fullFilePath)
 				print "Configuration restored for " + wName
@@ -457,9 +453,6 @@ Function CONF_RestoreDAEphys(jsonID, fullFilePath, [middleOfExperiment, forceNew
 				panelTitle = DAP_CreateDAEphysPanel()
 			endif
 		endif
-
-		SetWindow $panelTitle, userData($EXPCONFIG_UDATA_SOURCEFILE_PATH)=""
-		SetWindow $panelTitle, userData($EXPCONFIG_UDATA_SOURCEFILE_HASH)=""
 
 		if(middleOfExperiment)
 			PGC_SetAndActivateControl(panelTitle, "check_Settings_SyncMiesToMCC", val = CHECKBOX_UNSELECTED)
@@ -841,6 +834,9 @@ Function/S CONF_JSONToWindow(wName, restoreMask, jsonID)
 
 		ASSERT(WinType(wName), "Window " + wName + " does not exist!")
 		ASSERT(restoreMask & (EXPCONFIG_SAVE_VALUE | EXPCONFIG_SAVE_POSITION | EXPCONFIG_SAVE_USERDATA | EXPCONFIG_SAVE_DISABLED | EXPCONFIG_SAVE_CTRLTYPE), "No property class enabled to restore in restoreMask.")
+
+		SetWindow $wName, userData($EXPCONFIG_UDATA_SOURCEFILE_PATH)=""
+		SetWindow $wName, userData($EXPCONFIG_UDATA_SOURCEFILE_HASH)=""
 
 		if(restoreMask & EXPCONFIG_MINIMIZE_ON_RESTORE)
 			SetWindow $wName, hide=1

--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -314,12 +314,11 @@ Function CONF_RestoreWindow(fName[, usePanelTypeFromFile, rigFile])
 				if(!IsEmpty(rigFile))
 					CONF_JoinRigFile(jsonID, rigFile)
 				endif
-				CONF_RestoreDAEphys(jsonID, fullFilePath, forceNewPanel = 1)
+				wName = CONF_RestoreDAEphys(jsonID, fullFilePath, forceNewPanel = 1)
 			elseif(!CmpStr(panelType, PANELTAG_DATABROWSER))
 				DB_OpenDataBrowser()
 				wName = GetMainWindow(GetCurrentWindow())
 				wName = CONF_JSONToWindow(wName, restoreMask, jsonID)
-				CONF_AddConfigFileUserData(wName, fullFilePath)
 				print "Configuration restored for " + wName
 			else
 				ASSERT(0, "Configuration file entry for panel type has an unknown panel tag (" + panelType + ").")
@@ -336,7 +335,7 @@ Function CONF_RestoreWindow(fName[, usePanelTypeFromFile, rigFile])
 				if(!IsEmpty(rigFile))
 					CONF_JoinRigFile(jsonID, rigFile)
 				endif
-				CONF_RestoreDAEphys(jsonID, fullFilePath)
+				wName = CONF_RestoreDAEphys(jsonID, fullFilePath)
 			else
 				[input, fullFilePath] = LoadTextFile(fName, fileFilter = EXPCONFIG_FILEFILTER, message = "Open configuration file for frontmost window")
 				if(IsEmpty(input))
@@ -344,10 +343,11 @@ Function CONF_RestoreWindow(fName[, usePanelTypeFromFile, rigFile])
 				endif
 				jsonID = CONF_ParseJSON(input)
 				wName = CONF_JSONToWindow(wName, restoreMask, jsonID)
-				CONF_AddConfigFileUserData(wName, fullFilePath)
 				print "Configuration restored for " + wName
 			endif
 		endif
+
+		CONF_AddConfigFileUserData(wName, fullFilePath)
 	catch
 		errMsg = getRTErrMessage()
 		if(!IsNaN(jsonID))
@@ -408,7 +408,9 @@ End
 ///                      - Reuses locked DA_Ephys panel with same device as saved in configuration
 ///                      - Uses open unlocked DA_Ephys panel
 ///                      - Opens new DA_Ephys panel
-Function CONF_RestoreDAEphys(jsonID, fullFilePath, [middleOfExperiment, forceNewPanel])
+///
+/// @return name of the created DAEphys panel
+Function/S CONF_RestoreDAEphys(jsonID, fullFilePath, [middleOfExperiment, forceNewPanel])
 	variable jsonID
 	string fullFilePath
 	variable middleOfExperiment, forceNewPanel
@@ -491,7 +493,6 @@ Function CONF_RestoreDAEphys(jsonID, fullFilePath, [middleOfExperiment, forceNew
 
 		CONF_RestoreHeadstageAssociation(panelTitle, jsonID, middleOfExperiment)
 		CONF_RestoreUserPressure(panelTitle, jsonID)
-		CONF_AddConfigFileUserData(panelTitle, fullFilePath)
 
 		filename = GetTimeStamp() + PACKED_FILE_EXPERIMENT_SUFFIX
 		path = CONF_GetStringFromSettings(jsonID, SAVE_PATH)
@@ -510,7 +511,7 @@ Function CONF_RestoreDAEphys(jsonID, fullFilePath, [middleOfExperiment, forceNew
 
 		print "Start Sciencing"
 		SetWindow $panelTitle, hide=0, needUpdate=1
-
+		return panelTitle
 	catch
 		if(isTagged)
 			panelTitle = CONF_FindWindow(winHandle, uKey = DAEPHYS_UDATA_WINHANDLE)

--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -469,14 +469,16 @@ Function CONF_RestoreDAEphys(jsonID, fullFilePath, [middleOfExperiment, forceNew
 		endif
 
 		StimSetPath = CONF_GetStringFromSettings(jsonID, STIMSET_NAME)
-		if(IsEmpty(StimSetPath))
-			err = NWB_LoadAllStimSets(overwrite = 1)
-		else
-			err = NWB_LoadAllStimSets(overwrite = 1, fileName = StimSetPath)
-		endif
-		if(err)
-			print "Stim set failed to load, check file path"
-			ControlWindowToFront()
+		if(!IsEmpty(StimSetPath))
+			if(FileExists(StimSetPath))
+				err = NWB_LoadAllStimSets(overwrite = 1, fileName = StimSetPath)
+				if(err)
+					print "Stim set failed to load, check file path"
+					ControlWindowToFront()
+				endif
+			else
+				print "Specified StimSet file at " + StimSetPath + " not found! No file was loaded."
+			endif
 		endif
 
 		restoreMask = EXPCONFIG_SAVE_VALUE | EXPCONFIG_SAVE_POPUPMENU_AS_STRING_ONLY | EXPCONFIG_SAVE_DISABLED | EXPCONFIG_SAVE_ONLY_RELEVANT | EXPCONFIG_MINIMIZE_ON_RESTORE

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -596,7 +596,7 @@ Constant WAVEBUILDER_PANEL_VERSION  = 8
 /// - Changed names of entries
 /// - Changed units or meaning of entries
 /// - New/Changed layers of entries
-Constant LABNOTEBOOK_VERSION = 35
+Constant LABNOTEBOOK_VERSION = 36
 
 /// Version of the stimset wave note
 Constant STIMSET_NOTE_VERSION = 7

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -4879,3 +4879,91 @@ Function ScaleToIndexWrapper(wv, scale, dim)
 
 	return min(DimSize(wv, dim) - 1, max(0, trunc(index)))
 End
+
+/// @brief Syncs data from a source json into a target json.
+/// @param[in] srcJsonID json Id of source object
+/// @param[in] tgtJsonID json Id of target object
+/// @param[in] srcPath root path for sync in source object
+/// @param[in] tgtPath root path for sync in target
+Function SyncJSON(srcJsonID, tgtJsonID, srcPath, tgtPath)
+	variable srcJsonID, tgtJsonID
+	string srcPath, tgtPath
+
+	variable type, i, numKeys, arraySize, parentIsArray
+	string localTgtPath
+
+	ASSERT(!IsNull(srcPath), "Invalid source path")
+	ASSERT(!IsNull(tgtPath), "Invalid target path")
+
+	localTgtPath = tgtPath + srcPath
+	parentIsArray = IsJsonParentArray(srcJsonID, srcPath)
+	type = JSON_GetType(srcJsonID, srcPath)
+	if(type != JSON_OBJECT && !parentIsArray)
+		ASSERT(!JSON_Exists(tgtJsonID, localTgtPath), "Overwrite to non object attempted.")
+	endif
+
+	if(type == JSON_OBJECT)
+		if(parentIsArray)
+			JSON_SetObjects(tgtJsonID, localTgtPath)
+		else
+			JSON_AddTreeObject(tgtJsonID, localTgtPath)
+		endif
+
+		WAVE/T keys = JSON_GetKeys(srcJsonID, srcPath)
+		numKeys = DimSize(keys, ROWS)
+		for(i = 0; i < numKeys; i += 1)
+			SyncJSON(srcJsonID, tgtJsonID, srcPath + "/" + keys[i], tgtPath)
+		endfor
+	elseif(type == JSON_ARRAY)
+		if(parentIsArray)
+			JsonSetEmptyArray(tgtJsonID, localTgtPath)
+		else
+			ASSERT(!JSON_Exists(tgtJsonID, localTgtPath), "Overwrite attempted with array.")
+			JSON_AddTreeArray(tgtJsonID, localTgtPath)
+		endif
+
+		arraySize = JSON_GetArraySize(srcJsonID, srcPath)
+		JSON_AddObjects(tgtJsonID, localTgtPath, objCount = arraySize)
+		for(i = 0; i < arraySize; i += 1)
+			SyncJSON(srcJsonID, tgtJsonID, srcPath + "/" + num2istr(i), tgtPath)
+		endfor
+	elseif(type == JSON_NUMERIC)
+		JSON_SetVariable(tgtJsonID, localTgtPath, JSON_GetVariable(srcJsonID, srcPath))
+	elseif(type == JSON_STRING)
+		JSON_SetString(tgtJsonID, localTgtPath, JSON_GetString(srcJsonID, srcPath))
+	elseif(type == JSON_BOOL)
+		JSON_SetBoolean(tgtJsonID, localTgtPath, JSON_GetVariable(srcJsonID, srcPath))
+	elseif(type == JSON_NULL)
+		JSON_SetNull(tgtJsonID, localTgtPath)
+	else
+		ASSERT(0, "Invalid type")
+	endif
+
+End
+
+/// @brief Returns true if the parent path is an array.
+/// @param[in] jsonID Id of json
+/// @param[in] path location where parent is checked, for path "/parent/data" the location "/parent" is checked. For path "" the location "" is checked.
+static Function IsJsonParentArray(jsonID, path)
+	variable jsonID
+	string path
+
+	variable pos = strsearch(path, "/", Inf, 1)
+	if(pos >= 0)
+		path = path[0, pos - 1]
+	endif
+	return JSON_GetType(jsonID, path) == JSON_ARRAY
+End
+
+/// @brief Sets an empty array in a json
+/// @param[in] jsonID Id of json
+/// @param[in] path location where empty array is placed
+static Function JsonSetEmptyArray(jsonID, path)
+	variable jsonID
+	string path
+
+	Make/FREE/N=1 w
+
+	JSON_SetWave(jsonID, path, w)
+	JSON_Remove(jsonID, path + "/0")
+End

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -2035,8 +2035,8 @@ End
 /// -26: Digitizer Hardware Name
 /// -27: Digitizer Serial Numbers
 /// -28: Epochs
-/// -29: JSON config file: path
-/// -30: JSON config file: SHA-256 hash
+/// -29: JSON config file: path (`|` separated list of full file paths)
+/// -30: JSON config file: SHA-256 hash (`|` separated list of hashes)
 Function/Wave GetSweepSettingsTextKeyWave(panelTitle)
 	string panelTitle
 

--- a/Packages/Settings/1_DA_Ephys.json
+++ b/Packages/Settings/1_DA_Ephys.json
@@ -2,8 +2,6 @@
     "Common configuration data": {
         "Headstage Association": {
             "0": {
-                "Amplifier Serial": 0,
-                "Amplifier Title": "0,1",
                 "IC AD": 0,
                 "IC DA": 0,
                 "Pressure AD": 0,
@@ -21,8 +19,6 @@
                 "VC DA": 0
             },
             "1": {
-                "Amplifier Serial": 0,
-                "Amplifier Title": "0,1",
                 "IC AD": 1,
                 "IC DA": 1,
                 "Pressure AD": 1,

--- a/Packages/Settings/1_DA_Ephys_rig.json
+++ b/Packages/Settings/1_DA_Ephys_rig.json
@@ -1,0 +1,14 @@
+{
+    "Common configuration data": {
+        "Headstage Association": {
+            "0": {
+                "Amplifier Serial": 0,
+                "Amplifier Title": "0,1"
+            },
+            "1": {
+                "Amplifier Serial": 0,
+                "Amplifier Title": "0,1"
+            }
+        }
+    }
+}


### PR DESCRIPTION
The AutoLoader (Load Standard Configuration) is now aware of [Name]_rig.json files that complement [Name].json files with a panel configuration. 
The rig file support is reduced to work for for DA_Ephys panels only.

Changed StimSet path behavior for DA_Ephys configuration laoding:
- when path is "" then StimSet loading is skipped
- when path is set and file does not exist a message is shown
- when path is set and file exists it is loaded without dialog.

I added an adapted configuration using a rig file.

Due to the StimsetPath change it is required to either preLoad the default stimsets or adapt the stimset path to the local location of the default nwb file in 1_DA_Ephys.json. If not adapted the panel restoration will fail when it tries to set a Stimset that was not previously loaded.

closes https://github.com/AllenInstitute/MIES/issues/396