### PR TITLE
AI_GetMCCSerialNumbers returns now a wave without duplicates as intended

### DIFF
--- a/Packages/MIES/MIES_AmplifierInteraction.ipf
+++ b/Packages/MIES/MIES_AmplifierInteraction.ipf
@@ -865,8 +865,7 @@ static Function/WAVE AI_GetMCCSerialNumbers()
 		AI_FindConnectedAmps()
 		WAVE W_TelegraphServers = GetAmplifierTelegraphServers()
 		Duplicate/FREE/R=[][FindDimLabel(W_TelegraphServers, COLS, "SerialNum")] W_TelegraphServers, OpenMCCList
-		DeleteDuplicates(OpenMCCList)
-		return OpenMCCList
+		return DeleteDuplicates(OpenMCCList)
 End
 
 /// @brief Return a path to the MCC.


### PR DESCRIPTION
- originally intended was that AI_GetMCCSerialNumbers returns a wave
  with amplifier serial numbers without duplicates, but it did not.

The function now correctly returns the wave without duplicates .

DeleteDuplicates returns the cleaned up wave as return wave.