### PR TITLE
LoadTextFile: Avoid opening the file twice

### DIFF
--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -4722,14 +4722,10 @@ Function [string data, string fName] LoadTextFile(string fileName[, string fileF
 		Open/R/P=home/Z=(zFlag)/F=fileFilter/M=message fnum as fileName
 	endif
 
-	if(IsEmpty(S_fileName))
+	if(IsEmpty(S_fileName) || V_flag)
 		return ["", ""]
 	endif
 
-	Open/Z/R fnum as S_fileName
-	if(V_flag)
-		return ["", S_fileName]
-	endif
 	FStatus fnum
 	data = ""
 	data = PadString(data, V_logEOF, 0x20)


### PR DESCRIPTION
The second open is not needed and leaves the file still locked on
windows as there is no corresponding close.

Bug introduced in 1f9f39c2 (Added utility function used in
MIES_Configuration, 2019-12-12).