### PR TITLE
Tests: Fix failing json configuration tests

### DIFF
--- a/Packages/Testing-MIES/UTF_Configuration.ipf
+++ b/Packages/Testing-MIES/UTF_Configuration.ipf
@@ -156,6 +156,17 @@ static Function TCONF_SaveJSON(jsonID, fName)
 	SaveTextFile(out, fName)
 End
 
+/// @brief Normalize a JSON encoded string
+static Function/S TCONF_NormalizeJSON(s)
+	string s
+
+	variable jsonID = JSON_Parse(s)
+	s = JSON_Dump(jsonID)
+	JSON_Release(jsonID)
+
+	return s
+End
+
 /// @brief helper function to compare two text files
 static Function TCONF_CompareTextFiles(fName1, fName2)
 	string fName1, fName2
@@ -165,8 +176,10 @@ static Function TCONF_CompareTextFiles(fName1, fName2)
 	[s1, fName1] = LoadTextFile(fName1)
 	[s2, fName2] = LoadTextFile(fName2)
 
-	Make/FREE/T w1 = { TrimString(s1) }
-	Make/FREE/T w2 = { TrimString(s2) }
+	// work around CHECK_EQUAL_STR: fails for very long strings
+	// see https://github.com/byte-physics/igor-unit-testing-framework/issues/76
+	Make/FREE/T w1 = { TCONF_NormalizeJSON(s1) }
+	Make/FREE/T w2 = { TCONF_NormalizeJSON(s2) }
 
 	CHECK_EQUAL_WAVES(w1, w2)
 End


### PR DESCRIPTION
In 38b90aba (Configuration: Introduce subgroups and add more amplifier
settings, 2020-01-30) some changes to the JSON configuration code was
added. This also changed the EOLS in the reference JSON files for testing.

And since then these tests are failing.

By normalizing the JSON documents, via parse and dump, the tests now
pass again.