### PR TITLE
Add configuration field Amplifier Channel to specify channel explicitly

### DIFF
--- a/Packages/MIES/MIES_AmplifierInteraction.ipf
+++ b/Packages/MIES/MIES_AmplifierInteraction.ipf
@@ -803,20 +803,15 @@ End
 /// Duplicate serial numbers are ignored as well as amplifier titles for the duplicates.
 /// For each unique serial number one MCC is opened.
 /// @param ampTitleList [optional, defaults to blank] MCC gui window title
-/// @param maxAttempts [optional, defaults to inf] Maximum number of attempts made to open specified MCCs
 /// @return 1 if all unique MCCs specified in ampSerialNumList were opened, 0 if one or more MCCs specified in ampSerialNumList were not able to be opened
-Function AI_OpenMCCs(ampSerialNumList, [ampTitleList, maxAttempts])
+Function AI_OpenMCCs(ampSerialNumList, [ampTitleList])
 	string ampSerialNumList
 	string ampTitleList
-	variable maxAttempts
 
 	string cmd, serialStr, title
 	variable i, j, numDups, serialNum, failedToOpenCount
 	variable ItemsInAmpSerialNumList = ItemsInList(AmpSerialNumList)
-
-	if(paramIsDefault(maxAttempts))
-		maxAttempts = inf
-	endif
+	variable maxAttempts = 3
 
 	if(paramIsDefault(AmpTitleList))
 		AmpTitleList = ""

--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -148,6 +148,7 @@ static StrConstant EXPCONFIG_SETTINGS_AMPTITLE = "0,1;2,3;4,5;6,7"
 static StrConstant EXPCONFIG_JSON_HSASSOCBLOCK = "Headstage Association"
 static StrConstant EXPCONFIG_JSON_AMPSERIAL = "Amplifier Serial"
 static StrConstant EXPCONFIG_JSON_AMPTITLE = "Amplifier Title"
+static StrConstant EXPCONFIG_JSON_AMPCHANNEL = "Amplifier Channel"
 static StrConstant EXPCONFIG_JSON_AMPVCDA = "VC DA"
 static StrConstant EXPCONFIG_JSON_AMPVCAD = "VC AD"
 static StrConstant EXPCONFIG_JSON_AMPICDA = "IC DA"
@@ -1703,8 +1704,10 @@ static Function CONF_GetHeadstageAssociation(panelTitle)
 			DAP_ParseAmplifierDef(amplifierDef, ampSerial, ampChannelID)
 			if(IsFinite(ampSerial) && IsFinite(ampChannelID))
 				JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_AMPSERIAL, ampSerial)
+				JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_AMPCHANNEL, ampChannelID)
 			else
 				JSON_AddNull(jsonID, jsonPath + EXPCONFIG_JSON_AMPSERIAL)
+				JSON_AddNull(jsonID, jsonPath + EXPCONFIG_JSON_AMPCHANNEL)
 			endif
 			JSON_AddString(jsonID, jsonPath + EXPCONFIG_JSON_AMPTITLE, StringFromList(trunc(i / 2), EXPCONFIG_SETTINGS_AMPTITLE))
 
@@ -1743,7 +1746,7 @@ static Function CONF_RestoreHeadstageAssociation(panelTitle, jsonID, midExp)
 	string panelTitle
 	variable jsonID, midExp
 
-	variable i, type, numRows, ampSerial, ampIndex, index, value
+	variable i, type, numRows, ampSerial, ampChannel, index, value
 	string jsonPath, jsonHSPath, winPositionMCC
 	string ampSerialList = ""
 	string ampTitleList = ""
@@ -1780,8 +1783,6 @@ static Function CONF_RestoreHeadstageAssociation(panelTitle, jsonID, midExp)
 	PGC_SetAndActivateControl(panelTitle, "button_Settings_UpdateAmpStatus")
 	PGC_SetAndActivateControl(panelTitle, "button_Settings_UpdateDACList")
 
-	Make/FREE/U/I/N=(ItemsInList(ampSerialList)) ampIDTracker = 1
-
 	for(i = 0; i < NUM_HEADSTAGES; i += 1)
 		jsonHSPath = jsonPath + num2istr(i)
 		PGC_SetAndActivateControl(panelTitle, "Popup_Settings_HeadStage", val = i)
