### PR TITLE
fix undefined current datafolder when exiting TS_ThreadGroupPutVariable

### DIFF
--- a/Packages/MIES/MIES_ThreadsafeUtilities.ipf
+++ b/Packages/MIES/MIES_ThreadsafeUtilities.ipf
@@ -151,10 +151,13 @@ threadsafe Function TS_ThreadGroupPutVariable(tgID, varName, varValue)
 	string varName
 	variable varValue
 
+	DFREF dfrSave = GetDataFolderDFR()
 	SetDataFolder NewFreeDataFolder()
 	variable/G $varName = varValue
 
 	ThreadGroupPutDF tgID, :
+
+	SetDataFolder dfrSave
 End
 
 /// @brief Push a datafolder to the thread queue


### PR DESCRIPTION
Restores the original data folder now when before function returns.

Conceptionally ThreadGroupPutDF should work (at the end) like KillDataFolder. However here we had the situation that the current datafolder is a free datafolder and the current datafolder is killed.

The help at KillDataFodler states only:

> However, if dataFolderSpec  is the name of a data folder reference variable that refers to a free data folder, the variable is cleared and the data folder is killed only if this is the last reference to that free data folder.

It is not described what happens if the dataFolderSpec  is actually the current DF.