### PR TITLE
Removed non required ASYNC include in Backgroundwatchdog

### DIFF
--- a/Packages/MIES/MIES_BackgroundWatchdog.ipf
+++ b/Packages/MIES/MIES_BackgroundWatchdog.ipf
@@ -12,7 +12,6 @@
 #include ":MIES_Debugging"
 #include ":MIES_GuiUtilities"
 #include ":MIES_Structures"
-#include ":MIES_Async"
 #include ":MIES_Utilities"
 // JSON XOP
 #include "json_functions"


### PR DESCRIPTION
In independent module Backgroundwatchdog ASYNC was included but not used.
This prevented compilation when ASYNC used function that are not included in
BackgroundWatchdog as well.