@@ -1793,11 +1794,9 @@ static Function CONF_RestoreHeadstageAssociation(panelTitle, jsonID, midExp)
 			PGC_SetAndActivateControl(panelTitle, "popup_Settings_Pressure_dev", str = NONE)
 		elseif(type == JSON_OBJECT)
 			ampSerial = JSON_GetVariable(jsonID, jsonHSPath + EXPCONFIG_JSON_AMPSERIAL)
-			if(IsFinite(ampSerial))
-				ampIndex = WhichListItem(num2istr(ampSerial), ampSerialList)
-				ASSERT(ampIDTracker[ampIndex] <= 2, "More than two headstages are configured for the same amplifier serial.")
-				PGC_SetAndActivateControl(panelTitle, "popup_Settings_Amplifier", val = CONF_FindAmpInList(ampSerial, ampIDTracker[ampIndex]))
-				ampIDTracker[ampIndex] += 1
+			ampChannel = JSON_GetVariable(jsonID, jsonHSPath + EXPCONFIG_JSON_AMPCHANNEL)
+			if(IsFinite(ampSerial) && IsFinite(ampChannel))
+				PGC_SetAndActivateControl(panelTitle, "popup_Settings_Amplifier", val = CONF_FindAmpInList(ampSerial, ampChannel))
 			endif
 			PGC_SetAndActivateControl(panelTitle, "Popup_Settings_VC_DA", val = JSON_GetVariable(jsonID, jsonHSPath + EXPCONFIG_JSON_AMPVCDA))
 			PGC_SetAndActivateControl(panelTitle, "Popup_Settings_VC_AD", val = JSON_GetVariable(jsonID, jsonHSPath + EXPCONFIG_JSON_AMPVCAD))

--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -1772,7 +1772,7 @@ static Function CONF_RestoreHeadstageAssociation(panelTitle, jsonID, midExp)
 	WAVE telegraphServers = GetAmplifierTelegraphServers()
 	numRows = DimSize(telegraphServers, ROWS)
 	if(!numRows)
-		Assert(AI_OpenMCCs(ampSerialList, ampTitleList = ampTitleList, maxAttempts = ATTEMPTS), "Evil kittens prevented MultiClamp from opening - FULL STOP" )
+		Assert(AI_OpenMCCs(ampSerialList, ampTitleList = ampTitleList), "Evil kittens prevented MultiClamp from opening - FULL STOP" )
 	endif
 
 	winPositionMCC = CONF_GetStringFromSettings(jsonID, POSITION_MCC)

--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -1762,7 +1762,13 @@ static Function CONF_RestoreHeadstageAssociation(panelTitle, jsonID, midExp)
 		if(type == JSON_NULL)
 			continue
 		elseif(type == JSON_OBJECT)
-			ampSerialList = AddListItem(num2istr(JSON_GetVariable(jsonID, jsonHSPath + "/" + EXPCONFIG_JSON_AMPSERIAL)), ampSerialList)
+			ampSerial = JSON_GetVariable(jsonID, jsonHSPath + "/" + EXPCONFIG_JSON_AMPSERIAL)
+
+			if(IsNaN(ampSerial))
+				continue
+			endif
+
+			ampSerialList = AddListItem(num2istr(ampSerial), ampSerialList)
 			ampTitleList = AddListItem(JSON_GetString(jsonID, jsonHSPath + "/" + EXPCONFIG_JSON_AMPTITLE), ampTitleList)
 		else
 			ASSERT(0, "Unexpected entry for headstage data in Headstage Association block")

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -773,7 +773,6 @@ Constant DA_EPHYS_PANEL_PRESSURE_USER = 2
 ///@{
 Constant    EXPCONFIG_VERSION_NUM   = 1
 StrConstant USER_CONFIG_PATH        = "..:..:UserConfig.txt"
-Constant    ATTEMPTS                = 5
 StrConstant CONFIG_VERSION          = "Version"
 StrConstant SAVE_PATH               = "Save data to"
 StrConstant STIMSET_PATH            = "Load stim set from"

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -584,7 +584,7 @@ Constant HARDWARE_DAC_EXTERNAL_TRIGGER = 0x1
 /// @}
 
 /// Used to upgrade the GuiStateWave as well as the DA Ephys panel
