### PR TITLE
Packages/MIES/MIES_SweepFormula.ipf: Assert out on invalid sweep range

### DIFF
--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -1217,6 +1217,9 @@ static Function/WAVE SF_GetSweepForFormula(graph, range, channels, sweeps)
 			endif
 			ASSERT(!IsNaN(rangeStart) && !IsNaN(rangeEnd), "Specified range not valid.")
 
+			ASSERT(rangeStart == -inf || (IsFinite(rangeStart) && rangeStart >= leftx(sweep) && rangeStart < rightx(sweep)), "Specified starting range does not lie completely inside the sweep.")
+			ASSERT(rangeEnd == inf || (IsFinite(rangeEnd) && rangeEnd >= leftx(sweep) && rangeEnd < rightx(sweep)), "Specified ending range does not lie completely inside the sweep.")
+
 			pStart[i][j] = ScaleToIndexWrapper(sweep, rangeStart, ROWS)
 			pEnd[i][j] = ScaleToIndexWrapper(sweep, rangeEnd, ROWS)
 

--- a/Packages/Testing-MIES/UTF_Utils.ipf
+++ b/Packages/Testing-MIES/UTF_Utils.ipf
@@ -3590,7 +3590,11 @@ Function STIW_TestDimensions()
 
 	REQUIRE_EQUAL_VAR(ScaleToIndex(testWave, -1, ROWS), DimOffset(testwave, ROWS) - 1 / DimDelta(testwave, ROWS))
 	REQUIRE_EQUAL_VAR(ScaleToIndexWrapper(testWave, -1, ROWS), 0)
+#if (NumberByKey("BUILD", IgorInfo(0)) < 36039)
 	REQUIRE_EQUAL_VAR(ScaleToIndex(testWave, -inf, ROWS), DimSize(testwave, ROWS) - 1)
+#else
+	REQUIRE_EQUAL_VAR(ScaleToIndex(testWave, -inf, ROWS), NaN)
+#endif
 	REQUIRE_EQUAL_VAR(ScaleToIndexWrapper(testWave, -inf, ROWS), 0)
 
 	REQUIRE_EQUAL_VAR(ScaleToIndex(testWave, 1e3, ROWS), DimOffset(testwave, ROWS) + 1e3 / DimDelta(testwave, ROWS))
@@ -3600,8 +3604,9 @@ Function STIW_TestDimensions()
 	SetScale/P x, 0, -0.1, testwave
 	REQUIRE_EQUAL_VAR(ScaleToIndex(testWave, -1, ROWS), DimOffset(testwave, ROWS) - 1 / DimDelta(testwave, ROWS))
 	REQUIRE_EQUAL_VAR(ScaleToIndexWrapper(testWave, 1, ROWS), 0)
+#if (NumberByKey("BUILD", IgorInfo(0)) < 36039)
 	REQUIRE_EQUAL_VAR(ScaleToIndex(testWave, -inf, ROWS), ScaleToIndexWrapper(testWave, -inf, ROWS))
-
+#endif
 	REQUIRE_EQUAL_VAR(ScaleToIndex(testWave, 1, ROWS), DimOffset(testwave, ROWS) + 1 / DimDelta(testwave, ROWS))
 	REQUIRE_EQUAL_VAR(ScaleToIndexWrapper(testWave, 1, ROWS), 0)
 	REQUIRE_EQUAL_VAR(ScaleToIndex(testWave, inf, ROWS), DimSize(testwave, ROWS) - 1)


### PR DESCRIPTION
If the range for the data function is not completely inside the given
sweeps we currently return bogus data.

Let's assert out instead as this is more correct.

This has yet to use proper error handling, but that will be not part
of this commit.

Closes #468.

This is actually stricter to the plain wording of the issue. We now bug out if the full range is not completely inside all sweeps. Is that the right thing to do?