### PR TITLE
Bugfix/too short dimension labels makes entry not queryable from labnotebook

### DIFF
--- a/Packages/MIES/MIES_Async.ipf
+++ b/Packages/MIES/MIES_Async.ipf
@@ -14,7 +14,7 @@
 /// \endrst
 
 static StrConstant ASYNC_BACKGROUND = "AsyncFramework"
-static Constant MAX_OBJECT_NAME_LENGTH_IN_BYTES = 31
+static Constant MAX_OBJECT_NAME_LENGTH_IN_BYTES = 255
 static Constant ASYNC_THREAD_MARKER = 299792458
 static Constant ASYNC_MAX_THREADS = 64
 

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -883,8 +883,8 @@ Constant NI_ADC_MIN = -10
 Constant NI_ADC_MAX =  10
 /// @}
 
-/// Maximum length of a valid name in bytes in Igor Pro.
-Constant MAX_OBJECT_NAME_LENGTH_IN_BYTES = 31
+/// Maximum length of a valid object name in bytes in Igor Pro >= 8
+Constant MAX_OBJECT_NAME_LENGTH_IN_BYTES = 255
 
 StrConstant LABNOTEBOOK_NO_TOLERANCE = "-"
 StrConstant LABNOTEBOOK_BINARY_UNIT  = "On/Off"

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -886,6 +886,9 @@ Constant NI_ADC_MAX =  10
 /// Maximum length of a valid object name in bytes in Igor Pro >= 8
 Constant MAX_OBJECT_NAME_LENGTH_IN_BYTES = 255
 
+/// (Deprecated) Maximum length of a valid object name in bytes in Igor Pro < 8
+Constant MAX_OBJECT_NAME_LENGTH_IN_BYTES_SHORT = 31
+
 StrConstant LABNOTEBOOK_NO_TOLERANCE = "-"
 StrConstant LABNOTEBOOK_BINARY_UNIT  = "On/Off"
 

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -596,7 +596,7 @@ Constant WAVEBUILDER_PANEL_VERSION  = 8
 /// - Changed names of entries
 /// - Changed units or meaning of entries
 /// - New/Changed layers of entries
-Constant LABNOTEBOOK_VERSION = 36
+Constant LABNOTEBOOK_VERSION = 37
 
 /// Version of the stimset wave note
 Constant STIMSET_NOTE_VERSION = 7

--- a/Packages/MIES/MIES_WaveBuilderPanel.ipf
+++ b/Packages/MIES/MIES_WaveBuilderPanel.ipf
@@ -900,11 +900,13 @@ static Function/S WBP_AssembleSetName([modName])
 	string modName
 	string AssembledBaseName = ""
 
+	variable maxLength = (MAX_OBJECT_NAME_LENGTH_IN_BYTES_SHORT - 1) / 2
+
 	ControlInfo/W=$panel setvar_WaveBuilder_baseName
 	if(ParamIsDefault(modName))
-		AssembledBaseName += s_value[0,15]
+		AssembledBaseName += s_value[0,maxLength]
 	else
-		AssembledBaseName += s_value[0,(15 - strlen(modName))]
+		AssembledBaseName += s_value[0,(maxLength - strlen(modName))]
 		AssembledBaseName += modName
 	endif
 	ControlInfo/W=$panel popup_WaveBuilder_OutputType

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -1115,6 +1115,7 @@ End
 /// - Removal of invalid units for "Stim Scale Factor", "DA Gain" and "AD Gain"
 /// - Addition of fourth column "EntrySourceType"
 /// - Fix unit and tolerance of "Repeat Sets"
+/// - Reapplying the dimension labels as the old ones were cut off after 31 bytes
 static Function UpgradeLabNotebook(panelTitle)
 	string panelTitle
 
@@ -1256,6 +1257,12 @@ static Function UpgradeLabNotebook(panelTitle)
 	// no upgrade for async entries also in the INDEP_HEADSTAGE layer
 
 	// no upgrade for basic entries like sweepNum only in first layer due to IP7 semantics change
+
+	if(WaveVersionIsSmaller(numericalKeys, 37))
+		// reapply the dimension labels as the old ones were cut off after 31 bytes
+		SetDimensionLabels(numericalKeys, numericalValues)
+		SetDimensionLabels(textualKeys, textualValues)
+	endif
 End
 
 /// @brief Return a wave reference to the text labnotebook keys

--- a/Packages/Testing-MIES/UTF_AnalysisFunctionHelpers.ipf
+++ b/Packages/Testing-MIES/UTF_AnalysisFunctionHelpers.ipf
@@ -124,6 +124,7 @@ Function AE_WorksWithValidInput()
 
 	Make/FREE/N=(LABNOTEBOOK_LAYER_COUNT) values = NaN
 	ED_AddEntryToLabnotebook(device, "myKey" , values)
