### PR TITLE
NumericWaveToList: Workaround %d output bug

### DIFF
--- a/Packages/MIES/MIES_AnalysisFunctions_Dashboard.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_Dashboard.ipf
@@ -335,7 +335,7 @@ static Function/S AD_GetDAScaleFailMsg(numericalValues, textualValues, sweepNo, 
 	if(Sum(fISlopeReached) == 0)
 		key = PSQ_CreateLBNKey(PSQ_DA_SCALE, PSQ_FMT_LBN_DA_fI_SLOPE, query = 1)
 		WAVE fISlope = GetLastSettingEachSCI(numericalValues, sweepNo, key, headstage, UNKNOWN_MODE)
-		fISlopeStr = RemoveEnding(NumericWaveToList(fISlope, "%, ", format = "%d"), "%, ")
+		fISlopeStr = RemoveEnding(NumericWaveToList(fISlope, "%, ", format = "%.15g"), "%, ")
 
 		finalSlopePercent = AFH_GetAnalysisParamNumerical("FinalSlopePercent", params[headstage])
 

--- a/Packages/MIES/MIES_Cache.ipf
+++ b/Packages/MIES/MIES_Cache.ipf
@@ -163,7 +163,7 @@ End
 Function/S CA_AveragingKey(waveRefs)
 	WAVE/WAVE waveRefs
 
-	return CA_WaveCRCs(waveRefs, includeWaveScalingAndUnits=1, dims=ROWS) + "Version 5"
+	return CA_WaveCRCs(waveRefs, includeWaveScalingAndUnits=1, dims=ROWS) + "Version 6"
 End
 
 /// @brief Calculate the CRC of all metadata of all or the given dimension
@@ -228,7 +228,7 @@ static Function/S CA_WaveCRCs(waveRefs, [crcMode, includeWaveScalingAndUnits, di
 		MultiThread/NT=(rows < NUM_ENTRIES_FOR_MULTITHREAD) crc[] = CA_WaveScalingCRC(crc[p], waveRefs[p])
 	endif
 
-	return NumericWaveToList(crc, ";", format = "%d")
+	return NumericWaveToList(crc, ";", format = "%.15g")
 End
 
 /// @brief Calculate the cache key for SI_FindMatchingTableEntry.

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -3099,6 +3099,10 @@ Function/S NumericWaveToList(wv, sep, [format])
 	ASSERT(IsNumericWave(wv), "Expected a numeric wave")
 	ASSERT(DimSize(wv, COLS) == 0, "Expected a 1D wave")
 
+	if(IsFloatingPointWave(wv))
+		ASSERT(!GrepString(format, "%.*d"), "%d triggers an Igor bug")
+	endif
+
 	wfprintf list, format + sep, wv
 
 	return list
@@ -4580,10 +4584,10 @@ Function/WAVE FindLevelWrapper(data, level, edge, mode)
 	switch(mode)
 		case FINDLEVEL_MODE_SINGLE:
 			Make/D/FREE/N=(DimSize(resultSingle, ROWS)) numMaxLevels = 1
-			SetWaveDimLabel(resultSingle, NumericWaveToList(numMaxLevels, ";", format = "%d"), ROWS)
+			SetWaveDimLabel(resultSingle, NumericWaveToList(numMaxLevels, ";"), ROWS)
 			return resultSingle
 		case FINDLEVEL_MODE_MULTI:
-			SetWaveDimLabel(resultMulti, NumericWaveToList(numMaxLevels, ";", format = "%d"), ROWS)
+			SetWaveDimLabel(resultMulti, NumericWaveToList(numMaxLevels, ";"), ROWS)
 
 			// avoid single column waves
 			if(DimSize(resultMulti, COLS) == 1)

--- a/Packages/Testing-MIES/UTF_Utils.ipf
+++ b/Packages/Testing-MIES/UTF_Utils.ipf
@@ -3798,3 +3798,51 @@ Function GSJIWorksWithCorruptID()
 End
 
 /// @}
+
+/// NumericWaveToList
+/// @{
+
+Function NWLWorks()
+
+	string expected, result
+
+	Make/FREE dataFP = {1, 1e6, -inf, 1.5, NaN}
+	result = NumericWaveToList(dataFP, ";")
+	expected = "1;1e+06;-inf;1.5;nan;"
+	CHECK_EQUAL_STR(result, expected)
+
+	Make/FREE/I dataInt = {1, 1e6, -100}
+	result = NumericWaveToList(dataInt, ";", format="%d")
+	expected = "1;1000000;-100;"
+	CHECK_EQUAL_STR(result, expected)
+End
+
+Function NWLChecksInput()
+
+	try
+		Make/FREE/DF wrongWaveType
+		NumericWaveToList(wrongWaveType, ";"); AbortONRTE
+		FAIL()
+	catch
+		PASS()
+	endtry
+
+	try
+		Make/FREE/D/N=(2, 2) TwoDWave
+		NumericWaveToList(TwoDWave, ";"); AbortONRTE
+		FAIL()
+	catch
+		PASS()
+	endtry
+
+	// asserts out when triggering IP bug
+	try
+		Make/D/N=(2) input
+		NumericWaveToList(input, ";", format="%d"); AbortONRTE
+		FAIL()
+	catch
+		PASS()
+	endtry
+End
+
+/// @}


### PR DESCRIPTION
Since 378d514f (NumericWaveToList: Make it faster, 2020-08-14) we are
using wfprintf in NumericWaveToList.

Unfortunately this does not work for %d with data beyond 2^31 -1. Until
we have a fix from WaveMetrics we can rely on, let's use ".15g" instead
for all callers.

We also raise the average key version as erroneous cache entries was
what triggerd this bug hunt.

@timjarsky This fixes the buggy pulse average we saw on tuesday.