### PR TITLE
NWB_WriteStimsetTemplateWaves: Don't kill third party stimsets

### DIFF
--- a/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
+++ b/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
@@ -1037,9 +1037,6 @@ static Function NWB_WriteStimsetTemplateWaves(locationID, stimSet, compressionMo
 
 		stimset = NameOfWave(stimSetWave)
 		IPNWB#H5_WriteDataset(groupID, stimset, wv=stimSetWave, compressionMode = compressionMode, overwrite=1, writeIgorAttr=1)
-		// @todo remove once IP7 64bit is mandatory
-		// save memory by deleting the stimset again
-		KillOrMoveToTrash(wv=stimSetWave)
 
 		HDF5CloseGroup groupID
 		return NaN


### PR DESCRIPTION
In case we have a third party stimset we unconditionally deleted the
stimset. This is disastrous as we can't recreate it as it is a third
party stimset.

Bug introduced in 17809452 (NWB: Change stimset writing logic,
2016-08-17).