### PR TITLE
IVS_ExportAllData: Remove existing NWB files first as requested

### DIFF
--- a/Packages/MIES/MIES_IVSCC.ipf
+++ b/Packages/MIES/MIES_IVSCC.ipf
@@ -435,6 +435,9 @@ End
 Function IVS_ExportAllData(filePath)
 	string filePath
 
+	CloseNWBFile()
+	DeleteFile/Z filePath
+
 	printf "Saving experiment data in NWB format to %s\r", filePath
 
 	NWB_ExportAllData(IVS_DEFAULT_NWBVERSION, overrideFilePath = filePath)


### PR DESCRIPTION
Close #610.

@aleonlein Here you go. I can't find the place in MIES where we deleted the NWB file in the old code before exporting into it. Maybe that was done on the client side (i.e. outside of MIES)?

The patch is based on the 2.1 release, ping my if you need something built on top of master.