### PR TITLE
MIES_Include.ipf: Require the latest nightly build

### DIFF
--- a/Packages/MIES_Include.ipf
+++ b/Packages/MIES_Include.ipf
@@ -3,13 +3,13 @@
 #pragma rtFunctionErrors=1
 
 // Igor Pro nightly installation:
-// - Download from https://www.byte-physics.de/Downloads/WinIgor8_10APR2020.zip
+// - Download from https://www.byte-physics.de/Downloads/WinIgor8_06MAY2020.zip
 // - Close Igor Pro 8
 // - Extract the contents into C:\Program Files\WaveMetrics\Igor Pro 8 Folder (overwriting existing files, requires Administrator access)
 // - Restart Igor Pro 8
 //
 // By ignoring the error and *commenting out* the below check you will certainly break MIES.
-#if (NumberByKey("BUILD", IgorInfo(0)) < 35537)
+#if (NumberByKey("BUILD", IgorInfo(0)) < 35712)
 #define *** Too old Igor Pro 8 version, click "Edit procedure" for instructions
 #pragma IgorVersion=8.04
 #endif


### PR DESCRIPTION
Our new GUIPopupExtension triggered an Igor Pro bug by having long dimension labels in zeroed out dimensions.

The code

```igorpro
Function Dostuff()
     Make/O/N=1 data
     SetDimLabel 0, -1, $PadString("", 32, 10), data
     Redimension/N=0 data
End
```

triggers that crash on save.

Let's require a more recent nightly build to avoid that crash.