### PR TITLE
GetColfromWavewithDimLabel: Rename parameter to avoid IP9 compile error

### DIFF
--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -3082,13 +3082,13 @@ Function/WAVE ListToNumericWave(list, sep, [type])
 End
 
 /// @brief Returns the column from a multidimensional wave using the dimlabel
-Function/WAVE GetColfromWavewithDimLabel(waveRef, dimLabel)
-	WAVE waveRef
+Function/WAVE GetColfromWavewithDimLabel(wv, dimLabel)
+	WAVE wv
 	string dimLabel
-	
-	variable column = FindDimLabel(waveRef, COLS, dimLabel)
+
+	variable column = FindDimLabel(wv, COLS, dimLabel)
 	ASSERT(column != -2, "dimLabel:" + dimLabel + "cannot be found")
-	matrixOp/FREE OneDWv = col(waveRef, column)
+	matrixOp/FREE OneDWv = col(wv, column)
 	return OneDWv
 End
 


### PR DESCRIPTION
The token waveref is the name of a builtin function in IP9.