### PR TITLE
Extended PopupMenus procedures to replace long popup menus

### DIFF
--- a/Packages/MIES/MIES_AnalysisBrowser_LabNotebookTPStorageBrowser.ipf
+++ b/Packages/MIES/MIES_AnalysisBrowser_LabNotebookTPStorageBrowser.ipf
@@ -584,7 +584,7 @@ Function/S LBN_GetLBTextualKeys(graph)
 
 	WAVE/T textualKeys = GetAnalysLBTextualKeys(expFolder, device)
 
-	return GetLabNotebookSortedKeys(textualKeys)
+	return TextWaveToList(GetLabNotebookSortedKeys(textualKeys), ";")
 End
 
 Function/S LBN_GetLBNumericalKeys(graph)
@@ -608,7 +608,7 @@ Function/S LBN_GetLBNumericalKeys(graph)
 
 	WAVE/T numericalKeys = GetAnalysLBNumericalKeys(expFolder, device)
 
-	return GetLabNotebookSortedKeys(numericalKeys)
+	return TextWaveToList(GetLabNotebookSortedKeys(numericalKeys), ";")
 End
 
 Function/S LBN_TPStorageViewAbleCols(graph)

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -585,7 +585,7 @@ Constant HARDWARE_DAC_EXTERNAL_TRIGGER = 0x1
 
 /// Used to upgrade the GuiStateWave as well as the DA Ephys panel
 Constant DA_EPHYS_PANEL_VERSION     = 49
-Constant DATABROWSER_PANEL_VERSION  = 14
+Constant DATABROWSER_PANEL_VERSION  = 15
 Constant SWEEPBROWSER_PANEL_VERSION = 3
 Constant WAVEBUILDER_PANEL_VERSION  = 8
 

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -1286,3 +1286,11 @@ Constant PEXT_SUBSPLIT_ALPHA = 1
 /// @{
 Constant PEXT_SUBNAMEGEN_DEFAULT = 0
 /// @}
+
+/// @name Lab notebook entry types
+/// @anchor LNBEntryTypes
+/// @{
+Constant LNB_TYPE_NONE = 0
+Constant LNB_TYPE_NUMERICAL = 1
+Constant LNB_TYPE_TEXTUAL = 2
+/// @}

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -1266,3 +1266,23 @@ StrConstant EXPCONFIG_GUI_PREFERRED =   "0;2;0;0;0;3;2;0;1;1;0;1;"
 
 StrConstant EXPCONFIG_GUI_SUSERDATA =   "1;0;1;1;0;1;1;1;1;1;0;0;"
 /// @}
+
+/// @name PopupMenu extension keys for userdata definition of procedures
+/// @anchor PopupMenuExtension
+/// @{
+StrConstant PEXT_UDATA_ITEMGETTER = "Items"
+StrConstant PEXT_UDATA_POPUPPROC = "popupProc"
+/// @}
+
+/// @name PopupMenu extension sub menu splitting methods
+/// @anchor PEXT_SubMenuSplitting
+/// @{
+Constant PEXT_SUBSPLIT_DEFAULT = 0
+Constant PEXT_SUBSPLIT_ALPHA = 1
+/// @}
+
+/// @name PopupMenu extension sub menu name generation methods
+/// @anchor PEXT_SubMenuNameGeneration
+/// @{
+Constant PEXT_SUBNAMEGEN_DEFAULT = 0
+/// @}

--- a/Packages/MIES/MIES_DataBrowser_Macro.ipf
+++ b/Packages/MIES/MIES_DataBrowser_Macro.ipf
@@ -11,14 +11,13 @@
 
 Window DataBrowser() : Graph
 	PauseUpdate; Silent 1		// building window...
-	Display /W=(346.5,343.25,779.25,648.5)/K=1  as "DataBrowser"
+	Display /W=(564,166.25,996.75,471.5)/K=1  as "DataBrowser"
 	Button button_BSP_open,pos={3.00,3.00},size={24.00,24.00},disable=1,proc=DB_ButtonProc_Panel,title="<<"
 	Button button_BSP_open,help={"Open Side Panel"}
 	Button button_BSP_open,userdata(ResizeControlsInfo)= A"!!,>M!!#8L!!#=#!!#=#z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	Button button_BSP_open,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	Button button_BSP_open,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
 	SetWindow kwTopWin,hook(TA_CURSOR_MOVED)=TimeAlignCursorMovedHook
-	SetWindow kwTopWin,hook(ResizeControls)=ResizeControls#ResizeControlsHook
 	SetWindow kwTopWin,hook(cleanup)=DB_SweepBrowserWindowHook
 	SetWindow kwTopWin,userdata(BROWSER)=  "D"
 	SetWindow kwTopWin,userdata(DEVICE)=  "- none -"
@@ -26,6 +25,7 @@ Window DataBrowser() : Graph
 	SetWindow kwTopWin,userdata(ResizeControlsInfo)= A"!!*'\"z!!#C=?iWQ]TE\"rlzzzzzzzzzzzzzzzzzzzz"
 	SetWindow kwTopWin,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzzzzzzzzzzzzzzz"
 	SetWindow kwTopWin,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzzzzzzzzz!!!"
+	SetWindow kwTopWin,userdata(ResizeControlsHookStash)=  "ResizeControls#ResizeControlsHook"
 	Execute/Q/Z "SetWindow kwTopWin sizeLimit={324,228,inf,inf}" // sizeLimit requires Igor 7 or later
 	NewPanel/HOST=#/EXT=2/W=(0,0,580,66)  as "Sweep Control"
 	Button button_SweepControl_NextSweep,pos={333.00,0.00},size={150.00,36.00},title="Next  \\W649"
@@ -824,7 +824,7 @@ Window DataBrowser() : Graph
 	PopupMenu popup_DB_lockedDevices,userdata(ResizeControlsInfo)= A"!!,C$!!#BQJ,hr2!!#<Pz!!#`-A7TLfzzzzzzzzzzzzzz!!#r+D.OhkBk2=!z"
 	PopupMenu popup_DB_lockedDevices,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu popup_DB_lockedDevices,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	PopupMenu popup_DB_lockedDevices,mode=3,popvalue="- none -",value= #"DB_GetAllDevicesWithData()"
