### PR TITLE
SweepFormula: Always return 0 for instantaneous with too few levels

### DIFF
--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -807,7 +807,7 @@ Function/WAVE SF_FormulaExecutor(jsonID, [jsonPath, graph])
 
 					for(i = 0; i < numSets; i += 1)
 						if(levelPerSet[i] <= 1)
-							outD[i] = NaN
+							outD[i] = 0
 						else
 							Make/FREE/D/N=(levelPerSet[i] - 1) distances
 							distances[0, levelPerSet[i] - 2] = levels[i][p + 1] - levels[i][p]

--- a/Packages/Testing-MIES/UTF_SweepFormula.ipf
+++ b/Packages/Testing-MIES/UTF_SweepFormula.ipf
@@ -717,9 +717,9 @@ static Function TestAPFrequency()
 	WAVE output = SF_FormulaExecutor(SF_FormulaParser("apfrequency([10, 20, 30, 20], 0, 100)"))
 	Make/FREE/D output_ref = {0}
 
-	// returns NaN if nothing found for Instantaneous
+	// returns 0 if nothing found for Instantaneous
 	WAVE output = SF_FormulaExecutor(SF_FormulaParser("apfrequency([10, 20, 30, 20], 1, 100)"))
-	Make/FREE/D output_ref = {NaN}
+	Make/FREE/D output_ref = {0}
 
 	REQUIRE_EQUAL_WAVES(output, output_ref, mode = WAVE_DATA)
 End


### PR DESCRIPTION
Request by Tim Jarsky.

CLose #394.