### PR TITLE
Work load class tracking in ASYNC frame work

### DIFF
--- a/Packages/MIES/MIES_Async.ipf
+++ b/Packages/MIES/MIES_Async.ipf
@@ -925,3 +925,57 @@ static Function ASYNC_IsASYNCRunning()
 	ResetDebugOnError(doe)
 	return waitResult != 0
 End
+
+/// @brief Deletes one row, column, layer or chunk from a wave
+/// Advantages over DeletePoints:
+/// Keeps the dimensionality of the wave when deleting the last row, column, layer or chunk in a wave
+/// Implements range check
+/// Advantages over DeletePoints + KillWaves:
+/// The wave reference stays valid
+///
+/// @param wv wave where the row, column, layer or chunk should be deleted
+///
+/// @param dim dimension 0 - rows, 1 - column, 2 - layer, 3 - chunk
+///
+/// @param index index where one point in the given dimension is deleted
+static Function DeleteWavePoint(wv, dim, index)
+   WAVE wv
+   variable dim, index
+
+   variable size
+
+   ASSERT(WaveExists(wv), "wave does not exist")
+   ASSERT(dim >= 0 && dim < 4, "dim must be 0, 1, 2 or 3")
+   size = DimSize(wv, dim)
+   if(index >= 0 && index < size)
+	   if(size > 1)
+		   DeletePoints/M=(dim) index, 1, wv
+	   else
+		   switch(dim)
+			   case 0:
+				   Redimension/N=(0, -1, -1, -1) wv
+				   break
+			   case 1:
+				   Redimension/N=(-1, 0, -1, -1) wv
+				   break
+			   case 2:
+				   Redimension/N=(-1, -1, 0, -1) wv
+				   break
+			   case 3:
+				   Redimension/N=(-1, -1, -1, 0) wv
+				   break
+		   endswitch
+	   endif
+   else
+	   ASSERT(0, "index out of range")
+   endif
+End
+
+/// @brief Check if a name for an object adheres to the strict naming rules
+///
+/// @see `DisplayHelpTopic "ObjectName"`
+threadsafe static Function IsValidObjectName(name)
+	string name
+
+	return !cmpstr(name, CleanupName(name, 0, MAX_OBJECT_NAME_LENGTH_IN_BYTES))
+End

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -1256,6 +1256,14 @@ Constant POST_PLOT_FULL_UPDATE = 0x8     ///< Forces a complete update from scra
 
 /// @}
 
+/// @name Work Load Class names used in ASYNC frame work
+/// @anchor AsyncWorkLoadClassNames
+///
+/// @{
+StrConstant WORKLOADCLASS_TP = "TestPulse"
+/// @}
+
+
 Constant PA_SETTINGS_STRUCT_VERSION = 5
 
 StrConstant NOTE_NEEDS_UPDATE = "NeedsUpdate"

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -29,6 +29,8 @@ static StrConstant GUI_CONTROLSAVESTATE_DISABLED = "oldDisabledState"
 // PCIe-6343 | PXI-6259
 static StrConstant NI_DAC_PATTERNS = "AI:32;AO:4;COUNTER:4;DIOPORTS:3;LINES:32,8,8|AI:32;AO:4;COUNTER:2;DIOPORTS:3;LINES:32,8,8"
 
+static Constant DAP_WAITFORTPANALYSIS_TIMEOUT = 2
+
 /// @brief Creates meta information about coupled CheckBoxes (Radio Button) controls
 ///        Used for saving/restoring the GUI state
 /// @return Free text wave with lists of coupled CheckBox controls
@@ -4787,6 +4789,7 @@ static Function DAP_UnlockDevice(panelTitle)
 	PGC_SetAndActivateControl(panelTitle, "check_Settings_TPAfterDAQ", val = CHECKBOX_UNSELECTED)
 	DQ_StopDAQ(panelTitle)
 	TP_StopTestPulse(panelTitle)
