### PR TITLE
tools/build-documentation.sh: Check sphinx-build version

### DIFF
--- a/tools/build-documentation.sh
+++ b/tools/build-documentation.sh
@@ -84,6 +84,15 @@ done
 if hash sphinx-build 2>/dev/null; then
   echo "Start sphinx-build"
 
+  sphinx_version=$(sphinx-build --version 2>&1 | cut -f 2 -d " ")
+  sphinx_version_required=1.8.3
+
+  if [[ "$sphinx_version" != "$sphinx_version_required" ]]; then
+    echo "Errors building the documentation" 1>&2
+    echo "sphinx-build version is wrong, we require exactly $sphinx_version_required but got $sphinx_version" 1>&2
+    Failed
+  fi
+
   rm -f sphinx-output.log
 
   sphinx-build -q -w sphinx-output.log . html


### PR DESCRIPTION
Incompatible versions result in difficult to understand error messages.