### PR TITLE
Fixes for extended Popup Menu

### DIFF
--- a/Packages/MIES/MIES_GuiPopupMenuExt.ipf
+++ b/Packages/MIES/MIES_GuiPopupMenuExt.ipf
@@ -22,9 +22,9 @@
 ///    Function SetupPopupMenuExt()
 ///        KillWindow/Z panel0
 ///        NewPanel/N=$"panel0"/K=1
-///        Button popupext_menu1, pos={3.00, 20.00}, size={200,20},proc=PEXT_ButtonProc,title="DropDownMenu1 ▼", userdata($PEXT_UDATA_POPUPPROC)="DemoProc, userdata($PEXT_UDATA_ITEMGETTER)="GetMenuList1"
-///        Button popupext_menu2, pos={3.00, 55.00}, size={200,20},proc=PEXT_ButtonProc,title="DropDownMenu2 ▼", userdata($PEXT_UDATA_POPUPPROC)="DemoProc, userdata($PEXT_UDATA_ITEMGETTER)="GetMenuList2"
-///        Button popupext_menu3, pos={3.00, 90.00}, size={200,20},proc=PEXT_ButtonProc,title="DropDownMenu3 ▼", userdata($PEXT_UDATA_POPUPPROC)="DemoProc, userdata($PEXT_UDATA_ITEMGETTER)="GetMenuList3"
+///        Button popupext_menu1, pos={3.00, 20.00}, size={200,20},proc=PEXT_ButtonProc,title="DropDownMenu1 ▼", userdata($PEXT_UDATA_POPUPPROC)="DemoProc", userdata($PEXT_UDATA_ITEMGETTER)="GetMenuList1"
+///        Button popupext_menu2, pos={3.00, 55.00}, size={200,20},proc=PEXT_ButtonProc,title="DropDownMenu2 ▼", userdata($PEXT_UDATA_POPUPPROC)="DemoProc", userdata($PEXT_UDATA_ITEMGETTER)="GetMenuList2"
+///        Button popupext_menu3, pos={3.00, 90.00}, size={200,20},proc=PEXT_ButtonProc,title="DropDownMenu3 ▼", userdata($PEXT_UDATA_POPUPPROC)="DemoProc", userdata($PEXT_UDATA_ITEMGETTER)="GetMenuList3"
 ///    End
 ///
 ///    Function DemoProc(pa) : PopupMenuControl

--- a/Packages/MIES/MIES_GuiPopupMenuExt.ipf
+++ b/Packages/MIES/MIES_GuiPopupMenuExt.ipf
@@ -117,6 +117,8 @@ static StrConstant WAVE_NOTE_PROCNAME = "PROC"
 static StrConstant WAVE_NOTE_WINDOWNAME = "WINNAME"
 static StrConstant WAVE_NOTE_CTRLNAME = "CTRLNAME"
 static StrConstant MENUNAME_UNUSED = "*** bug, report to dev ***"
+static StrConstant MENU_DISABLE_SPECIAL = "\\M0"
+static StrConstant LSEP = ";"
 
 /// @brief Menu definition templates for up to 10 sub menus.
 ///        The constant MAX_SUBMENUS stores the number of these definitions
@@ -337,7 +339,7 @@ Function/S PEXT_SubMenuName(subMenuNr)
 		return MENUNAME_UNUSED
 	endif
 
-	return s
+	return MENU_DISABLE_SPECIAL + s
 End
 
 /// @brief Returns menu items for all PEXT menus
@@ -476,7 +478,7 @@ static Function PEXT_VerifyAndSetMenuWave(menuWave)
 				ASSERT(!IsEmpty(subItem), "Defined sub menu entry is empty")
 				SetDimLabel ROWS, i, $subItem, itemListWave
 			endfor
-			multithread itemListWave[] = menuWave[p]
+			multithread itemListWave[] = MENU_DISABLE_SPECIAL + ReplaceString(LSEP, menuWave[p], LSEP + MENU_DISABLE_SPECIAL)
 		endif
 	endif
 End


### PR DESCRIPTION
- Typo fixed in example code in inline documentation
- Special Characters are now disabled for submenu names and menu items, exclusion with :<special>: is still possible when required.

close https://github.com/AllenInstitute/MIES/issues/632