### PR TITLE
Fix for data browser showing empty root data folder after ThreadGroupPutDF

### DIFF
--- a/Packages/MIES_Include.ipf
+++ b/Packages/MIES_Include.ipf
@@ -3,13 +3,13 @@
 #pragma rtFunctionErrors=1
 
 // Igor Pro nightly installation:
-// - Download from https://www.byte-physics.de/Downloads/WinIgor8_24FEB2020.zip
+// - Download from https://www.byte-physics.de/Downloads/WinIgor8_10APR2020.zip
 // - Close Igor Pro 8
 // - Extract the contents into C:\Program Files\WaveMetrics\Igor Pro 8 Folder (overwriting existing files, requires Administrator access)
 // - Restart Igor Pro 8
 //
 // By ignoring the error and *commenting out* the below check you will certainly break MIES.
-#if (NumberByKey("BUILD", IgorInfo(0)) < 35301)
+#if (NumberByKey("BUILD", IgorInfo(0)) < 35537)
 #define *** Too old Igor Pro 8 version, click "Edit procedure" for instructions
 #pragma IgorVersion=8.04
 #endif


### PR DESCRIPTION
this bug was introduced in commit 7b2cd9b9c4ae6d251616dfa13c974a35741f9511

After using any functionality that pushed threaded workloads the data browser
root started to show an empty name. Also the data browser did not update any
more.

closes https://github.com/AllenInstitute/MIES/issues/500