### PR TITLE
UploadCrashDumps: Fix folder moving

### DIFF
--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -5086,7 +5086,7 @@ Function UploadCrashDumps()
 	diagPath = S_path
 
 	basePath = GetUniqueSymbolicPath()
-	NewPath/Q/O/Z $basePath diagPath + ":"
+	NewPath/Q/O/Z $basePath diagPath + "..:"
 
 	MoveFolder/P=$basePath "Diagnostics" as UniqueFileOrFolder(basePath, "Diagnostics_old")
 


### PR DESCRIPTION
Bug introduced in fc842ca2 (Add UploadCrashDumps() with menu entry, 2020-03-05).

We need to go one lever higher compared to the diagnostics folder.