+	PopupMenu popup_DB_lockedDevices,mode=1,popvalue="- none -",value= #"DB_GetAllDevicesWithData()"
 	GroupBox group_enable_sweepFormula,pos={5.00,25.00},size={380.00,50.00},disable=1,title="SweepFormula"
 	GroupBox group_enable_sweepFormula,userdata(tabnum)=  "5"
 	GroupBox group_enable_sweepFormula,userdata(tabcontrol)=  "Settings"
@@ -994,40 +994,40 @@ Window DataBrowser() : Graph
 	SetActiveSubwindow ##
 	RenameWindow #,BrowserSettingsPanel
 	SetActiveSubwindow ##
-	NewPanel/HOST=#/EXT=2/W=(0,0,588,154)  as " "
+	NewPanel/HOST=#/EXT=2/W=(0,0,588,113)  as " "
 	ModifyPanel fixedSize=0
-	Button popupext_LBKeys,pos={416.00,26.00},size={150.00,19.00},bodyWidth=150,proc=PEXT_ButtonProc
-	Button popupext_LBKeys,title="Lab Notebook Entries ▼", userdata=(PEXT_UDATA_ITEMGETTER + ":DB_PopupExtGetLBKeys;" + PEXT_UDATA_POPUPPROC + ":DB_PopMenuProc_LabNotebook")
+	Button popupext_LBKeys,pos={416.00,26.00},size={150.00,19.00},bodyWidth=150,proc=PEXT_ButtonProc,title="Lab Notebook Entries ▼"
 	Button popupext_LBKeys,help={"Select lab notebook data to display"}
-	Button popupext_LBKeys,userdata(ResizeControlsInfo)= A"!!,I3J,hm^!!#A%!!#<Pz!!#N3Bk1ct<C^(Dzzzzzzzzzzzzz!!#N3Bk1ct<C^(Dz"
+	Button popupext_LBKeys,userdata=  "Items:DB_PopupExtGetLBKeys;popupProc:DB_PopMenuProc_LabNotebook"
+	Button popupext_LBKeys,userdata(ResizeControlsInfo)= A"!!,I6!!#=3!!#A%!!#<Pz!!#N3Bk1ct<C^(Dzzzzzzzzzzzzz!!#N3Bk1ct<C^(Dz"
 	Button popupext_LBKeys,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:DuaGl<C]S6zzzzzzzzzz"
 	Button popupext_LBKeys,userdata(ResizeControlsInfo) += A"zzz!!#u:DuaGl<C]S6zzzzzzzzzzzzz!!!"
-	Button button_clearlabnotebookgraph,pos={407.00,85.00},size={80.00,25.00},proc=DB_ButtonProc_ClearGraph,title="Clear graph"
-	Button button_clearlabnotebookgraph,userdata(ResizeControlsInfo)= A"!!,I/!!#?c!!#?Y!!#=+z!!#N3Bk1ct<C^(Dzzzzzzzzzzzzz!!#N3Bk1ct<C^(Dz"
+	Button button_clearlabnotebookgraph,pos={407.00,55.00},size={80.00,25.00},proc=DB_ButtonProc_ClearGraph,title="Clear graph"
+	Button button_clearlabnotebookgraph,userdata(ResizeControlsInfo)= A"!!,I1J,ho@!!#?Y!!#=+z!!#N3Bk1ct<C^(Dzzzzzzzzzzzzz!!#N3Bk1ct<C^(Dz"
 	Button button_clearlabnotebookgraph,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:DuaGl<C]S6zzzzzzzzzz"
 	Button button_clearlabnotebookgraph,userdata(ResizeControlsInfo) += A"zzz!!#u:DuaGl<C]S6zzzzzzzzzzzzz!!!"
-	Button button_switchxaxis,pos={499.00,85.00},size={80.00,25.00},proc=DB_ButtonProc_SwitchXAxis,title="Switch X-axis"
+	Button button_switchxaxis,pos={499.00,55.00},size={80.00,25.00},proc=DB_ButtonProc_SwitchXAxis,title="Switch X-axis"
 	Button button_switchxaxis,help={"Toggle lab notebook horizontal axis between time of day or sweep number"}
-	Button button_switchxaxis,userdata(ResizeControlsInfo)= A"!!,I]!!#?c!!#?Y!!#=+z!!#N3Bk1ct<C^(Dzzzzzzzzzzzzz!!#N3Bk1ct<C^(Dz"
+	Button button_switchxaxis,userdata(ResizeControlsInfo)= A"!!,I_J,ho@!!#?Y!!#=+z!!#N3Bk1ct<C^(Dzzzzzzzzzzzzz!!#N3Bk1ct<C^(Dz"
 	Button button_switchxaxis,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:DuaGl<C]S6zzzzzzzzzz"
 	Button button_switchxaxis,userdata(ResizeControlsInfo) += A"zzz!!#u:DuaGl<C]S6zzzzzzzzzzzzz!!!"
-	GroupBox group_labnotebook_ctrls,pos={408.00,5.00},size={170.00,78.00},title="Settings History Column"
-	GroupBox group_labnotebook_ctrls,userdata(ResizeControlsInfo)= A"!!,I/J,hj-!!#A9!!#?Uz!!#N3Bk1ct<C^(Dzzzzzzzzzzzzz!!#N3Bk1ct<C^(Dz"
+	GroupBox group_labnotebook_ctrls,pos={408.00,5.00},size={170.00,47.00},title="Settings History Column"
+	GroupBox group_labnotebook_ctrls,userdata(ResizeControlsInfo)= A"!!,I2!!#9W!!#A9!!#>Jz!!#N3Bk1ct<C^(Dzzzzzzzzzzzzz!!#N3Bk1ct<C^(Dz"
 	GroupBox group_labnotebook_ctrls,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:DuaGl<C]S6zzzzzzzzzz"
 	GroupBox group_labnotebook_ctrls,userdata(ResizeControlsInfo) += A"zzz!!#u:DuaGl<C]S6zzzzzzzzzzzzz!!!"
