### PR TITLE
RA_SkipSweeps: Fix various corner cases

### DIFF
--- a/Packages/MIES/MIES_Async.ipf
+++ b/Packages/MIES/MIES_Async.ipf
@@ -6,7 +6,7 @@
 #pragma ModuleName=MIES_ASYNC
 #endif
 
-/// @file MIES_ASYNC.ipf
+/// @file MIES_Async.ipf
 /// @brief __ASYNC__ This file holds the asynchronous execution framework
 ///
 /// \rst

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -5082,7 +5082,7 @@ Function DAP_ButtonProc_skipSweep(ba) : ButtonControl
 
 	switch( ba.eventCode )
 		case 2:
-			RA_SkipSweeps(ba.win, 1)
+			RA_SkipSweeps(ba.win, 1, limitToSetBorder = 1)
 			break
 	endswitch
 
@@ -5094,7 +5094,7 @@ Function DAP_ButtonProc_skipBack(ba) : ButtonControl
 
 	switch( ba.eventCode )
 		case 2:
-			RA_SkipSweeps(ba.win, -1)
+			RA_SkipSweeps(ba.win, -1, limitToSetBorder = 1)
 			break
 	endswitch
 

--- a/Packages/MIES/MIES_TestPulse.ipf
+++ b/Packages/MIES/MIES_TestPulse.ipf
@@ -16,6 +16,9 @@ static Constant TP_DIMENSION_SCALING_INTERVAL = 18  ///< [s]
 static Constant TP_PRESSURE_INTERVAL          = 0.090  ///< [s]
 static Constant TP_EVAL_POINT_OFFSET          = 5
 
+// comment in for debugging
+// #define TP_ANALYSIS_DEBUGGING
+
 Function TP_CreateTPAvgBuffer(panelTitle)
 	string panelTitle
 
@@ -261,7 +264,7 @@ threadsafe Function/DF TP_TSAnalysis(dfrInp)
 	NVAR/SDFR=dfrInp marker = param9
 	NVAR/SDFR=dfrInp activeADCs = param10
 
-#if defined(DEBUGGING_ENABLED)
+#if defined(TP_ANALYSIS_DEBUGGING)
 	DEBUGPRINT_TS("Marker: ", var = marker)
 	Duplicate data dfrOut:colors
 	Duplicate data dfrOut:data
@@ -286,7 +289,7 @@ threadsafe Function/DF TP_TSAnalysis(dfrInp)
 	refTime = (tpStartPoint - TP_EVAL_POINT_OFFSET) * sampleInt
 	AvgBaselineSS = mean(data, refTime - evalRange, refTime)
 
-#if defined(DEBUGGING_ENABLED)
+#if defined(TP_ANALYSIS_DEBUGGING)
 	// color BASE
 	variable refpt = tpStartPoint - TP_EVAL_POINT_OFFSET
 	colors[refpt - evalRange / sampleInt, refpt] = 50
@@ -302,7 +305,7 @@ threadsafe Function/DF TP_TSAnalysis(dfrInp)
 	refTime = (lengthTPInPoints - tpStartPoint - TP_EVAL_POINT_OFFSET) * sampleInt
 	avgTPSS = mean(data, refTime - evalRange, refTime)
 
-#if defined(DEBUGGING_ENABLED)
+#if defined(TP_ANALYSIS_DEBUGGING)
 	DEBUGPRINT_TS("TPSS range begin (ms): ", var = refTime - evalRange)
 	DEBUGPRINT_TS("TPSS range eng (ms): ", var = refTime)
 	DEBUGPRINT_TS("average TPSS: ", var = avgTPSS)
@@ -319,7 +322,7 @@ threadsafe Function/DF TP_TSAnalysis(dfrInp)
 	WaveStats/Q/M=1 inst1d
 	avgInst = (clampAmp < 0) ? mean(inst1d, pnt2x(inst1d, V_minRowLoc - 1), pnt2x(inst1d, V_minRowLoc + 1)) : mean(inst1d, pnt2x(inst1d, V_maxRowLoc - 1), pnt2x(inst1d, V_maxRowLoc + 1))
 
-#if defined(DEBUGGING_ENABLED)
+#if defined(TP_ANALYSIS_DEBUGGING)
 	refpt = V_minRowLoc + refPoint
 	DEBUGPRINT_TS("refPoint IntSS: ", var = refpt)
 	DEBUGPRINT_TS("average InstSS: ", var = avgInst)
@@ -335,7 +338,7 @@ threadsafe Function/DF TP_TSAnalysis(dfrInp)
 	endif
 	outData[0] = avgBaselineSS
 
-#if defined(DEBUGGING_ENABLED)
+#if defined(TP_ANALYSIS_DEBUGGING)
 	DEBUGPRINT_TS("IntRes: ", var = outData[2])
 	DEBUGPRINT_TS("SSRes: ", var = outData[1])
 #endif

--- a/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
+++ b/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
@@ -1789,7 +1789,7 @@ Function SkipSweepsDuringITI_SD([str])
 	InitDAQSettingsFromString(s, "MD0_RA1_I0_L0_BKG_1_RES_5")
 	AcquireData(s, str)
 