+	PASS()
 End
 
 Function AE_Works1()

--- a/Packages/Testing-MIES/UTF_AnalysisFunctionHelpers.ipf
+++ b/Packages/Testing-MIES/UTF_AnalysisFunctionHelpers.ipf
@@ -78,7 +78,7 @@ Function AE_ThrowsWithTooLongKey()
 
 	try
 		WAVE values = AE_GenerateValidNum_IGNORE()
-		ED_AddEntryToLabnotebook(device, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" , values)
+		ED_AddEntryToLabnotebook(device, PadString("", MAX_OBJECT_NAME_LENGTH_IN_BYTES + 1, char2num("a")) , values)
 		FAIL()
 	catch
 		PASS()

--- a/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
+++ b/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
@@ -3537,3 +3537,57 @@ Function RestoreDAEphysPanel([str])
 	CONF_RestoreDAEphys(jsonID, rewrittenConfigPath, middleOfExperiment = 1)
 	MIES_CONF#CONF_SaveDAEphys(fname)
 End
+
+static Function CheckLabnotebookKeys_IGNORE(keys, values)
+	WAVE/T keys
+	WAVE values
+
+	string lblKeys, lblValues, entry
+	variable i, numKeys
+
+	numKeys = DimSize(keys, COLS)
+	for(i = 0; i < numKeys; i += 1)
+		entry = keys[0][i]
+		lblKeys = GetDimLabel(keys, COLS, i)
+		lblValues = GetDimLabel(values, COLS, i)
+		CHECK_EQUAL_STR(entry, lblValues)
+		CHECK_EQUAL_STR(entry, lblKeys)
+	endfor
+end
+
+Function LabnotebookEntriesCanBeQueried_IGNORE(device)
+	string device
+
+	PGC_SetAndActivateControl(device, DAP_GetClampModeControl(I_CLAMP_MODE, 1), val = 1)
+End
+
+// UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
+Function LabnotebookEntriesCanBeQueried([str])
+	string str
+
+	STRUCT DAQSettings s
+	InitDAQSettingsFromString(s, "MD1_RA0_I0_L0_BKG_1")
+
+	AcquireData(s, str, preAcquireFunc = LabnotebookEntriesCanBeQueried_IGNORE)
+End
+
+Function LabnotebookEntriesCanBeQueried_REENTRY([str])
+	string str
+
+	variable sweepNo, numKeys, i, j
+
+	CHECK_EQUAL_VAR(GetSetVariable(str, "SetVar_Sweep"), 1)
+
+	sweepNo = AFH_GetLastSweepAcquired(str)
+	CHECK_EQUAL_VAR(sweepNo, 0)
+
+	WAVE numericalKeys = GetLBNumericalKeys(str)
+	WAVE numericalValues = GetLBNumericalValues(str)
+
+	CheckLabnotebookKeys_IGNORE(numericalKeys, numericalValues)
+
+	WAVE textualKeys = GetLBTextualKeys(str)
+	WAVE textualValues = GetLBTextualValues(str)
+
+	CheckLabnotebookKeys_IGNORE(textualKeys, textualValues)
+End

--- a/Packages/Testing-MIES/UTF_Labnotebook.ipf
+++ b/Packages/Testing-MIES/UTF_Labnotebook.ipf
@@ -502,7 +502,7 @@ Function LBNCache_Reliable()
 
 	numKeys = DimSize(numericalKeys, COLS)
 	for(i = 1; i < numSweeps; i += 1)
-		for(j = 4; j < numKeys; j += 1) // don't ask for the four always present
+		for(j = INITIAL_KEY_WAVE_COL_COUNT; j < numKeys; j += 1) // don't ask for the four always present
 
 			key = numericalKeys[0][j]
 			WAVE/Z settingsNoCache = MIES_MIESUTILS#GetLastSettingNoCache(numericalValues, i, key, DATA_ACQUISITION_MODE)
@@ -522,7 +522,7 @@ Function LBNCache_Reliable()
 
 	numKeys = DimSize(textualKeys, COLS)
 	for(i = 1; i < numSweeps; i += 1)
-		for(j = 4; j < numKeys; j += 1) // don't ask for the four always present
+		for(j = INITIAL_KEY_WAVE_COL_COUNT; j < numKeys; j += 1) // don't ask for the four always present
 
 			key = textualKeys[0][j]
 			WAVE/Z settingsNoCache = MIES_MIESUTILS#GetLastSettingNoCache(textualValues, i, key, DATA_ACQUISITION_MODE)


### PR DESCRIPTION
That was a fun one.

Our dimension label usage in the labnotebook did not work for one LBN entry as we cut the entry names off after 31 bytes.

I've now fixed that for new labnotebooks and added an upgrade path for old ones. And a test.