-	Button button_DataBrowser_setaxis,pos={406.00,114.00},size={171.00,25.00},proc=DB_ButtonProc_AutoScale,title="Autoscale"
+	Button button_DataBrowser_setaxis,pos={406.00,84.00},size={171.00,25.00},proc=DB_ButtonProc_AutoScale,title="Autoscale"
 	Button button_DataBrowser_setaxis,help={"Autoscale sweep data"}
-	Button button_DataBrowser_setaxis,userdata(ResizeControlsInfo)= A"!!,I.J,hps!!#A:!!#=+z!!#N3Bk1ct<C^(Dzzzzzzzzzzzzz!!#N3Bk1ct<C^(Dz"
+	Button button_DataBrowser_setaxis,userdata(ResizeControlsInfo)= A"!!,I1!!#?a!!#A:!!#=+z!!#N3Bk1ct<C^(Dzzzzzzzzzzzzz!!#N3Bk1ct<C^(Dz"
 	Button button_DataBrowser_setaxis,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	Button button_DataBrowser_setaxis,userdata(ResizeControlsInfo) += A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
 	DefineGuide UGV0={FR,-187}
 	SetWindow kwTopWin,hook(ResizeControls)=ResizeControls#ResizeControlsHook
-	SetWindow kwTopWin,userdata(ResizeControlsInfo)= A"!!*'\"z!!#D!^]6_8zzzzzzzzzzzzzzzzzzzzz"
+	SetWindow kwTopWin,userdata(ResizeControlsInfo)= A"!!*'\"z!!#D#!!#@Fzzzzzzzzzzzzzzzzzzzzz"
 	SetWindow kwTopWin,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzzzzzzzzzzzzzzz"
 	SetWindow kwTopWin,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzzzzzzzzz!!!"
 	SetWindow kwTopWin,userdata(ResizeControlsGuides)=  "UGV0;"
-	SetWindow kwTopWin,userdata(ResizeControlsInfoUGV0)=  "NAME:UGV0;WIN:SettingsHistory;TYPE:User;HORIZONTAL:0;POSITION:396.00;GUIDE1:FR;GUIDE2:;RELPOSITION:-187;"
-	Execute/Q/Z "SetWindow kwTopWin sizeLimit={447,135,inf,inf}" // sizeLimit requires Igor 7 or later
+	SetWindow kwTopWin,userdata(ResizeControlsInfoUGV0)=  "NAME:UGV0;WIN:DataBrowser#SettingsHistoryPanel;TYPE:User;HORIZONTAL:0;POSITION:401.00;GUIDE1:FR;GUIDE2:;RELPOSITION:-187;"
+	Execute/Q/Z "SetWindow kwTopWin sizeLimit={447,110.25,inf,inf}" // sizeLimit requires Igor 7 or later
 	Display/W=(200,187,395,501)/FG=(FL,FT,UGV0,FB)/HOST=# 
 	ModifyGraph margin(right)=74
 	TextBox/C/N=text0/F=0/B=1/X=0.50/Y=2.02/E=2 ""

--- a/Packages/MIES/MIES_DataBrowser_Macro.ipf
+++ b/Packages/MIES/MIES_DataBrowser_Macro.ipf
@@ -996,18 +996,12 @@ Window DataBrowser() : Graph
 	SetActiveSubwindow ##
 	NewPanel/HOST=#/EXT=2/W=(0,0,588,154)  as " "
 	ModifyPanel fixedSize=0
-	PopupMenu popup_LBNumericalKeys,pos={416.00,26.00},size={150.00,19.00},bodyWidth=150,proc=DB_PopMenuProc_LabNotebook
-	PopupMenu popup_LBNumericalKeys,help={"Select numeric lab notebook data to display"}
-	PopupMenu popup_LBNumericalKeys,userdata(ResizeControlsInfo)= A"!!,I3J,hm^!!#A%!!#<Pz!!#N3Bk1ct<C^(Dzzzzzzzzzzzzz!!#N3Bk1ct<C^(Dz"
-	PopupMenu popup_LBNumericalKeys,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:DuaGl<C]S6zzzzzzzzzz"
-	PopupMenu popup_LBNumericalKeys,userdata(ResizeControlsInfo) += A"zzz!!#u:DuaGl<C]S6zzzzzzzzzzzzz!!!"
-	PopupMenu popup_LBNumericalKeys,mode=1,popvalue="- none -",value= #"\"- none -\""
-	PopupMenu popup_LBTextualKeys,pos={416.00,55.00},size={150.00,19.00},bodyWidth=150,proc=DB_PopMenuProc_LabNotebook
-	PopupMenu popup_LBTextualKeys,help={"Select textual lab notebook data to display"}
-	PopupMenu popup_LBTextualKeys,userdata(ResizeControlsInfo)= A"!!,I3J,ho@!!#A%!!#<Pz!!#N3Bk1ct<C^(Dzzzzzzzzzzzzz!!#N3Bk1ct<C^(Dz"
-	PopupMenu popup_LBTextualKeys,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:DuaGl<C]S6zzzzzzzzzz"
-	PopupMenu popup_LBTextualKeys,userdata(ResizeControlsInfo) += A"zzz!!#u:DuaGl<C]S6zzzzzzzzzzzzz!!!"
-	PopupMenu popup_LBTextualKeys,mode=1,popvalue="- none -",value= #"\"- none -\""
+	Button popupext_LBKeys,pos={416.00,26.00},size={150.00,19.00},bodyWidth=150,proc=PEXT_ButtonProc
+	Button popupext_LBKeys,title="Lab Notebook Entries ▼", userdata=(PEXT_UDATA_ITEMGETTER + ":DB_PopupExtGetLBKeys;" + PEXT_UDATA_POPUPPROC + ":DB_PopMenuProc_LabNotebook")
+	Button popupext_LBKeys,help={"Select lab notebook data to display"}
+	Button popupext_LBKeys,userdata(ResizeControlsInfo)= A"!!,I3J,hm^!!#A%!!#<Pz!!#N3Bk1ct<C^(Dzzzzzzzzzzzzz!!#N3Bk1ct<C^(Dz"
+	Button popupext_LBKeys,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:DuaGl<C]S6zzzzzzzzzz"
+	Button popupext_LBKeys,userdata(ResizeControlsInfo) += A"zzz!!#u:DuaGl<C]S6zzzzzzzzzzzzz!!!"
 	Button button_clearlabnotebookgraph,pos={407.00,85.00},size={80.00,25.00},proc=DB_ButtonProc_ClearGraph,title="Clear graph"
 	Button button_clearlabnotebookgraph,userdata(ResizeControlsInfo)= A"!!,I/!!#?c!!#?Y!!#=+z!!#N3Bk1ct<C^(Dzzzzzzzzzzzzz!!#N3Bk1ct<C^(Dz"
 	Button button_clearlabnotebookgraph,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:DuaGl<C]S6zzzzzzzzzz"

