### PR TITLE
BSP_ClosePanelHook: Avoid RTE on killVote event

### DIFF
--- a/Packages/MIES/MIES_BrowserSettingsPanel.ipf
+++ b/Packages/MIES/MIES_BrowserSettingsPanel.ipf
@@ -564,16 +564,10 @@ Function BSP_ClosePanelHook(s)
 	STRUCT WMWinHookStruct &s
 
 	string mainPanel
-	string panels
 
 	switch(s.eventCode)
 		case 17: // killVote
 			mainPanel = GetMainWindow(s.winName)
-			panels = AddListItem(BSP_GetPanel(mainPanel), panels)
-			panels = AddListItem(BSP_GetSweepControlsPanel(mainPanel), panels)
-
-			ASSERT(FindListItem(s.winName, panels) >= 0, "this hook is only available for specific BSP panel.")
-
 			SetWindow $s.winName hide=1
 
 			BSP_MainPanelButtonToggle(mainPanel, 1)


### PR DESCRIPTION
In 6140d450 (BSP_MainPanelButtonToggle: Code cleanup, 2020-08-25) the
initialization of panels to "" was erroneously removed.

Instead of fixing it directly, we just the whole code part using it.
It's only reason is to avoid having it being attached to the wrong
panel, and we ensure that already.