### PR TITLE
Feature/upload crash dumps

### DIFF
--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -4599,6 +4599,7 @@ Function DAP_LockDevice(panelTitle)
 		GetPxPVersion()
 		SetupBackgroundTasks()
 		CtrlNamedBackground _all_, noevents=1
+		UploadCrashDumpsDaily()
 	endif
 
 	WAVE deviceInfo = GetDeviceInfoWave(panelTitle)

--- a/Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf
+++ b/Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf
@@ -666,3 +666,17 @@ Function/S GetSweepFormulaParseErrorMessage(dfr)
 
 	return GetSVARAsString(dfr, "sweepFormulaParseResult")
 End
+
+/// @brief Return the JSON id of the settings file
+///
+/// Loads the stored settings on disc if required.
+Function/S GetSettingsJSONid()
+	string path = GetNVARAsString(GetMiesPath(), "settingsJSONid", initialValue = NaN)
+	NVAR JSONid = $path
+
+	if(IsNaN(JSONid))
+		JSONid = PS_ReadSettings("MIES", GenerateSettingsDefaults)
+	endif
+
+	return path
+End

--- a/Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf
+++ b/Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf
@@ -157,7 +157,7 @@ End
 /// or #UNKNOWN_MIES_VERSION on error
 ///
 /// @returns the mies version
-Function/S CreateMiesVersion()
+static Function/S CreateMiesVersion()
 
 	string path, cmd, topDir, version, gitPathCandidates, gitPath
 	string userName, gitDir, fullVersionPath

--- a/Packages/MIES/MIES_IgorHooks.ipf
+++ b/Packages/MIES/MIES_IgorHooks.ipf
@@ -67,6 +67,23 @@ static Function IH_KillStimSets()
 	CallFunctionForEachListItem_TS(KillOrMoveToTrashPath, list)
 End
 
+/// @brief Write the current JSON settings to disc
+///
+/// We also invalidate the stored json ID, so that on the next access
+/// it is read again.
+static Function PS_SerializeSettings()
+	NVAR JSONid = $GetSettingsJSONid()
+
+	try
+		ClearRTError()
+		PS_WriteSettings("MIES", JSONid); AbortOnRTE
+	catch
+		ClearRTError()
+	endtry
+
+	JSONid = NaN
+End
+
 static Function BeforeExperimentSaveHook(rN, fileName, path, type, creator, kind)
 	Variable rN, kind
 	String fileName, path, type, creator
