### PR TITLE
AD_FillWaves: Ignore TP during DAQ channels

### DIFF
--- a/Packages/MIES/MIES_AnalysisFunctions_Dashboard.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_Dashboard.ipf
@@ -83,7 +83,11 @@ static Function AD_FillWaves(panelTitle, list, info)
 		headstage = headstages[V_minloc]
 
 		WAVE/Z stimsetCycleIDs = GetLastSetting(numericalValues, i, STIMSET_ACQ_CYCLE_ID_KEY, DATA_ACQUISITION_MODE)
-		ASSERT(WaveExists(stimsetCycleIDs), "Unexpected invalid stimset cycle ID")
+
+		if(!WaveExists(stimsetCycleIDs)) // TP during DAQ
+			continue
+		endif
+
 		stimsetCycleID = stimsetCycleIDs[headstage]
 
 		FindValue/RMD=[][0]/TXOP=4/TEXT=num2str(stimsetCycleID) info


### PR DESCRIPTION
Since TP during DAQ was added in fce6612d
(DC_PlaceDataInHardwareDataWave support for TPwhileDAQ on DAC channels,
2019-01-04) we bug out in the dashboard when we have that kind of data.

The reason is that we don't have a Stimset Cycle ID for TP during DAQ
channels.