--- a/Packages/MIES/MIES_GuiPopupMenuExt.ipf
+++ b/Packages/MIES/MIES_GuiPopupMenuExt.ipf
@@ -1,0 +1,633 @@
+#pragma TextEncoding = "UTF-8"
+#pragma rtGlobals=3 // Use modern global access method and strict wave access.
+#pragma rtFunctionErrors=1
+
+#ifdef AUTOMATED_TESTING
+#pragma ModuleName=MIES_GUIPOPUPEXT
+#endif
+
+/// @file MIES_GuiPopupMenuExt.ipf
+/// @brief Helper functions related to GUI controls
+///
+/// @anchor PopupMenuExtensionShortDescription
+///
+/// These procedures provide a way to replace popup menus with many entries with context menus.
+/// Context menus can provide submenus, that allow better organization of menu entries.
+///
+/// Example:
+///
+/// \rst
+/// .. code-block:: igorpro
+///
+///    Function SetupPopupMenuExt()
+///        KillWindow/Z panel0
+///        NewPanel/N=$"panel0"/K=1
+///        Button popupext_menu1, pos={3.00, 20.00}, size={200,20},proc=PEXT_ButtonProc,title="DropDownMenu1 ▼", userdata=(PEXT_UDATA_ITEMGETTER + ":GetMenuList1;" + PEXT_UDATA_POPUPPROC + ":DemoProc")
+///        Button popupext_menu2, pos={3.00, 55.00}, size={200,20},proc=PEXT_ButtonProc,title="DropDownMenu2 ▼", userdata=(PEXT_UDATA_ITEMGETTER + ":GetMenuList2;" + PEXT_UDATA_POPUPPROC + ":DemoProc")
+///        Button popupext_menu3, pos={3.00, 90.00}, size={200,20},proc=PEXT_ButtonProc,title="DropDownMenu3 ▼", userdata=(PEXT_UDATA_ITEMGETTER + ":GetMenuList3;" + PEXT_UDATA_POPUPPROC + ":DemoProc")
+///    End
+///
+///    Function DemoProc(pa) : PopupMenuControl
+///        STRUCT WMPopupAction &pa
+///
+///        print "EventCode/Win/Selected/ctrlName: ", pa.eventCode, pa.win, pa.popStr, pa.ctrlName
+///    End
+///
+///    Function/S GetMenuList1()
+///
+///        Make/FREE/T/N=300 testItems = num2char(97 + mod(p, 26)) + "_" + num2str(p)
+///        return TextWaveToList(testItems, ";")
+///    End
+///
+///    Function/WAVE GetMenuList2(panelTitle)
+///        string panelTitle
+///
+///        Make/FREE/T/N=(2) menus
+///        menus[0] = "Kriemhild;Brünhild"
+///        menus[1] = "Siegfried;Gunther"
+///        SetDimLabel ROWS, 0, $"Women", menus
+///        SetDimLabel ROWS, 1, $"Men", menus
+///
+///        return menus
+///    End
+///
+///    Function/WAVE GetMenuList3(panelTitle)
+///        string panelTitle
+///
+///        Make/FREE/T menus = {"Kriemhild", "Brünhild", "Siegfried", "Gunther"}
+///        WAVE/T splitMenu = PEXT_SplitToSubMenus(menus, method = PEXT_SUBSPLIT_ALPHA)
+///        PEXT_GenerateSubMenuNames(splitMenu)
+///        return splitMenu
+///    End
+/// \endrst
+///
+/// The original popupmenu has to be replaced by a button with the PEXT_ButtonProc as procedure. The userdata of the
+/// button stores as list with key value pairs a function that returns the menu item list and a function that is the
+/// PopupMenuControl procecure of the former popupmenu. The function for the menu item list corresponds to the function
+/// given for a popupmenu as e.g. value=GetMenuList1() that returns a string with semicolon separated list of menu items.
+/// The names for the submenus are generated automatically in that case.
+/// If one wants to disable the menu, return "" as menu item list. Then a disabled "_none_" is shown that can not be selected.
+///
+///
+/// The constants PEXT_UDATA_ITEMGETTER and PEXT_UDATA_POPUPPROC were defined for the keys in the userdata string.
+///
+/// When a user selects an entry in the context menu the PopupMenuControl control defined through PEXT_UDATA_POPUPPROC is called.
+/// So the proc of the previous popupmenu can be used without further adaptations.
+///
+/// User defined sub menus:
+///
+/// User defined submenus can be created as well. Therefore an extension was added to the function that returns the menu items.
+/// Instead of a string as described before a function can be defined that returns a 1D text wave, e.g. GetMenuList2() in the example.
+/// Each element contains a semicolon separated list of menu items. Each rows DimLabel is used as submenu name, where the elements
+/// menu items are put. The DimLabels must not be empty. The wave can have up to MAX_SUBMENUS elements.
+/// The button popupext_menu2 shows this extension in the example.
+///
+/// Half automatic generation:
+///
+/// Example 3 from Button popupext_menu3 shows how a menu is created by defining a wave with menu items first.
+/// Then the menu items are split to sub menus with PEXT_SplitToSubMenus using the method PEXT_SUBSPLIT_ALPHA.
+/// In the second step the sub menu named are generated with the default algorithm by calling PEXT_GenerateSubMenuNames.
+///
+/// Method Description
+///
+/// PEXT_SUBSPLIT_DEFAULT
+///
+/// In each sub menu up to NUM_SUBENTRIES menu items are placed.
+/// If MAX_SUBMENUS number of sub menus are reached then the remaining menu items are placed in the last sub menu.
+///
+/// PEXT_SUBSPLIT_ALPHA
+///
+/// In each sub menu up to NUM_SUBENTRIES menu items are placed. If the beginning letter of the last menu item in the sub menu differs from the
+/// beginning letter of the first menu item then the menu items in the sub menu get reduced. All menu item beginning with the letter of the last menu item
+/// are moved to the next sub menu.
+/// If the beginning letters match then no menu items get moved.
+/// If MAX_SUBMENUS number of sub menus are reached then the remaining menu items are placed in the last sub menu.
+///
+/// PEXT_SUBNAMEGEN_DEFAULT
+///
+/// In a sub menu from the first and last menu item the number of letters from the beginning is counted until the letters do not match. This part of the
+/// menu item is used and taken as a sub menu name in a range notation: Alfons, Aluminium -> Alf .. Alu
+/// This is also applied between different sub menus, so the last menu item and the first menu item of the next sub menu.
+/// If in the previous sub menu the number of letters determined for the last menu item is higher then for the first name component the higher amount is taken:
+/// e.g. Balalaika, Cembalo -> B .. C -> Bal .. C (because Alu were three letters)
+
+static Constant NUM_SUBENTRIES = 30
+static Constant MAX_SUBMENUS = 10
+static StrConstant WAVE_NOTE_PROCNAME = "PROC"
+static StrConstant WAVE_NOTE_WINDOWNAME = "WINNAME"
+static StrConstant WAVE_NOTE_CTRLNAME = "CTRLNAME"
+static StrConstant MENUNAME_UNUSED = "*** bug, report to dev ***"
+
+/// @brief Menu definition templates for up to 10 sub menus.
+///        The constant MAX_SUBMENUS stores the number of these definitions
+///        and must be updated if more definitions are added.
+///
+Menu "PopupExt1", contextualmenu, dynamic
+	PEXT_PopupMenuItems(0), /Q, ;
+End
+
+Menu "PopupExt2", contextualmenu, dynamic
+	SubMenu PEXT_SubMenuName(0)
+		PEXT_PopupMenuItems(0), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(1)
+		PEXT_PopupMenuItems(1), /Q, ;
+	End
+End
+
+Menu "PopupExt3", contextualmenu, dynamic
+	SubMenu PEXT_SubMenuName(0)
+		PEXT_PopupMenuItems(0), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(1)
+		PEXT_PopupMenuItems(1), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(2)
+		PEXT_PopupMenuItems(2), /Q, ;
+	End
+End
+
+Menu "PopupExt4", contextualmenu, dynamic
+	SubMenu PEXT_SubMenuName(0)
+		PEXT_PopupMenuItems(0), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(1)
+		PEXT_PopupMenuItems(1), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(2)
+		PEXT_PopupMenuItems(2), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(3)
+		PEXT_PopupMenuItems(3), /Q, ;
+	End
+End
+
+Menu "PopupExt5", contextualmenu, dynamic
+	SubMenu PEXT_SubMenuName(0)
+		PEXT_PopupMenuItems(0), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(1)
+		PEXT_PopupMenuItems(1), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(2)
+		PEXT_PopupMenuItems(2), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(3)
+		PEXT_PopupMenuItems(3), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(4)
+		PEXT_PopupMenuItems(4), /Q, ;
+	End
+End
+
+Menu "PopupExt6", contextualmenu, dynamic
+	SubMenu PEXT_SubMenuName(0)
+		PEXT_PopupMenuItems(0), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(1)
+		PEXT_PopupMenuItems(1), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(2)
+		PEXT_PopupMenuItems(2), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(3)
+		PEXT_PopupMenuItems(3), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(4)
+		PEXT_PopupMenuItems(4), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(5)
+		PEXT_PopupMenuItems(5), /Q, ;
+	End
+End
+
+Menu "PopupExt7", contextualmenu, dynamic
+	SubMenu PEXT_SubMenuName(0)
+		PEXT_PopupMenuItems(0), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(1)
+		PEXT_PopupMenuItems(1), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(2)
+		PEXT_PopupMenuItems(2), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(3)
+		PEXT_PopupMenuItems(3), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(4)
+		PEXT_PopupMenuItems(4), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(5)
+		PEXT_PopupMenuItems(5), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(6)
+		PEXT_PopupMenuItems(6), /Q, ;
+	End
+End
+
+Menu "PopupExt8", contextualmenu, dynamic
+	SubMenu PEXT_SubMenuName(0)
+		PEXT_PopupMenuItems(0), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(1)
+		PEXT_PopupMenuItems(1), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(2)
+		PEXT_PopupMenuItems(2), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(3)
+		PEXT_PopupMenuItems(3), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(4)
+		PEXT_PopupMenuItems(4), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(5)
+		PEXT_PopupMenuItems(5), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(6)
+		PEXT_PopupMenuItems(6), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(7)
+		PEXT_PopupMenuItems(7), /Q, ;
+	End
+End
+
+Menu "PopupExt9", contextualmenu, dynamic
+	SubMenu PEXT_SubMenuName(0)
+		PEXT_PopupMenuItems(0), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(1)
+		PEXT_PopupMenuItems(1), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(2)
+		PEXT_PopupMenuItems(2), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(3)
+		PEXT_PopupMenuItems(3), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(4)
+		PEXT_PopupMenuItems(4), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(5)
+		PEXT_PopupMenuItems(5), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(6)
+		PEXT_PopupMenuItems(6), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(7)
+		PEXT_PopupMenuItems(7), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(8)
+		PEXT_PopupMenuItems(8), /Q, ;
+	End
+End
+
+Menu "PopupExt10", contextualmenu, dynamic
+	SubMenu PEXT_SubMenuName(0)
+		PEXT_PopupMenuItems(0), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(1)
+		PEXT_PopupMenuItems(1), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(2)
+		PEXT_PopupMenuItems(2), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(3)
+		PEXT_PopupMenuItems(3), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(4)
+		PEXT_PopupMenuItems(4), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(5)
+		PEXT_PopupMenuItems(5), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(6)
+		PEXT_PopupMenuItems(6), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(7)
+		PEXT_PopupMenuItems(7), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(8)
+		PEXT_PopupMenuItems(8), /Q, ;
+	End
+	SubMenu PEXT_SubMenuName(9)
+		PEXT_PopupMenuItems(9), /Q, ;
+	End
+End
+
+/// @brief Returns sub menu names for all PEXT sub menus
+///        This is called on each menu click/compilation for all dynamic defined Menus
+///        where PEXT_SubMenuName is used.
+///
+/// @param subMenuNr number of current sub menu
+Function/S PEXT_SubMenuName(subMenuNr)
+	variable subMenuNr
+
+	string s
+
+	WAVE/T itemListWave = GetPopupExtMenuWave()
+	variable subMenuCnt = DimSize(itemListWave, ROWS)
+
+	if(subMenuNr >= subMenuCnt)
+		return MENUNAME_UNUSED
+	endif
+
+	s = GetDimLabel(itemListWave, ROWS, subMenuNr)
+	if(IsEmpty(s))
+		return MENUNAME_UNUSED
+	endif
+
+	return s
+End
+
+/// @brief Returns menu items for all PEXT menus
+///        This is called on each menu click/compilation for all dynamic defined Menus
+///        where PEXT_PopupMenuItems is used.
+///
+/// @param subMenuNr number of current sub menu
+Function/S PEXT_PopupMenuItems(subMenuNr)
+	variable subMenuNr
+
+	WAVE/T itemListWave = GetPopupExtMenuWave()
+	variable subMenuCnt = DimSize(itemListWave, ROWS)
+
+	if(subMenuNr >= subMenuCnt)
+		return ""
+	endif
+
+	return itemListWave[subMenuNr]
+End
+
+/// @brief This callback is executed when the user selected a PEXT dynamic menu item.
+///        It is not called if the user aborted the menu by clicking somewhere else.
+///
+/// @param popupStr popup string
+/// @param text selected menu item text
+/// @param itemNum selected item index in submenu
+Function PEXT_Callback(string popupStr,string text,variable itemNum)
+
+	STRUCT WMPopupAction pa
+
+	WAVE/T itemListWave = GetPopupExtMenuWave()
+
+	if(IsEmpty(text) && itemNum == 0)
+		Redimension/N=0 itemListWave
+		return 0
+	endif
+
+	pa.ctrlName = GetStringFromWaveNote(itemListWave, WAVE_NOTE_CTRLNAME)
+	pa.eventCode = 2
+	pa.eventMod = 0
+	pa.popNum = NaN
+	pa.popStr = text
+	pa.win = GetStringFromWaveNote(itemListWave, WAVE_NOTE_WINDOWNAME)
+
+	FUNCREF PEXT_POPUPACTION_PROTO popupAction = $GetStringFromWaveNote(itemListWave, WAVE_NOTE_PROCNAME)
+	note/K itemListWave
+	ASSERT(FuncRefIsAssigned(FuncRefInfo(popupAction)), "Popup extension action has wrong function template format")
+
+	popupAction(pa)
+End
+
+/// @brief Prototype for the menu item getter that allows user defined
+///        sub menu attribution of menu items
+///
+Function/S PEXT_ITEMGETTER_LIST_PROTO()
+End
+
+/// @brief Prototype for the menu item getter that is compatible with the
+///        former popupmenu value=procedure definition.
+///
+Function/WAVE PEXT_ITEMGETTER_WAVE_PROTO(panelTitle)
+	string panelTitle
+End
+
+/// @brief Prototype for the former popupaction procedure, that is only
+///        called virtually now through the PopupContextualMenu callback.
+///
+/// @param pa WMPopupAction structure
+Function PEXT_POPUPACTION_PROTO(pa) : PopupMenuControl
+	STRUCT WMPopupAction &pa
+End
+
+/// @brief Generic procedure for button actions from popup extension controls
+///        Fills the global popupExtMenuInfo wave with current menu setup information
+///        retrieved from the function defined in the buttons userdata through PEXT_UDATA_ITEMGETTER key.
+///        This getter function can either return a string or 1D text wave.
+///
+/// @param ba WMButtonAction structure
+Function PEXT_ButtonProc(ba) : ButtonControl
+	STRUCT WMButtonAction &ba
+
+	string itemGetter, itemList
+
+	switch(ba.eventCode)
+		case 2:
+
+			WAVE/T itemListWave = GetPopupExtMenuWave()
+			SetStringInWaveNote(itemListWave, WAVE_NOTE_WINDOWNAME, ba.win)
+			SetStringInWaveNote(itemListWave, WAVE_NOTE_PROCNAME, StringByKey(PEXT_UDATA_POPUPPROC, ba.userdata))
+			SetStringInWaveNote(itemListWave, WAVE_NOTE_CTRLNAME, ba.ctrlName)
+
+			itemGetter = StringByKey(PEXT_UDATA_ITEMGETTER, ba.userdata)
+			FUNCREF PEXT_ITEMGETTER_LIST_PROTO GetItemList = $itemGetter
+			if(FuncRefIsAssigned(FuncRefInfo(GetItemList)))
+				itemList = GetItemList()
+				ASSERT(!IsNull(itemList), "Popup Extension got menu item list that is null.")
+				WAVE/T itemWave = ListToTextWave(itemList, ";")
+				WAVE/T splitMenu = PEXT_SplitToSubMenus(itemWave)
+				PEXT_GenerateSubMenuNames(splitMenu)
+				PEXT_VerifyAndSetMenuWave(splitMenu)
+			else
+				FUNCREF PEXT_ITEMGETTER_WAVE_PROTO GetItemWave = $itemGetter
+				ASSERT(FuncRefIsAssigned(FuncRefInfo(GetItemWave)), "Popup extension item getter has wrong function template format")
+				WAVE/T/Z itemWave = GetItemWave(ba.win)
+				PEXT_VerifyAndSetMenuWave(itemWave)
+			endif
+
+			PopupContextualMenu/N/ASYN=PEXT_Callback "PopupExt" + num2str(DimSize(itemListWave, ROWS))
+			break
+	endswitch
+	return 0
+End
+
+/// @brief Verifies menu data input wave and transfers it to global
+static Function PEXT_VerifyAndSetMenuWave(menuWave)
+	WAVE/T/Z menuWave
+
+	variable subMenuCnt, i
+	string subItem
+
+	if(!WaveExists(menuWave))
+		PEXT_SetDisabledMenu()
+	else
+		subMenuCnt = DimSize(menuWave, ROWS)
+		if(!subMenuCnt)
+			PEXT_SetDisabledMenu()
+		else
+			ASSERT(subMenuCnt <= MAX_SUBMENUS, "Menu definition wave has too many submenu entries.")
+
+			WAVE/T itemListWave = GetPopupExtMenuWave()
+			Redimension/N=(subMenuCnt) itemListWave
+
+			for(i = 0; i < subMenuCnt; i++)
+				subItem = GetDimLabel(menuWave, ROWS, i)
+				ASSERT(!IsEmpty(subItem), "Defined sub menu entry is empty")
+				SetDimLabel ROWS, i, $subItem, itemListWave
+			endfor
+			multithread itemListWave[] = menuWave[p]
+		endif
+	endif
+End
+
+/// @brief Sets the menu to show a non selectable "_none_" entry.
+static Function PEXT_SetDisabledMenu()
+
+	WAVE/T itemListWave = GetPopupExtMenuWave()
+	Redimension/N=1 itemListWave
+	itemListWave = ""
+	SetDimLabel ROWS, 0, $MENUNAME_UNUSED, itemListWave
+End
+
+/// @brief Automatically splits a 1D text wave with menu items to submenus
+///        This function does not name submenus
+///
+/// @param[in] menuList 1d text wave with menu items
+/// @param[in] method [optional, default = PEXT_SUBSPLIT_DEFAULT] sets how the menu items are split to sub menus @sa PEXT_SubMenuSplitting
+/// @returns 1d text wave where each element contains a list of menu items. Each element represents a sub menu.
+Function/WAVE PEXT_SplitToSubMenus(menuList[, method])
+	WAVE/T/Z menuList
+	variable method
+
+	variable subMenuCnt, beginitem, endItem, i, j
+	variable numItems, remainItems, menuPos, subIndex, subMenuLength
+	string begEntry, endEntry, checkEntry
+
+	if(!WaveExists(menuList))
+		return $""
+	endif
+
+	method = ParamIsDefault(method) ? PEXT_SUBSPLIT_DEFAULT : method
+
+	if(method == PEXT_SUBSPLIT_DEFAULT)
+		Sort/A menuList, menuList
+		subMenuCnt = trunc(DimSize(menuList, ROWS) / NUM_SUBENTRIES) + 1
+		subMenuCnt = subMenuCnt > MAX_SUBMENUS ? MAX_SUBMENUS : subMenuCnt
+
+		Make/FREE/T/N=(subMenuCnt) splitMenu
+
+		for(i = 0; i < subMenuCnt; i++)
+			beginItem = i * NUM_SUBENTRIES
+			endItem = i == subMenuCnt - 1 ? DimSize(menuList, ROWS) - 1 : beginItem + NUM_SUBENTRIES - 1
+
+			for(j = beginitem; j < enditem; j++)
+				splitMenu[i] = AddListItem(menuList[j], splitMenu[i], ";", Inf)
+			endfor
+		endfor
+
+	elseif(method == PEXT_SUBSPLIT_ALPHA)
+		Sort/A menuList, menuList
+
+		numItems = DimSize(menuList, ROWS)
+		Make/FREE/T/N=(MAX_SUBMENUS) splitMenu
+		do
+			remainItems = DimSize(menuList, ROWS) - menuPos
+			if(remainItems < NUM_SUBENTRIES || subIndex == MAX_SUBMENUS - 1)
+				subMenuLength = remainItems
+			else
+				begEntry = menuList[menuPos]
+				endEntry = menuList[menuPos + NUM_SUBENTRIES - 1]
+				if(!CmpStr(begEntry[0], endEntry[0]))
+					subMenuLength = NUM_SUBENTRIES
+				else
+					subMenuLength = NUM_SUBENTRIES - 1
+					do
+						subMenuLength--
+						checkEntry = menuList[menuPos + subMenuLength]
+					while(!CmpStr(endEntry[0], checkEntry[0]))
+					subMenuLength++
+				endif
+			endif
+
+			for(i = 0; i < subMenuLength; i++)
+				splitMenu[subIndex] = AddListItem(menuList[menuPos + i], splitMenu[subIndex], ";", Inf)
+			endfor
+
+			subIndex++;
+			menuPos += subMenuLength
+		while(menuPos < numItems)
+
+		Redimension/N=(subIndex) splitMenu
+	else
+		ASSERT(0, "Unknown method for automatically splitting to submenus")
+	endif
+
+	return splitMenu
+End
+
+/// @brief Automatically generates submenu names and applies them on the given wave
+///
+/// @param[in] splitMenu 1d text wave with menu item lists for sub menus as returned by PEXT_SplitToSubMenus()
+/// @param[in] method [optional, default = PEXT_SUBNAMEGEN_DEFAULT] sets how the sub menu names are generated @sa PEXT_SubMenuNameGeneration
+Function PEXT_GenerateSubMenuNames(splitMenu[, method])
+	WAVE/T/Z splitMenu
+	variable method
+
+	string subItemList, subItem
+	variable subMenuCnt, i, j
+	variable beginItem, endItem, endLen, minLen
+	string begEntry, endEntry, s1, s2
+
+	if(!WaveExists(splitMenu))
+		return 0
+	endif
+	subMenuCnt = DimSize(splitMenu, ROWS)
+	if(!subMenuCnt)
+		return 0
+	endif
+	method = ParamIsDefault(method) ? PEXT_SUBNAMEGEN_DEFAULT : method
+
+	if(method == PEXT_SUBNAMEGEN_DEFAULT)
+		Make/FREE/T/N=(subMenuCnt * 2) subMenuBoundary, subMenuShort
+		for(i = 0; i < subMenuCnt; i++)
+			subItemList = splitMenu[i]
+			ASSERT(!IsEmpty(subItemList), "menu item list for submenu is empty in splitMenu wave")
+			subMenuBoundary[2 * i] = StringFromList(0, subItemList)
+			subMenuBoundary[2 * i + 1] = StringFromList(ItemsInList(subItemList) - 1, subItemList)
+		endfor
+
+		minLen = 0
+		for(i = 0; i < 2 * subMenuCnt - 1; i++)
+			begEntry = subMenuBoundary[i]
+			endEntry = subMenuBoundary[i + 1]
+			endLen = min(strlen(begEntry), strlen(endEntry))
+			s1 = ""
+			s2 = ""
+
+			for(j = 0; j < endLen; j++)
+				s1 = s1 + begEntry[j]
+				s2 = s2 + endEntry[j]
+				if(CmpStr(s1, s2))
+					break
+				endif
+			endfor
+			if(j < minLen)
+				s1 = begEntry[j, minLen]
+			endif
+
+			minLen = j
+			subMenuShort[i] = s1
+			if(i == 2 * subMenuCnt - 2)
+				subMenuShort[i + 1] = s2
+			endif
+		endfor
+
+		for(i = 0; i < subMenuCnt; i++)
+			subItem = subMenuShort[2 * i] + " .. " + subMenuShort[2 * i + 1]
+			SetDimLabel ROWS, i, $subItem, splitMenu
+		endfor
+
+	else
+		ASSERT(0, "Unknown method for automatically generating submenus")
+	endif
+End

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -2570,23 +2570,43 @@ Function CreateTiledChannelGraph(graph, config, sweepNo, numericalValues,  textu
 	endif
 End
 
-/// @brief Return a sorted list of all keys in the labnotebook key wave
-Function/S GetLabNotebookSortedKeys(keyWave)
+/// @brief Return a wave with all keys in the labnotebook key wave
+Function/WAVE GetLabNotebookKeys(keyWave)
 	WAVE/Z/T keyWave
 
-	string list = ""
-	variable numCols, i
+	variable numCols
 
 	if(!WaveExists(keyWave))
-		return list
+		return $""
 	endif
 
-	numCols = DimSize(keyWave, COLS)
-	for(i = INITIAL_KEY_WAVE_COL_COUNT; i < numCols; i += 1)
-		list = AddListItem(keyWave[%Parameter][i], list, ";", Inf)
-	endfor
+	numCols = DimSize(keyWave, COLS) - INITIAL_KEY_WAVE_COL_COUNT
+	if(numCols <= 0)
+		return $""
+	endif
 
-	return SortList(list)
+	Make/FREE/T/N=(numCols) keys
+	keys[] = keyWave[%Parameter][INITIAL_KEY_WAVE_COL_COUNT + p]
+
+	return keys
+End
+
+/// @brief Return a sorted wave with all keys in the labnotebook key wave
+Function/WAVE GetLabNotebookSortedKeys(keyWave)
+	WAVE/Z/T keyWave
+
+	if(!WaveExists(keyWave))
+		return $""
+	endif
+
+	WAVE/Z/T keys = GetLabNotebookKeys(keyWave)
+	if(!WaveExists(keys))
+		return $""
+	endif
+
+	Sort/A keys, keys
+
+	return keys
 End
 
 /// @brief Check if the x wave belonging to the first trace in the

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -6603,3 +6603,23 @@ Function/WAVE GetSweepFormulaY(dfr)
 
 	return wv
 End
+
+/// @brief Return the global temporary wave for extended popup menu
+Function/WAVE GetPopupExtMenuWave()
+
+	variable versionOfNewWave = 1
+	DFREF dfr = GetMiesPath()
+	WAVE/T/Z/SDFR=dfr wv = popupExtMenuInfo
+
+	if(ExistsWithCorrectLayoutVersion(wv, versionOfNewWave))
+		return wv
+	elseif(WaveExists(wv))
+		// handle upgrade
+	else
+		Make/T/N=1 dfr:popupExtMenuInfo/WAVE=wv
+	endif
+
+	SetWaveVersion(wv, versionOfNewWave)
+
+	return wv
+End

--- a/Packages/MIES_Include.ipf
+++ b/Packages/MIES_Include.ipf
@@ -82,6 +82,7 @@
 #include "MIES_ExperimentDocumentation"
 #include "MIES_ForeignFunctionInterface"
 #include "MIES_GlobalStringAndVariableAccess"
+#include "MIES_GuiPopupMenuExt"
 #include "MIES_GuiUtilities"
 #include "MIES_IgorHooks"
 #include "MIES_Indexing"


### PR DESCRIPTION
The procures try to keep a compatible upgrade, where long popupmenus
get replaced by a button and previous proc definition move to the
buttons userdata.
After the menu finishes the old proc gets called as if it would be a
popupmenucontrol.

See SetupPopupMenuExt() for demo code.

closes https://github.com/AllenInstitute/MIES/issues/228