### PR TITLE
More specific error message for conflicts in split configurations

### DIFF
--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -2124,6 +2124,6 @@ static Function CONF_JoinRigFile(jsonID, rigFileName)
 		return 0
 	endif
 	jsonIDRig = CONF_ParseJSON(input)
-	SyncJSON(jsonIDRig, jsonID, "", "")
+	SyncJSON(jsonIDRig, jsonID, "", "", rigFileName)
 	JSON_Release(jsonIDRig)
 End


### PR DESCRIPTION
Now the source (rig) file name as well as the conflicting paths in the config
files are printed if a conflict is encountered.

- The previous ASSERTion was replaced with a simple Abort.

closes https://github.com/AllenInstitute/MIES/issues/414

from https://github.com/AllenInstitute/MIES/pull/397#issuecomment-571992950
and https://github.com/AllenInstitute/MIES/pull/397#issuecomment-572169844