### PR TITLE
Simplified/SpeedUp DataFolderExistsDFR and Tests

### DIFF
--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -553,26 +553,11 @@ End
 
 /// @brief Checks if the datafolder referenced by dfr exists.
 ///
-/// Unlike DataFolderExists() a dfref pointing to an empty ("") dataFolder is considered non-existing here.
+/// @param[in] dfr data folder to test
 /// @returns one if dfr is valid and references an existing or free datafolder, zero otherwise
-/// Taken from http://www.igorexchange.com/node/2055
-threadsafe Function DataFolderExistsDFR(dfr)
-	dfref dfr
+threadsafe Function DataFolderExistsDFR(DFREF dfr)
 
-	string dataFolder
-
-	switch(DataFolderRefStatus(dfr))
-		case 0: // invalid ref, does not exist
-			return 0
-		case 1: // might be valid
-			dataFolder = GetDataFolder(1,dfr)
-			return cmpstr(dataFolder,"") != 0 && DataFolderExists(dataFolder)
-		case 3: // free data folders always exist
-			return 1
-		default:
-			ASSERT_TS(0, "impossible case")
-			return 0
-	endswitch
+	return DataFolderRefStatus(dfr) != 0
 End
 
 /// @brief Check if the passed datafolder reference is a global/permanent datafolder

--- a/Packages/Testing-MIES/UTF_Utils.ipf
+++ b/Packages/Testing-MIES/UTF_Utils.ipf
@@ -4238,3 +4238,134 @@ Function IC_WorksSpecialValues([val])
 End
 
 /// @}
+
+/// DataFolderExistsDFR
+/// @{
+
+static structure dfrTest
+	DFREF structDFR
+endstructure
+
+Function DFED_WorksRegular1()
+
+	STRUCT dfrTest s
+	Make/FREE/DF/N=1 wDfr
+
+	NewDataFolder test
+	DFREF dfr = test
+	s.structDFR = test
+	wDfr[0] = test
+
+	CHECK(DataFolderExistsDFR(dfr))
+	CHECK(DataFolderExistsDFR(s.structDFR))
+	CHECK(DataFolderExistsDFR(wDfr[0]))
+End
+
+Function DFED_WorksRegular2()
+
+	STRUCT dfrTest s
+	Make/FREE/DF/N=1 wDfr
+
+	NewDataFolder test
+	DFREF dfr = test
+	s.structDFR = test
+	wDfr[0] = test
+
+	NewDataFolder test1
+	MoveDataFolder test, test1
+
+	CHECK(DataFolderExistsDFR(dfr))
+	CHECK(DataFolderExistsDFR(s.structDFR))
+	CHECK(DataFolderExistsDFR(wDfr[0]))
+End
+
+Function DFED_WorksRegular3()
+
+	STRUCT dfrTest s
+	Make/FREE/DF/N=1 wDfr
+
+	DFREF dfr = NewFreeDataFolder()
+	s.structDFR = dfr
+	wDfr[0] = dfr
+
+	NewDataFolder test
+	MoveDataFolder dfr, test
+
+	CHECK(DataFolderExistsDFR(dfr))
+	CHECK(DataFolderExistsDFR(s.structDFR))
+	CHECK(DataFolderExistsDFR(wDfr[0]))
+End
+
+Function DFED_WorksRegular4()
+
+	STRUCT dfrTest s
+	Make/FREE/DF/N=1 wDfr
+
+	DFREF dfr = NewFreeDataFolder()
+	s.structDFR = dfr
+	wDfr[0] = dfr
+
+	RenameDataFolder dfr, test1234
+
+	CHECK(DataFolderExistsDFR(dfr))
+	CHECK(DataFolderExistsDFR(s.structDFR))
+	CHECK(DataFolderExistsDFR(wDfr[0]))
+End
+
+Function DFED_FailsRegular1()
+
+	STRUCT dfrTest s
+	Make/FREE/DF/N=1 wDfr
+
+	DFREF dfr = $""
+	s.structDFR = $""
+	wDfr[0] = $""
+
+	CHECK(!DataFolderExistsDFR(dfr))
+	CHECK(!DataFolderExistsDFR(s.structDFR))
+	CHECK(!DataFolderExistsDFR(wDfr[0]))
+End
+
+Function DFED_FailsRegular2()
+
+	STRUCT dfrTest s
+	Make/FREE/DF/N=1 wDfr
+
+	NewDataFolder test
+
+	DFREF dfr = test
+	s.structDFR = test
+	wDfr[0] = test
+
+	KillDataFolder test
+
+	CHECK(!DataFolderExistsDFR(dfr))
+	CHECK(!DataFolderExistsDFR(s.structDFR))
+	CHECK(!DataFolderExistsDFR(wDfr[0]))
+End
+
+Function DFED_FailsRegular3()
+
+	DFREF dfr = NewFreeDataFolder()
+	Make/DF/N=1 dfr:wDfr/Wave=wDfr
+	wDfr[0] = dfr
+	CHECK(DataFolderExistsDFR(wDfr[0]))
+
+	dfr = NewFreeDataFolder()
+	CHECK(DataFolderExistsDFR(wDfr[0]))
+
+	dfr = GetWavesDataFolderDFR(wDfr)
+	CHECK(DataFolderExistsDFR(dfr))
+
+
+	wDfr[0] = root:
+
+	dfr = GetWavesDataFolderDFR(wDfr)
+	CHECK(DataFolderExistsDFR(dfr))
+
+	dfr = NewFreeDataFolder()
+	dfr = GetWavesDataFolderDFR(wDfr)
+	CHECK(!DataFolderExistsDFR(dfr))
+End
+
+/// @}


### PR DESCRIPTION
The forward and backward resolving by string of the data folder for case 1 was very slow.

We could not reproduce the case in IP7+ where this specific case can cause problems and require this additional check.
We presume it has been fixed in IP.