### PR TITLE
GetSettingsJSONid: Handle invalid JSON ID

### DIFF
--- a/Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf
+++ b/Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf
@@ -674,7 +674,8 @@ Function/S GetSettingsJSONid()
 	string path = GetNVARAsString(GetMiesPath(), "settingsJSONid", initialValue = NaN)
 	NVAR JSONid = $path
 
-	if(IsNaN(JSONid))
+	// missing or stale JSON document
+	if(IsNaN(JSONid) || !JSON_Exists(JSONid, ""))
 		JSONid = PS_ReadSettings("MIES", GenerateSettingsDefaults)
 	endif
 

--- a/Packages/Testing-MIES/UTF_Utils.ipf
+++ b/Packages/Testing-MIES/UTF_Utils.ipf
@@ -3740,3 +3740,29 @@ Function LBP_Works()
 End
 
 /// @}
+
+/// GetSettingsJSONid
+/// @{
+
+Function GSJIWorks()
+
+	NVAR/Z jsonID = $GetSettingsJSONid()
+	CHECK(NVAR_Exists(jsonID))
+	CHECK(JSON_Exists(jsonID, ""))
+End
+
+Function GSJIWorksWithCorruptID()
+
+	NVAR/Z jsonID = $GetSettingsJSONid()
+	CHECK(NVAR_Exists(jsonID))
+
+	// close the JSON document to fake an invalid ID
+	JSON_Release(jsonID)
+
+	// fetching again now returns a valid ID again
+	NVAR/Z jsonID = $GetSettingsJSONid()
+	CHECK(NVAR_Exists(jsonID))
+	CHECK(JSON_Exists(jsonID, ""))
+End
+
+/// @}


### PR DESCRIPTION
For reasons yet to be understood the settinsJSONid does sometimes refer
to a non-existing JSON document.

We now regenerate the package settings in this case as well.