-	CtrlNamedBackGround ExecuteDuringITI, start, period=30, proc=ExecuteDuringITI_IGNORE
+	CtrlNamedBackGround ExecuteDuringITI, start, period=30, proc=SkipToEndDuringITI_IGNORE
 
 	PGC_SetAndActivateControl(str, "Check_DataAcq_Get_Set_ITI", val = 0)
 	PGC_SetAndActivateControl(str, "SetVar_DataAcq_ITI", val = 5)
@@ -1818,7 +1818,7 @@ Function SkipSweepsDuringITI_MD([str])
 	InitDAQSettingsFromString(s, "MD1_RA1_I0_L0_BKG_1_RES_5")
 	AcquireData(s, str)
 
-	CtrlNamedBackGround ExecuteDuringITI, start, period=30, proc=ExecuteDuringITI_IGNORE
+	CtrlNamedBackGround ExecuteDuringITI, start, period=30, proc=SkipToEndDuringITI_IGNORE
 
 	PGC_SetAndActivateControl(str, "Check_DataAcq_Get_Set_ITI", val = 0)
 	PGC_SetAndActivateControl(str, "SetVar_DataAcq_ITI", val = 5)

--- a/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
+++ b/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
@@ -1839,6 +1839,89 @@ Function SkipSweepsDuringITI_MD_REENTRY([str])
 	endfor
 End
 
+Function SkipSweepsBackDuringITIAnaFuncs_IGNORE(device)
+	string device
+
+	WAVE/T wv = root:MIES:WaveBuilder:SavedStimulusSetParameters:DA:WPT_StimulusSetA_DA_0
+
+	wv[][%Set] = ""
+	wv[%$"Analysis function (generic)"][%Set] = "TrackActiveSetCountsAndEvents"
+
+	WAVE/T wv = root:MIES:WaveBuilder:SavedStimulusSetParameters:DA:WPT_StimulusSetB_DA_0
+
+	wv[][%Set] = ""
+	wv[%$"Analysis function (generic)"][%Set] = "TrackActiveSetCountsAndEvents"
+
+	WAVE/T wv = root:MIES:WaveBuilder:SavedStimulusSetParameters:DA:WPT_StimulusSetC_DA_0
+
+	wv[][%Set] = ""
+	wv[%$"Analysis function (generic)"][%Set] = "TrackActiveSetCountsAndEvents"
+
+	WAVE/T wv = root:MIES:WaveBuilder:SavedStimulusSetParameters:DA:WPT_StimulusSetD_DA_0
+
+	wv[][%Set] = ""
+	wv[%$"Analysis function (generic)"][%Set] = "TrackActiveSetCountsAndEvents"
+End
+
+static Function SkipSweepsBackDuringITIStimsets_IGNORE(device)
+	string device
+
+	PGC_SetAndActivateControl(device, GetPanelControl(1, CHANNEL_TYPE_HEADSTAGE, CHANNEL_CONTROL_CHECK), val = 0)
+	PGC_SetAndActivateControl(device, GetPanelControl(0, CHANNEL_TYPE_DAC, CHANNEL_CONTROL_WAVE), str = "StimulusSetA_*")
+	PGC_SetAndActivateControl(device, GetPanelControl(0, CHANNEL_TYPE_DAC, CHANNEL_CONTROL_INDEX_END), str = "StimulusSetD_*")
+End
+
+// UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
+Function SkipSweepsBackDuringITI([str])
+	string str
+
+	STRUCT DAQSettings s
+	InitDAQSettingsFromString(s, "MD1_RA1_I0_L0_BKG_1_RES_0")
+	AcquireData(s, str, postInitializeFunc = SkipSweepsBackDuringITIAnaFuncs_IGNORE, preAcquireFunc = SkipSweepsBackDuringITIStimsets_IGNORE)
+
+	CtrlNamedBackGround ExecuteDuringITI, start, period=30, proc=SkipSweepBackDuringITI_IGNORE
+
+	PGC_SetAndActivateControl(str, "Check_DataAcq_Get_Set_ITI", val = 0)
+	PGC_SetAndActivateControl(str, "SetVar_DataAcq_ITI", val = 5)
+End
+
+Function SkipSweepsBackDuringITI_REENTRY([str])
+	string str
+
+	variable numSweeps = 4
+	variable sweepNo   = 0
+	variable headstage = 0
+
+	CHECK_EQUAL_VAR(GetSetVariable(str, "SetVar_Sweep"), numSweeps)
+
+	WAVE/T textualValues   = GetLBTextualValues(str)
+	WAVE   numericalValues = GetLBNumericalValues(str)
+
+	WAVE/T/Z foundStimSets = GetLastSettingTextEachRAC(numericalValues, textualValues, sweepNo, STIM_WAVE_NAME_KEY, headstage, DATA_ACQUISITION_MODE)
+	REQUIRE_WAVE(foundStimSets, TEXT_WAVE)
+	CHECK_EQUAL_TEXTWAVES(foundStimSets, {"StimulusSetA_DA_0", "StimulusSetA_DA_0", "StimulusSetA_DA_0", "StimulusSetA_DA_0"})
+
+	WAVE/Z sweepCounts = GetLastSettingEachRAC(numericalValues, sweepNo, "Set Sweep Count", headstage, DATA_ACQUISITION_MODE)
+	REQUIRE_WAVE(sweepCounts, NUMERIC_WAVE)
+	CHECK_EQUAL_WAVES(sweepCounts, {0, 0, 1, 2}, mode = WAVE_DATA)
+
+	// XXX_SET_EVENT counts are subject to change with sweep skipping
+	WAVE anaFuncTracker = TrackAnalysisFunctionCalls()
+	CHECK_EQUAL_VAR(anaFuncTracker[PRE_DAQ_EVENT], 1)
+	CHECK_EQUAL_VAR(anaFuncTracker[PRE_SET_EVENT], 1)
+	CHECK_EQUAL_VAR(anaFuncTracker[PRE_SWEEP_EVENT], 4)
+	CHECK(anaFuncTracker[MID_SWEEP_EVENT] >= 1)
+	CHECK_EQUAL_VAR(anaFuncTracker[POST_SWEEP_EVENT], 4)
+	CHECK_EQUAL_VAR(anaFuncTracker[POST_SET_EVENT], 1)
+	CHECK_EQUAL_VAR(anaFuncTracker[POST_DAQ_EVENT], 1)
+	CHECK_EQUAL_VAR(anaFuncTracker[GENERIC_EVENT], 0)
+
+	WAVE anaFuncActiveSetCount = GetTrackActiveSetCount()
+
+	WaveTransform/O zapNans, anaFuncActiveSetCount
+	CHECK_EQUAL_WAVES(anaFuncActiveSetCount, {3, 3, 2, 1})
+End
+
 static Function CheckLastLBNEntryFromTP_IGNORE(device)
 	string device
 

