### PR TITLE
Open config files in notebook

### DIFF
--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -231,6 +231,34 @@ static Function CONF_DefaultSettings()
 	return jsonID
 End
 
+/// @brief Open all configuration files in plain text notebooks
+///
+/// Existing notebooks with the files are brought to the front.
+Function CONF_OpenConfigInNotebook()
+	variable i, numFiles
+	string path, name
+
+	WAVE/T/Z rawFileList = CONF_GetConfigFiles()
+
+	if(!WaveExists(rawFileList))
+		printf "There are no files to load from the %s folder.\r", EXPCONFIG_SETTINGS_FOLDER
+		ControlWindowToFront()
+		return NaN
+	endif
+
+	numFiles = DimSize(rawFileList, ROWS)
+	for(i = 0; i < numFiles; i += 1)
+		path = rawFileList[i]
+		name = CleanupName(GetFile(path), 0)
+
+		if(WindowExists(name))
+			DoWindow/F $name
+		else
+			OpenNotebook/ENCG=1/N=$name path
+		endif
+	endfor
+End
+
 /// @brief Return a text wave with absolute paths to the JSON configuration files
 static Function/WAVE CONF_GetConfigFiles()
 

--- a/Packages/MIES/MIES_Menu.ipf
+++ b/Packages/MIES/MIES_Menu.ipf
@@ -25,6 +25,7 @@ Menu "Mies Panels"
 		"Load Standard Configuration/1"        , /Q, CONF_AutoLoader()
 		"Load Window Configuration"            , /Q, CONF_RestoreWindow("", usePanelTypeFromFile = 1)
 		"Save Window Configuration"            , /Q, CONF_SaveWindow("")
+		"Open Configuration Files"             , /Q, CONF_OpenConfigInNotebook()
 		"Blowout/8"                            , /Q, BWO_SelectDevice()
 		"Save and Clear Experiment"            , /Q, SaveExperimentSpecial(SAVE_AND_CLEAR)
 		"Close Mies"                           , /Q, CloseMies()


### PR DESCRIPTION
Close #630.

This is the bare-bones solution.

I could also create a panel, have a notebook subwindow in that and add a save button on the panel. The save button would allow to check the JSON file for syntax errors. This would catch the most obvious errors.