@@ -77,6 +94,8 @@ static Function BeforeExperimentSaveHook(rN, fileName, path, type, creator, kind
 	endif
 
 	DAP_SerializeAllCommentNBs()
+	PS_SerializeSettings()
+
 	IH_KillTemporaries()
 #if !defined(IGOR64)
 	IH_KillStimSets()
@@ -106,6 +125,7 @@ static Function IH_Cleanup()
 		IH_KillTemporaries(); AbortOnRTE
 		IH_KillStimSets(); AbortOnRTE
 		CA_FlushCache(); AbortOnRTE
+		PS_SerializeSettings(); AbortOnRTE
 
 		DFREF dfrNWB = GetNWBFolder()
 		KilLVariables/Z dfrNWB:histRefNumber

--- a/Packages/MIES/MIES_IgorHooks.ipf
+++ b/Packages/MIES/MIES_IgorHooks.ipf
@@ -52,7 +52,7 @@ Function IH_RemoveAmplifierConnWaves()
 End
 
 /// @brief Delete all wavebuilder stim sets to save memory
-Function IH_KillStimSets()
+static Function IH_KillStimSets()
 
 	string list, path
 

--- a/Packages/MIES/MIES_Menu.ipf
+++ b/Packages/MIES/MIES_Menu.ipf
@@ -53,6 +53,7 @@ Menu "Mies Panels"
 		"Flush Cache"                              , /Q, CA_FlushCache()
 		"Output Cache statistics"                  , /Q, CA_OutputCacheStatistics()
 		"Show Diagnostics (crash dumps) directory" , /Q, ShowDiagnosticsDirectory()
+		"Upload crash dumps"                       , /Q, UploadCrashDumps()
 	End
 End
 

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -6022,3 +6022,40 @@ Function/S GetLastNonEmptyEntry(wv, colLabel, endRow)
 
 	return wv[indizes[DimSize(indizes, ROWS) - 1]][%$colLabel]
 End
+
+/// @brief Generate a default settings file in JSON format
+///
+/// \rst
+/// .. code-block:: json
+///
+/// 	{
+/// 	  "diagnostics": {
+/// 	    "last upload": "2020-03-05T13:43:32Z"
+/// 	  },
+/// 	  "version": 1
+/// 	}
+///
+///	\endrst
+///
+/// Explanation:
+/// - "version": Major version number to track breaking changes
+/// - "diagnostics": Groups settings related to diagnostics and crash dump handling
+/// - "diagnostics/last upload": ISO8601 timestamp when the last successfull
+///                              upload of crash dumps was tried. This is also set
+///                              when no crash dumps have been uploadad.
+///
+/// @return JSONid
+///
+/// Caller is responsible for releasing the document.
+Function GenerateSettingsDefaults()
+
+	variable JSONid
+
+	JSONid = JSON_New()
+
+	JSON_AddVariable(JSONid, "version", 1)
+	JSON_AddTreeObject(JSONid, "/diagnostics")
+	JSON_AddString(JSONid, "/diagnostics/last upload", GetIso8601TimeStamp(secondsSinceIgorEpoch=0))
+
+	return JSONid
+End

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -6059,3 +6059,30 @@ Function GenerateSettingsDefaults()
 
 	return JSONid
 End
+
+/// @brief Call UploadCrashDumps() if we haven't called it since at least a day.
+Function UploadCrashDumpsDaily()
+
+	variable lastWrite
+
+	try
+		ClearRTError()
+		NVAR JSONid = $GetSettingsJSONid()
+
+		lastWrite = ParseISO8601TimeStamp(JSON_GetString(jsonID, "/diagnostics/last upload"))
+
+		if((lastWrite + 24 * 3600) > DateTimeInUTC())
+			// nothing to do
+			return NaN
+		endif
+
+		if(UploadCrashDumps())
+			printf "Crash dumps have been successfully uploaded.\r"
+		endif
+
+		JSON_SetString(jsonID, "/diagnostics/last upload", GetIso8601TimeStamp())
+	catch
+		ClearRTError()
+		BUG("Could not upload crash dumps!")
+	endtry
+End

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -3042,7 +3042,7 @@ Function SaveExperimentSpecial(mode)
 
 	// saved experiments are stored in the symbolic path "home"
 	expLoc  = "home"
-	expName = UniqueFile(expLoc, expName, PACKED_FILE_EXPERIMENT_SUFFIX)
+	expName = UniqueFileOrFolder(expLoc, expName, suffix = PACKED_FILE_EXPERIMENT_SUFFIX)
 
 	ret = SaveExperimentWrapper(expLoc, expName, overrideInteractiveMode = showSaveDialog)
 

--- a/Packages/MIES/MIES_PackageSettings.ipf
+++ b/Packages/MIES/MIES_PackageSettings.ipf
@@ -1,0 +1,74 @@
+#pragma TextEncoding = "UTF-8"
+#pragma rtGlobals=3 // Use modern global access method and strict wave access.
+#pragma rtFunctionErrors=1
+
+#ifdef AUTOMATED_TESTING
+#pragma ModuleName=MIES_PS
+#endif
+
+/// @file MIES_PackageSettings.ipf
+/// @brief Routines for dealing with JSON settings
+
+/// @brief This functions should return a JSON ID with the default settings
+Function PS_GenerateSettingsDefaults()
+	ASSERT(0, "Can not call prototype")
+End
+
+/// @brief Return a JSON ID with an opened JSON settings file
+///
+/// Caller is responsible for releasing the document.
+Function PS_ReadSettings(package, generateDefaults)
+	string package
+	FUNCREF PS_GenerateSettingsDefaults generateDefaults
+
+	string filepath, data, fName
+	variable JSONid
+
+	filepath = PS_GetSettingsFile(package)
+
+	if(!FileExists(filepath))
+		JSONid = generateDefaults()
+		PS_WriteSettings(package, JSONid)
+		return JSONid
+	endif
+
+	[data, fName] = LoadTextFile(filepath)
+	return JSON_Parse(data)
+End
+
+/// @brief Write the settings from `JSONid` for `package` to disc
+///
+/// Call this function in `BeforeExperimentSaveHook` to write the settings to disc
+Function PS_WriteSettings(package, JSONid)
+	string package
+	variable JSONid
+
+	string filepath
+
+	ASSERT(IsFinite(JSONid), "Invalid JSONid")
+
+	filepath = PS_GetSettingsFile(package)
+	SaveTextFile(JSON_Dump(JSONid, indent=2), filepath)
+End
+
+// @brief Return the absolute path to the settings folder for `package`
+static Function/S PS_GetSettingsFolder(package)
+	string package
+
+	return SpecialDirPath("Igor Preferences", 0, 0, 1) + "Packages:" + CleanupName(package, 0)
+End
+
+// @brief Return the absolute path to the JSON settings file for `package`
+static Function/S PS_GetSettingsFile(package)
+	string package
+
+	string folder
+
+	folder = PS_GetSettingsFolder(package)
+
+	if(!FolderExists(folder))
+		CreateFolderOnDisk(folder)
+	endif
+
+	return folder + ":Settings.json"
+End

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -1527,15 +1527,15 @@ Function SetDimensionLabels(keys, values)
 	endfor
 End
 
-/// @brief Returns a unique and non-existing file name
+/// @brief Returns a unique and non-existing file or folder name
 ///
 /// @warning This function must *not* be used for security relevant purposes,
 /// as for that the check-and-file-creation must be an atomic operation.
 ///
 /// @param symbPath  symbolic path
 /// @param baseName  base name of the file, must not be empty
-/// @param suffix    file suffix, e.g. ".txt", must not be empty
-Function/S UniqueFile(symbPath, baseName, suffix)
+/// @param suffix    file/folder suffix
+Function/S UniqueFileOrFolder(symbPath, baseName, [suffix])
 	string symbPath, baseName, suffix
 
 	string file
@@ -1544,7 +1544,10 @@ Function/S UniqueFile(symbPath, baseName, suffix)
 	PathInfo $symbPath
 	ASSERT(V_flag == 1, "Symbolic path does not exist")
 	ASSERT(!isEmpty(baseName), "baseName must not be empty")
-	ASSERT(!isEmpty(suffix), "suffix must not be empty")
+
+	if(ParamIsDefault(suffix))
+		suffix = ""
+	endif
 
 	file = baseName + suffix
 

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -4834,7 +4834,7 @@ Function/S GetSymbolicPathForDiagnosticsDirectory()
 	sprintf path, "C:Users:%s:AppData:Roaming:WaveMetrics:Igor Pro %s:Diagnostics:", userName, GetIgorProVersion()[0]
 	symbPath = "crashInfo"
 
-	NewPath/O $symbPath, path
+	NewPath/O/Q $symbPath, path
 
 	return symbPath
 End

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -4832,6 +4832,11 @@ Function/S GetSymbolicPathForDiagnosticsDirectory()
 	userName = GetSystemUserName()
 
 	sprintf path, "C:Users:%s:AppData:Roaming:WaveMetrics:Igor Pro %s:Diagnostics:", userName, GetIgorProVersion()[0]
+
+	if(!FolderExists(path))
+		CreateFolderOnDisk(path)
+	endif
+
 	symbPath = "crashInfo"
 
 	NewPath/O/Q $symbPath, path

--- a/Packages/MIES_Include.ipf
+++ b/Packages/MIES_Include.ipf
@@ -92,6 +92,7 @@
 #include "MIES_OptimzedOverlapDistributedAcquisition"
 #include "MIES_Oscilloscope"
 #include "MIES_OverlaySweeps"
+#include "MIES_PackageSettings"
 #include "MIES_Pictures"
 #include "MIES_PressureControl"
 #include "MIES_ProgrammaticGuiControl"

--- a/tools/http-upload/.htaccess
+++ b/tools/http-upload/.htaccess
@@ -1,0 +1,1 @@
+Deny from all

--- a/tools/http-upload/upload-json-payload-v1.php
+++ b/tools/http-upload/upload-json-payload-v1.php
@@ -1,0 +1,121 @@
+<?php
+
+// Installation instructions
+//
+// - Create folder on website and put this script there
+// - Create an `uploads` folder and place the `.htaccess` file there
+// - Try it out with curl
+//   curl -X PUT -d '{"payload" : [{"name" : "abcd.txt", "contents" : "abcd"}]}' https://ai.customers.byte-physics.de/upload-json-payload-v1.php
+//
+// Example JSON file
+//
+// {
+//   "computer" : "abcd",
+//   "user" : "schorsch",
+//   "timestamp" : "2020-02-20T08:50:23Z",
+//   "payload" :
+//    [
+//      {
+//        "name" : "crash.dump",
+//        "encoding" : "base64",
+//        "contents" : "base 64 encoded file contents"
+//      },
+//      {
+//        "name" : "msg.txt",
+//        "contents" : "plain text file contents"
+//      }
+//    ]
+// }
+
+/// @brief Return the value of `key` from `array` if it exists or `default_value` otherwise
+function get_array_value($array, $key, $default_value = null)
+{
+  return (is_array($array) && array_key_exists($key, $array)) ? $array[$key] : $default_value;
+}
+
+/// @brief Convert `str` to safe filename on *nix OSes
+function sanitize_filename($str)
+{
+  return preg_replace("/[^a-zA-Z0-9.: ]+/", "-", $str);
+}
+
+/// @brief Create a unique folder named `basefolder_XXX` and return its name
+function create_unique_folder($basefolder)
+{
+  $folder = $basefolder;
+
+  $count=0;
+  while(!mkdir($folder, 0700, true))
+  {
+    $folder = $basefolder . "_" . $count++;
+  }
+
+  return $folder;
+}
+
+/// @brief Extract the file contents from the elements of the `payload` array
+function decode_contents($elem)
+{
+    $encoding = get_array_value($elem, "encoding", "plain");
+
+    if($encoding == "plain")
+    {
+      return $elem["contents"];
+    }
+    elseif($encoding == "base64")
+    {
+      $contents = base64_decode($elem["contents"], True);
+
+      if($contents == False) # not base64 encoded
+      {
+        die("Contents could not be base64 decoded");
+      }
+
+      return $contents;
+    }
+
+    die("Invalid encoding value.");
+}
+
+// get the HTTP method, path and body of the request
+$method = $_SERVER["REQUEST_METHOD"];
+
+if($method != "PUT")
+{
+  die("Unsupported HTTP method");
+}
+
+$received_data = file_get_contents("php://input");
+
+if($received_data == False)
+{
+  die("Missing data on HTTP PUT method.");
+}
+
+$input = json_decode($received_data, true);
+
+if(!array_key_exists("payload", $input))
+{
+  die("Missing payload");
+}
+
+$computer = get_array_value($input, "computer", "unknown");
+$user = get_array_value($input, "user", "unknown");
+$timestamp = get_array_value($input, "timestamp", "unknown");
+
+$folder = create_unique_folder("uploads/" . sanitize_filename($computer . "-" . $user . "-" . $timestamp));
+
+foreach($input["payload"] as $elem)
+{
+  if(array_key_exists("name", $elem) and array_key_exists("contents", $elem))
+  {
+    $filename = tempnam($folder, sanitize_filename($elem["name"]) . ".");
+    $contents = decode_contents($elem);
+
+    $ret = file_put_contents($filename, $contents);
+    if($ret == 0 || $ret == FALSE)
+    {
+      die("Problem writing file " . $filename);
+    }
+  }
+}


### PR DESCRIPTION
- [x] Add docu
- [x] Cleanup commits
- [x] Add proper TLS certificate for ai.customers.byte-physics.de
- [x] Add daily upload
- [x] Add menu entry in advanced
- [x] Don't remove the crash dumps/log files. Maybe move into `Diagnostics_old`?
- [x] Investigate missing crash dumps and zero files in upload folder

Close #51.