--- a/Packages/Testing-MIES/UTF_HardwareMain.ipf
+++ b/Packages/Testing-MIES/UTF_HardwareMain.ipf
@@ -393,6 +393,23 @@ Function SkipToEndDuringITI_IGNORE(s)
 	return 0
 End
 
+Function SkipSweepBackDuringITI_IGNORE(s)
+	STRUCT WMBackgroundStruct &s
+
+	SVAR devices = $GetDevicePanelTitleList()
+	string device = StringFromList(0, devices)
+
+	NVAR runMode = $GetTestpulseRunMode(device)
+
+	if(runMode & TEST_PULSE_DURING_RA_MOD)
+		CHECK_EQUAL_VAR(AFH_GetLastSweepAcquired(device), 0)
+		RA_SkipSweeps(device, -1)
+		return 1
+	endif
+
+	return 0
+End
+
 Function StopAcq_IGNORE(s)
 	STRUCT WMBackgroundStruct &s
 

--- a/Packages/Testing-MIES/UTF_HardwareMain.ipf
+++ b/Packages/Testing-MIES/UTF_HardwareMain.ipf
@@ -377,7 +377,7 @@ Function StartTPDuringITI_IGNORE(s)
 	return 0
 End
 
-Function ExecuteDuringITI_IGNORE(s)
+Function SkipToEndDuringITI_IGNORE(s)
 	STRUCT WMBackgroundStruct &s
 
 	SVAR devices = $GetDevicePanelTitleList()

--- a/Packages/Testing-MIES/UserAnalysisFunctions.ipf
+++ b/Packages/Testing-MIES/UserAnalysisFunctions.ipf
@@ -632,6 +632,21 @@ Function SkipSweepsAdvanced(panelTitle, s)
 	endif
 End
 
+Function TrackActiveSetCountsAndEvents(panelTitle, s)
+	string panelTitle
+	STRUCT AnalysisFunction_V3& s
+
+	WAVE anaFuncTracker = TrackAnalysisFunctionCalls()
+
+	CHECK(s.eventType >= 0 && s.eventType < DimSize(anaFuncTracker, ROWS))
+	anaFuncTracker[s.eventType][s.headstage] += 1
+
+	WAVE anaFuncActiveSetCount = GetTrackActiveSetCount()
+
+	NVAR activeSetCount = $GetActiveSetCount(panelTitle)
+	anaFuncActiveSetCount[s.sweepNo][s.headstage] = activeSetCount
+End
+
 Function WriteIntoLBNOnPreDAQ(panelTitle, s)
 	string panelTitle
 	STRUCT AnalysisFunction_V3& s


### PR DESCRIPTION
- [x] Check tests. The new limiting probably broke the test. We can also wait to the second IT for skipping back.

The current code did not expect that you call first without
limitToSetBorder=0 and then with limitToSetBorder=1.

It was also not working for -inf and did not adjust the active set count
correctly when limitToSetBorder=0.

These bugs are now fixed. The solution is to first calculate a skipCount
which is limited to the set borders if requested. And when a new count
is calculated using RA_SkipSweepCalc and the so calculated count offset
is used for adjusting count and the activeSetCount.