+	ASSERT(!ASYNC_WaitForWLCToFinishAndRemove(WORKLOADCLASS_TP + panelTitle, DAP_WAITFORTPANALYSIS_TIMEOUT), "TP analysis did not finish within timeout")
 	PGC_SetAndActivateControl(panelTitle, "check_Settings_TPAfterDAQ", val = state)
 
 	DAP_SerializeCommentNotebook(panelTitle)

--- a/Packages/MIES/MIES_Oscilloscope.ipf
+++ b/Packages/MIES/MIES_Oscilloscope.ipf
@@ -580,7 +580,7 @@ Function SCOPE_UpdateOscilloscopeData(panelTitle, dataAcqOrTP, [chunk, fifoPos, 
 					DEBUGPRINT("headstage: ", var = headstage)
 					DEBUGPRINT("channel: ", var = numDACs + j)
 
-					TP_SendToAnalysis(tpInput)
+					TP_SendToAnalysis(panelTitle, tpInput)
 
 					if(saveTP)
 						hsList = AddListItem(num2str(headstage), hsList, ",", Inf)

--- a/Packages/MIES/MIES_TestPulse.ipf
+++ b/Packages/MIES/MIES_TestPulse.ipf
@@ -862,11 +862,11 @@ End
 
 /// @brief Send a TP data set to the asynchroneous analysis function TP_TSAnalysis
 ///
+/// @param[in] panelTitle title of panel that ran this test pulse
 /// @param tpInput holds the parameters send to analysis
-Function TP_SendToAnalysis(tpInput)
-	STRUCT TPAnalysisInput &tpInput
+Function TP_SendToAnalysis(string panelTitle, STRUCT TPAnalysisInput &tpInput)
 
-	DFREF threadDF = ASYNC_PrepareDF("TP_TSAnalysis", "TP_ROAnalysis", WORKLOADCLASS_TP, inOrder=0)
+	DFREF threadDF = ASYNC_PrepareDF("TP_TSAnalysis", "TP_ROAnalysis", WORKLOADCLASS_TP + panelTitle, inOrder=0)
 	ASYNC_AddParam(threadDF, w=tpInput.data)
 	ASYNC_AddParam(threadDF, var=tpInput.clampAmp)
 	ASYNC_AddParam(threadDF, var=tpInput.clampMode)

--- a/Packages/MIES/MIES_TestPulse.ipf
+++ b/Packages/MIES/MIES_TestPulse.ipf
@@ -866,7 +866,7 @@ End
 Function TP_SendToAnalysis(tpInput)
 	STRUCT TPAnalysisInput &tpInput
 
-	DFREF threadDF = ASYNC_PrepareDF("TP_TSAnalysis", "TP_ROAnalysis", inOrder=0)
+	DFREF threadDF = ASYNC_PrepareDF("TP_TSAnalysis", "TP_ROAnalysis", WORKLOADCLASS_TP, inOrder=0)
 	ASYNC_AddParam(threadDF, w=tpInput.data)
 	ASYNC_AddParam(threadDF, var=tpInput.clampAmp)
 	ASYNC_AddParam(threadDF, var=tpInput.clampMode)

--- a/Packages/Testing-MIES/UTF_AsynFrameworkTest.ipf
+++ b/Packages/Testing-MIES/UTF_AsynFrameworkTest.ipf
@@ -1093,6 +1093,51 @@ static Function TASYNC_RunClassFail()
 	CHECK(IsNaN(ASYNC_IsWorkloadClassDone("UnknownWorkLoadClass")))
 End
 
+/// @brief Test if adding same workloads class with different order fails
+static Function TASYNC_RunClassMixedOrder()
+
+	DFREF threadDF1, threadDF2
+
+	ASYNC_Start(ThreadProcessorCount)
+
+	threadDF1 = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut", "WorkLoadMixedClassFail", inOrder = 1)
+	threadDF2 = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut", "WorkLoadMixedClassFail", inOrder = 0)
+	ASYNC_Execute(threadDF1)
+	try
+		ASYNC_Execute(threadDF2)
+		FAIL()
+	catch
+		PASS()
+	endtry
+End
+
+/// @brief Test if changing order of same workloads class works
+static Function TASYNC_RunClassChangeOrder()
+
+	DFREF threadDF1, threadDF2
+	string myDF
+
+	ASYNC_Start(ThreadProcessorCount)
+
+	myDF = GetDataFolder(1)
+	Make data
+	Make/N=0 returnOrder
+
+	threadDF1 = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut", "WorkLoadMixedClass", inOrder = 1)
+	ASYNC_AddParam(threadDF1, var=0)
+	ASYNC_AddParam(threadDF1, w=data)
+	ASYNC_AddParam(threadDF1, str=myDF)
+
+	threadDF2 = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut", "WorkLoadMixedClass", inOrder = 0)
+	ASYNC_AddParam(threadDF2, var=0)
+	ASYNC_AddParam(threadDF2, w=data)
+	ASYNC_AddParam(threadDF2, str=myDF)
+
+	ASYNC_Execute(threadDF1)
+	CHECK(!ASYNC_WaitForWLCToFinishAndRemove("WorkLoadMixedClass", THREADING_TEST_TIMEOUT))
+	ASYNC_Execute(threadDF2)
+End
+
 /// Worker/Readout functions follow
 
 /// @brief Generic worker with a variable runtime, the function transfers required data to the output folder

--- a/Packages/Testing-MIES/UTF_AsynFrameworkTest.ipf
+++ b/Packages/Testing-MIES/UTF_AsynFrameworkTest.ipf
@@ -95,7 +95,7 @@ End
 static Function TASYNC_PrepareDF_InvWorker()
 
 	try
-		DFREF threadDF = ASYNC_PrepareDF("1", "RunGenericReadOut")
+		DFREF threadDF = ASYNC_PrepareDF("1", "RunGenericReadOut", "TASYNCTest")
 		FAIL()
 	catch
 		PASS()
@@ -106,7 +106,7 @@ End
 static Function TASYNC_PrepareDF_InvReadOut()
 
 	try
-		DFREF threadDF = ASYNC_PrepareDF("RunGenericWorker", "1")
+		DFREF threadDF = ASYNC_PrepareDF("RunGenericWorker", "1", "TASYNCTest")
 		FAIL()
 	catch
 		PASS()
@@ -119,7 +119,7 @@ static Function TASYNC_PrepareDF_Setup()
 	string helperStr, compStr
 	DFREF threadDF
 
-	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut")
+	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut", "TASYNCTest")
 
 	SVAR/Z/SDFR=threadDF tempS=WorkerFunc
 	CHECK(SVAR_Exists(tempS))
@@ -166,7 +166,7 @@ static Function TASYNC_AddParam_NoParams()
 
 	ASYNC_Start(ThreadProcessorCount)
 
-	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut")
+	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut", "TASYNCTest")
 
 	try
 		ASYNC_AddParam(threadDF)
@@ -185,7 +185,7 @@ static Function TASYNC_AddParam_VarStr()
 
 	ASYNC_Start(ThreadProcessorCount)
 
-	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut")
+	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut", "TASYNCTest")
 
 	try
 		ASYNC_AddParam(threadDF, var=1, str="1")
@@ -204,7 +204,7 @@ static Function TASYNC_AddParam_VarWave()
 
 	ASYNC_Start(ThreadProcessorCount)
 
-	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut")
+	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut", "TASYNCTest")
 
 	Make/N=1 wv
 	try
@@ -224,7 +224,7 @@ static Function TASYNC_AddParam_StrWave()
 
 	ASYNC_Start(ThreadProcessorCount)
 
-	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut")
+	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut", "TASYNCTest")
 
 	Make/N=1 wv
 	try
@@ -244,7 +244,7 @@ static Function TASYNC_AddParam_VarStrWave()
 
 	ASYNC_Start(ThreadProcessorCount)
 
-	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut")
+	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut", "TASYNCTest")
 
 	Make/N=1 wv
 	try
@@ -264,7 +264,7 @@ static Function TASYNC_AddParam_VarMove()
 
 	ASYNC_Start(ThreadProcessorCount)
 
-	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut")
+	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut", "TASYNCTest")
 
 	Make/N=1 wv
 	try
@@ -284,7 +284,7 @@ static Function TASYNC_AddParam_StrMove()
 
 	ASYNC_Start(ThreadProcessorCount)
 
-	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut")
+	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut", "TASYNCTest")
 
 	Make/N=1 wv
 	try
@@ -304,7 +304,7 @@ static Function TASYNC_AddParam_FreeWaveMove()
 
 	ASYNC_Start(ThreadProcessorCount)
 
-	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut")
+	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut", "TASYNCTest")
 
 	Make/FREE/N=1 wv
 	ASYNC_AddParam(threadDF, w=wv, move=1)
@@ -323,7 +323,7 @@ static Function TASYNC_AddParam_WaveMove()
 
 	ASYNC_Start(ThreadProcessorCount)
 
-	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut")
+	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut", "TASYNCTest")
 
 	Make/N=1 wv
 	ASYNC_AddParam(threadDF, w=wv, move=1)
@@ -342,7 +342,7 @@ static Function TASYNC_AddParam_Wave()
 
 	ASYNC_Start(ThreadProcessorCount)
 
-	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut")
+	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut", "TASYNCTest")
 
 	Make/N=1 wv
 	ASYNC_AddParam(threadDF, w=wv)
@@ -361,7 +361,7 @@ static Function TASYNC_AddParam_FreeWave()
 
 	ASYNC_Start(ThreadProcessorCount)
 
-	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut")
+	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut", "TASYNCTest")
 
 	Make/FREE/N=1 wv
 	ASYNC_AddParam(threadDF, w=wv)
@@ -380,7 +380,7 @@ static Function TASYNC_AddParam_Var()
 
 	ASYNC_Start(ThreadProcessorCount)
 
-	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut")
+	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut", "TASYNCTest")
 
 	ASYNC_AddParam(threadDF, var=1)
 
@@ -398,7 +398,7 @@ static Function TASYNC_AddParam_Str()
 
 	ASYNC_Start(ThreadProcessorCount)
 
-	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut")
+	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut", "TASYNCTest")
 
 	ASYNC_AddParam(threadDF, str="1")
 
@@ -416,7 +416,7 @@ static Function TASYNC_AddParam_ParamsCount()
 
 	ASYNC_Start(ThreadProcessorCount)
 
-	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut")
+	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut", "TASYNCTest")
 
 	ASYNC_AddParam(threadDF, var=0)
 	ASYNC_AddParam(threadDF, var=1)
@@ -446,7 +446,7 @@ static Function TASYNC_Execute_NotRunning()
 	DFREF threadDF
 
 	ASYNC_Start(ThreadProcessorCount)
-	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut")
+	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut", "TASYNCTest")
 	ASYNC_Stop(timeout=1)
 
 	try
@@ -463,7 +463,7 @@ static Function TASYNC_Execute_InvalidDF()
 	DFREF threadDF
 
 	ASYNC_Start(ThreadProcessorCount)
-	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut")
+	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut", "TASYNCTest")
 
 	try
 		ASYNC_Execute(root)
@@ -482,7 +482,7 @@ static Function TASYNC_Execute_Valid()
 	variable endtime, timeout
 
 	ASYNC_Start(ThreadProcessorCount)
-	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut")
+	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut", "TASYNCTest")
 	ASYNC_AddParam(threadDF, var=1)
 	Make/N=10 data
 	ASYNC_AddParam(threadDF, w=data, move=1)
@@ -518,7 +518,7 @@ static Function TASYNC_WorkerRealDF()
 	variable endtime, timeout
 
 	ASYNC_Start(1)
-	threadDF = ASYNC_PrepareDF("RunGenericWorker3", "RunGenericReadOut")
+	threadDF = ASYNC_PrepareDF("RunGenericWorker3", "RunGenericReadOut", "TASYNCTest")
 	ASYNC_AddParam(threadDF, var=1)
 	Make/N=10 data
 	ASYNC_AddParam(threadDF, w=data, move=1)
@@ -553,7 +553,7 @@ static Function TASYNC_StopForAssert()
 	variable endtime, timeout
 
 	ASYNC_Start(ThreadProcessorCount)
-	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOutAbort")
+	threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOutAbort", "TASYNCTest")
 	ASYNC_AddParam(threadDF, var=1)
 	Make/N=10 data
 	ASYNC_AddParam(threadDF, w=data, move=1)
@@ -575,7 +575,7 @@ static Function TASYNC_WorkerNoDF()
 	variable endtime, timeout
 
 	ASYNC_Start(1)
-	threadDF = ASYNC_PrepareDF("RunGenericWorker4", "ReadOutCheckDF")
+	threadDF = ASYNC_PrepareDF("RunGenericWorker4", "ReadOutCheckDF", "TASYNCTest")
 	ASYNC_AddParam(threadDF, var=1)
 	Make/N=10 data
 	ASYNC_AddParam(threadDF, w=data, move=1)
@@ -618,7 +618,7 @@ static Function TASYNC_RunOrderless()
 	myDF = GetDataFolder(1)
 	for(i = 0;i < WORK_COUNT_GENERIC; i += 1)
 
-		threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut", inOrder=0)
+		threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut", "TASYNCTest", inOrder=0)
 		ASYNC_AddParam(threadDF, var=wlCount)
 		Make/N=10 data
 		ASYNC_AddParam(threadDF, w=data, move=1)
@@ -670,7 +670,7 @@ static Function TASYNC_RunInOrder()
 	myDF = GetDataFolder(1)
 	for(i = 0;i < WORK_COUNT_GENERIC; i += 1)
 
-		threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut")
+		threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut", "TASYNCTest")
 		ASYNC_AddParam(threadDF, var=wlCount)
 		Make/N=10 data
 		ASYNC_AddParam(threadDF, w=data, move=1)
@@ -719,10 +719,10 @@ static Function TASYNC_InOrderDiffWL()
 	for(i = 0;i < workCnt; i += 1)
 
 		if(mod(i, 2))
-			threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut")
+			threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut", "TASYNCTest")
 			ASYNC_AddParam(threadDF, var=wl1Count)
 		else
-			threadDF = ASYNC_PrepareDF("RunGenericWorker2", "RunGenericReadOut2")
+			threadDF = ASYNC_PrepareDF("RunGenericWorker2", "RunGenericReadOut2", "TASYNCTest")
 			ASYNC_AddParam(threadDF, var=wl2Count)
 		endif
 		Make/N=10 data
@@ -777,7 +777,7 @@ static Function TASYNC_RunErrorWorker()
 
 	for(i = 0;i < workCnt; i += 1)
 
-		threadDF = ASYNC_PrepareDF("RunWorkerOfDOOM", "RunReadOutOfDOOM")
+		threadDF = ASYNC_PrepareDF("RunWorkerOfDOOM", "RunReadOutOfDOOM", "TASYNCTest")
 		ASYNC_AddParam(threadDF, var=i)
 		Make/N=10 data
 		ASYNC_AddParam(threadDF, w=data, move=1)
@@ -811,7 +811,7 @@ static Function TASYNC_RunErrorReadOut()
 	variable endtime, timeout
 
 	ASYNC_Start(ThreadProcessorCount)
-	threadDF = ASYNC_PrepareDF("RunGenericWorker", "FailReadOut")
+	threadDF = ASYNC_PrepareDF("RunGenericWorker", "FailReadOut", "TASYNCTest")
 	ASYNC_AddParam(threadDF, var=1)
 	Make/N=10 data
 	ASYNC_AddParam(threadDF, w=data, move=1)
@@ -861,7 +861,7 @@ static Function TASYNC_OrderlessDirectStop()
 	myDF = GetDataFolder(1)
 	for(i = 0;i < WORK_COUNT_GENERIC; i += 1)
 
-		threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut", inOrder=0)
+		threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut", "TASYNCTest", inOrder=0)
 		ASYNC_AddParam(threadDF, var=wlCount)
 		Make/N=10 data
 		ASYNC_AddParam(threadDF, w=data, move=1)
@@ -899,7 +899,7 @@ static Function TASYNC_StopTimeOut()
 	myDF = GetDataFolder(1)
 	for(i = 0;i < WORK_COUNT_GENERIC; i += 1)
 
-		threadDF = ASYNC_PrepareDF("RunGenericWorker5", "RunGenericReadOut", inOrder=0)
+		threadDF = ASYNC_PrepareDF("RunGenericWorker5", "RunGenericReadOut", "TASYNCTest", inOrder=0)
 		ASYNC_AddParam(threadDF, var=wlCount)
 		Make/N=10 data
 		ASYNC_AddParam(threadDF, w=data, move=1)
@@ -924,7 +924,7 @@ static Function TASYNC_StopTimeOutForce()
 	ASYNC_Start(ThreadProcessorCount)
 
 	for(i = 0;i < WORK_COUNT_GENERIC; i += 1)
-		threadDF = ASYNC_PrepareDF("InfiniteWorker", "EmptyReadOut", inOrder=0)
+		threadDF = ASYNC_PrepareDF("InfiniteWorker", "EmptyReadOut", "TASYNCTest", inOrder=0)
 		ASYNC_Execute(threadDF)
 	endfor
 	Make/N=0 returnOrder
@@ -949,10 +949,10 @@ static Function TASYNC_IODiffWLDirectStop()
 	for(i = 0;i < workCnt; i += 1)
 
 		if(mod(i, 2))
-			threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut")
+			threadDF = ASYNC_PrepareDF("RunGenericWorker", "RunGenericReadOut", "TASYNCTest")
 			ASYNC_AddParam(threadDF, var=wl1Count)
 		else
-			threadDF = ASYNC_PrepareDF("RunGenericWorker2", "RunGenericReadOut2")
+			threadDF = ASYNC_PrepareDF("RunGenericWorker2", "RunGenericReadOut2", "TASYNCTest")
 			ASYNC_AddParam(threadDF, var=wl2Count)
 		endif
 		Make/N=10 data

--- a/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
+++ b/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
@@ -3143,25 +3143,6 @@ End
 
 static Constant TP_WAIT_TIMEOUT = 5
 
-Function TPWaitForAsync_IGNORE(TPStorage, storedTP)
-	WAVE TPStorage
-	WAVE storedTP
-	variable timeOut
-
-	variable sizeAsyncOut, sizeMainThread, endTime
-
-	sizeMainThread = GetNumberFromWaveNote(storedTP, NOTE_INDEX)
-	endTime = DateTime + TP_WAIT_TIMEOUT
-	do
-		ASYNC_ThreadReadOut()
-		sizeAsyncOut = GetNumberFromWaveNote(TPStorage, NOTE_INDEX)
-		if(sizeMainThread == sizeAsyncOut)
-			return NaN
-		endif
-	while(DateTime < endTime)
-	FAIL() // TimeOut for TP data was reached
-End
-
 static Constant TP_WIDTH_EPSILON = 1
 static Constant TP_DYN_PERC_TRESHOLD = 0.2
 static Constant TP_EDGE_EPSILON = 0.2
@@ -3198,9 +3179,7 @@ Function WaitAndCheckStoredTPs_IGNORE(device, expectedNumTPchannels)
 	CHECK_WAVE(storedTestPulses, WAVE_WAVE)
 	numTP = GetNumberFromWaveNote(storedTestPulses, NOTE_INDEX)
 
-	if(numTP != numStored)
-		TPWaitForAsync_IGNORE(TPStorage, storedTestPulses)
-	endif
+	CHECK(!ASYNC_WaitForWLCToFinishAndRemove(WORKLOADCLASS_TP + device, TP_WAIT_TIMEOUT))
 
 	tpLength = TP_GetTestPulseLengthInPoints(device, DATA_ACQUISITION_MODE)
 


### PR DESCRIPTION
- ASYNC_PrepareDF now setups a work load class name as well
- ASYNC_Execute registers now work loads by their class name
- ASYNC_ThreadReadOut tracks now work loads by their class
- ASYNC_IsWorkloadClassDone allows to check if a specific class of work loads
  finished. It also allows to remove the work load class when finished.

close https://github.com/AllenInstitute/MIES/issues/101