### PR TITLE
Require latest nightly build

### DIFF
--- a/Packages/MIES_Include.ipf
+++ b/Packages/MIES_Include.ipf
@@ -3,13 +3,13 @@
 #pragma rtFunctionErrors=1
 
 // Igor Pro nightly installation:
-// - Download from https://www.byte-physics.de/Downloads/WinIgor8_10DEC2019.zip
+// - Download from https://www.byte-physics.de/Downloads/WinIgor8_24FEB2020.zip
 // - Close Igor Pro 8
 // - Extract the contents into C:\Program Files\WaveMetrics\Igor Pro 8 Folder (overwriting existing files, requires Administrator access)
 // - Restart Igor Pro 8
 //
 // By ignoring the error and *commenting out* the below check you will certainly break MIES.
-#if (NumberByKey("BUILD", IgorInfo(0)) < 34845)
+#if (NumberByKey("BUILD", IgorInfo(0)) < 35301)
 #define *** Too old Igor Pro 8 version, click "Edit procedure" for instructions
 #pragma IgorVersion=8.04
 #endif


### PR DESCRIPTION
A potential crash in the threading code was fixed in response to a bug
report of ours.

- [x] Update IP8 on new Windows 10 box