### PR TITLE
GenerateRFC4122UUID: Don't call NewRandomSeed

### DIFF
--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -5126,8 +5126,7 @@ Function/S GenerateRFC4122UUID()
 	string str, randomness
 	STRUCT Uuid uu
 
-	NewRandomSeed()
-	randomness = Hash(num2str(GetReproducibleRandom()), 1)
+	randomness = Hash(num2strHighPrec(GetReproducibleRandom(), precision=15), 1)
 
 	WAVE binary = HexToBinary(randomness)
 


### PR DESCRIPTION
We don't have to request a new random seed on every call. This also
might result in duplicated UUIDs if GenerateRFC4122UUID() is called too
quickly.

Bug introduced in a06633d4 (Add RFC4122 style UUIDs, 2020-02-26).