### PR TITLE
Pulse Averaging: Pulse starting times are now read from the lab notebook (only this)

### DIFF
--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -1266,6 +1266,17 @@ StrConstant WORKLOADCLASS_TP = "TestPulse"
 /// @}
 
 
+/// @name Column numbers of epoch information
+/// @anchor epochColumnNumber
+///
+/// @{
+
+Constant EPOCH_COL_STARTTIME = 0
+Constant EPOCH_COL_ENDTIME = 1
+Constant EPOCH_COL_NAME = 2
+Constant EPOCH_COL_TREELEVEL = 3
+
+/// @}
 Constant PA_SETTINGS_STRUCT_VERSION = 5
 
 StrConstant NOTE_NEEDS_UPDATE = "NeedsUpdate"

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -757,6 +757,7 @@ static Constant EPOCHS_WAVE_VERSION = 1
 /// Rows:
 /// - epochs
 ///
+/// Column numbers must use global column number constants @sa epochColumnNumber
 /// Columns:
 ///   0 Start time in sec
 ///   1 End time in sec
@@ -781,10 +782,10 @@ Function/Wave GetEpochsWave(panelTitle)
 	  Make/T/N=(MINIMUM_WAVE_SIZE, 4, NUM_DA_TTL_CHANNELS) dfr:EpochsWave/Wave=wv
 	endif
 
-	SetDimLabel COLS, 0, StartTime, wv
-	SetDimLabel COLS, 1, EndTime, wv
-	SetDimLabel COLS, 2, Name, wv
-	SetDimLabel COLS, 3, TreeLevel, wv
+	SetDimLabel COLS, EPOCH_COL_STARTTIME, StartTime, wv
+	SetDimLabel COLS, EPOCH_COL_ENDTIME, EndTime, wv
+	SetDimLabel COLS, EPOCH_COL_NAME, Name, wv
+	SetDimLabel COLS, EPOCH_COL_TREELEVEL, TreeLevel, wv
 
 	SetWaveVersion(wv, EPOCHS_WAVE_VERSION)
 


### PR DESCRIPTION
- Pulse starting times are in PA_GetPulseStartTimes extracted from the epoch
  information stored in the lab notebook
- as fallback the pulse starting times are determined the old direct way
  through findlevels.