### PR TITLE
DAEphys: Disable the "Skip analysis function calls" checkbox during DAQ

### DIFF
--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -842,7 +842,7 @@ StrConstant STIMSET_WAVE_NOTE_KEY     = "Stim Wave Note"
 StrConstant EPOCHS_ENTRY_KEY          = "Epochs"
 
 /// DA_Ephys controls which should be disabled during DAQ
-StrConstant CONTROLS_DISABLE_DURING_DAQ = "Check_DataAcqHS_All;Radio_ClampMode_AllIClamp;Radio_ClampMode_AllVClamp;Radio_ClampMode_AllIZero;SetVar_Sweep;Check_DataAcq1_DistribDaq;Check_DataAcq1_dDAQOptOv;Check_DataAcq_Indexing;check_DataAcq_IndexRandom;Check_DataAcq1_IndexingLocked;check_DataAcq_RepAcqRandom;Check_DataAcq1_RepeatAcq"
+StrConstant CONTROLS_DISABLE_DURING_DAQ = "Check_DataAcqHS_All;Radio_ClampMode_AllIClamp;Radio_ClampMode_AllVClamp;Radio_ClampMode_AllIZero;SetVar_Sweep;Check_DataAcq1_DistribDaq;Check_DataAcq1_dDAQOptOv;Check_DataAcq_Indexing;check_DataAcq_IndexRandom;Check_DataAcq1_IndexingLocked;check_DataAcq_RepAcqRandom;Check_DataAcq1_RepeatAcq;Check_Settings_SkipAnalysFuncs"
 StrConstant CONTROLS_DISABLE_DURING_IDX = "SetVar_DataAcq_ListRepeats;SetVar_DataAcq_SetRepeats"
 
 /// DA_Ephys controls which should be disabled during DAQ *and* TP


### PR DESCRIPTION
Enabling that during DAQ would skip our analysis parameter checking and
we don't want that.