-Constant DA_EPHYS_PANEL_VERSION     = 45
+Constant DA_EPHYS_PANEL_VERSION     = 46
 Constant DATABROWSER_PANEL_VERSION  = 13
 Constant SWEEPBROWSER_PANEL_VERSION = 3
 Constant WAVEBUILDER_PANEL_VERSION  = 8

--- a/Packages/MIES/MIES_DAEphys_Macro.ipf
+++ b/Packages/MIES/MIES_DAEphys_Macro.ipf
@@ -2858,6 +2858,8 @@ Window DA_Ephys() : Panel
 	Slider slider_DataAcq_ActiveHeadstage,pos={129.00,129.00},size={255.00,22.00},disable=1,proc=DAP_SliderProc_MIESHeadStage
 	Slider slider_DataAcq_ActiveHeadstage,userdata(tabnum)=  "0"
 	Slider slider_DataAcq_ActiveHeadstage,userdata(tabcontrol)=  "ADC"
+	Slider slider_DataAcq_ActiveHeadstage,userdata(Config_DontRestore)= "1"
+	Slider slider_DataAcq_ActiveHeadstage,userdata(Config_DontSave)= "1"
 	Slider slider_DataAcq_ActiveHeadstage,userdata(ResizeControlsInfo)= A"!!,Ff!!#@e!!#B9!!#<Xz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	Slider slider_DataAcq_ActiveHeadstage,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	Slider slider_DataAcq_ActiveHeadstage,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"

--- a/Packages/MIES/MIES_ExperimentConfig.ipf
+++ b/Packages/MIES/MIES_ExperimentConfig.ipf
@@ -76,7 +76,7 @@ Function ExpConfig_ConfigureMIES([middleOfExperiment])
 		AmpTitleLocal = UserSettings[V_value][%SettingValue]
 	
 		printf "Openning MCC amplifiers\r"
-		Assert(AI_OpenMCCs(AmpSerialLocal, ampTitleList = AmpTitleLocal, maxAttempts = ATTEMPTS),"Evil kittens prevented MultiClamp from opening - FULL STOP" )
+		Assert(AI_OpenMCCs(AmpSerialLocal, ampTitleList = AmpTitleLocal),"Evil kittens prevented MultiClamp from opening - FULL STOP" )
 		
 		FindValue /TXOP = 4 /TEXT = ITC_DEV_TYPE UserSettings
 		ITCDevType = UserSettings[V_value][%SettingValue]
@@ -192,7 +192,7 @@ static Function ExpConfig_Amplifiers(panelTitle, UserSettings, midExp)
 	numRows = DimSize(telegraphServers, ROWS)
 	if(!numRows)
 		printf "Openning MCC amplifiers\r"
-		Assert(AI_OpenMCCs(AmpSerialLocal, ampTitleList = AmpTitleLocal, maxAttempts = ATTEMPTS),"Evil kittens prevented MultiClamp from opening - FULL STOP" )
+		Assert(AI_OpenMCCs(AmpSerialLocal, ampTitleList = AmpTitleLocal),"Evil kittens prevented MultiClamp from opening - FULL STOP" )
 	endif
 	
 	FindValue /TXOP = 4 /TEXT = POSITION_MCC UserSettings

--- a/Packages/Settings_template/1_DA_Ephys_rig.json
+++ b/Packages/Settings_template/1_DA_Ephys_rig.json
@@ -3,11 +3,13 @@
         "Headstage Association": {
             "0": {
                 "Amplifier Serial": 0,
-                "Amplifier Title": "0,1"
+                "Amplifier Title": "0,1",
+                "Amplifier Channel": 1
             },
             "1": {
                 "Amplifier Serial": 0,
-                "Amplifier Title": "0,1"
+                "Amplifier Title": "0,1",
+                "Amplifier Channel": 2
             }
         }
     }


### PR DESCRIPTION
In the configuration for headstages a new field "Amplifier Channel"
was added (constant EXPCONFIG_JSON_AMPCHANNEL) that sets the amplifier channel.
Currently typical values for amplifier channel are 1, 2 or null.

See also updates default 1_DA_Ephys_rig.json file.

closes https://github.com/AllenInstitute/MIES/issues/400
Close #416.
