### PR TITLE
AB_ScanFolder: Prevent loading the currently written to NWB file

### DIFF
--- a/Packages/MIES/MIES_AnalysisBrowser.ipf
+++ b/Packages/MIES/MIES_AnalysisBrowser.ipf
@@ -2155,7 +2155,8 @@ End
 static Function AB_ScanFolder(win)
 	string win
 
-	string baseFolder, path, pxpList, uxpList, nwbList, list
+	string baseFolder, path, pxpList, uxpList, nwbList, list, entry
+	string nwbFileUsedForExport
 	variable i, numEntries
 
 	// create new symbolic path
@@ -2179,10 +2180,21 @@ static Function AB_ScanFolder(win)
 	// sort combined list for readability
 	list = SortList(pxpList + uxpList + nwbList, "|")
 
+	nwbFileUsedForExport = ROStr(GetNWBFilePathExport())
+
 	numEntries = ItemsInList(list, "|")
 	for(i = 0; i < numEntries; i += 1)
+		entry = StringFromList(i, list, "|")
+
+		if(!cmpstr(entry, nwbFileUsedForExport))
+			printf "Ignore %s for adding into the analysis browser\ras we currently export data into it!\r", nwbFileUsedForExport
+			ControlWindowToFront()
+
+			continue
+		endif
+
 		// analyse files and save content in global list (GetExperimentBrowserGUIList)
-		AB_AddFile(baseFolder, StringFromList(i, list, "|"))
+		AB_AddFile(baseFolder, entry)
 	endfor
 
 	// redimension to maximum size (all expanded)


### PR DESCRIPTION
This does not work as we get a HDF5 library error when we try to read
with one file descriptor from it and write into it with another one.

Even if we used the same file descriptors for it, we would need updating
support in the analysis browser to make it really worthwhile using it.

So now we ignore the currently exported into file and warn the user.

Another one from the presentation.