### PR TITLE
PA_DrawScaleBarsHelper: Draw x scale bar length if different

### DIFF
--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -1586,7 +1586,7 @@ static Function CONF_ControlToJSON(wName, ctrlName, saveMask, jsonID, excCtrlTyp
 	string excCtrlTypes, excUserKeys
 
 	variable ctrlType, pos, i, numUdataKeys, setVarType, arrayIndex, oldSize, preferCode, arrayElemType
-	string wList, ctrlPath, controlPath, niceName, jsonPath, udataPath, udataKeys, uDataKey, uData, s, arrayName, arrayElemPath
+	string wList, ctrlPath, controlPath, niceName, jsonPath, udataPath, uDataKey, uData, s, arrayName, arrayElemPath
 
 
 	ASSERT((saveMask & (EXPCONFIG_SAVE_POPUPMENU_AS_STRING_ONLY | EXPCONFIG_SAVE_POPUPMENU_AS_INDEX_ONLY)) != (EXPCONFIG_SAVE_POPUPMENU_AS_STRING_ONLY | EXPCONFIG_SAVE_POPUPMENU_AS_INDEX_ONLY), "Invalid popup menu save selection. String only and Index only can not be set at the same time.")
@@ -1710,26 +1710,24 @@ static Function CONF_ControlToJSON(wName, ctrlName, saveMask, jsonID, excCtrlTyp
 			if(!IsEmpty(S_Userdata) && str2num(StringFromList(pos, EXPCONFIG_GUI_SUSERDATA)))
 				JSON_AddString(jsonID, udataPath, S_Userdata)
 			endif
-			udataKeys = GetUserdataKeys(S_recreation)
-			if(!IsEmpty(udataKeys))
-				numUdataKeys = ItemsInList(udataKeys)
-				for(i = 0; i < numUdataKeys; i +=1)
-					uDataKey = StringFromList(i, udataKeys)
-					if(WhichListItem(uDataKey, excUserKeys) >= 0)
-						continue
-					endif
-					uData = GetUserData(wName, ctrlName, uDataKey)
-					try
-						ClearRTError()
-						s = ConvertTextEncoding(uData, TextEncodingCode("UTF-8"), TextEncodingCode("UTF-8"), 1, 0); AbortOnRTE
-					catch
-						ClearRTError()
-						uData = Base64Encode(udata)
-						JSON_AddString(jsonID, udataPath + EXPCONFIG_FIELD_BASE64PREFIX + uDataKey, "1")
-					endtry
-					JSON_AddString(jsonID, udataPath + uDataKey, uData)
-				endfor
-			endif
+			WAVE/T/Z udataKeys = GetUserDataKeys(S_recreation)
+			numUdataKeys = WaveExists(udataKeys) ? DimSize(udataKeys, ROWS) : 0
+			for(i = 0; i < numUdataKeys; i +=1)
+				uDataKey = udataKeys[i]
+				if(WhichListItem(uDataKey, excUserKeys) >= 0)
+					continue
+				endif
+				uData = GetUserData(wName, ctrlName, uDataKey)
+				try
+					ClearRTError()
+					s = ConvertTextEncoding(uData, TextEncodingCode("UTF-8"), TextEncodingCode("UTF-8"), 1, 0); AbortOnRTE
+				catch
+					ClearRTError()
+					uData = Base64Encode(udata)
+					JSON_AddString(jsonID, udataPath + EXPCONFIG_FIELD_BASE64PREFIX + uDataKey, "1")
+				endtry
+				JSON_AddString(jsonID, udataPath + uDataKey, uData)
+			endfor
 		endif
 	elseif(saveMask & EXPCONFIG_SAVE_VALUE)
 		arrayIndex = str2num(GetUserData(wName, ctrlName, EXPCONFIG_UDATA_CTRLARRAYINDEX))

--- a/Packages/MIES/MIES_DataBrowser_Macro.ipf
+++ b/Packages/MIES/MIES_DataBrowser_Macro.ipf
@@ -1014,7 +1014,7 @@ Window DataBrowser() : Graph
 	SetVariable setvar_pulseAver_vert_scale_bar,userdata(ResizeControlsInfo)= A"!!,DC!!#@e!!#@r!!#<Hz!!#`-A7TLfzzzzzzzzzzzzzz!!#r+D.OhkBk2=!z"
 	SetVariable setvar_pulseAver_vert_scale_bar,userdata(ResizeControlsInfo) += A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable setvar_pulseAver_vert_scale_bar,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable setvar_pulseAver_vert_scale_bar,value= _NUM:1
+	SetVariable setvar_pulseAver_vert_scale_bar,value= _NUM:0.5
 	CheckBox check_pulseAver_ShowImage,pos={52.00,205.00},size={111.00,15.00},disable=1,proc=PA_CheckProc_Common,title="Enable image plot"
 	CheckBox check_pulseAver_ShowImage,help={"Enable the image plot which is *much* faster than the trace plot"}
 	CheckBox check_pulseAver_ShowImage,userdata(tabnum)=  "4"

--- a/Packages/MIES/MIES_GuiUtilities.ipf
+++ b/Packages/MIES/MIES_GuiUtilities.ipf
@@ -1735,33 +1735,38 @@ End
 /// @brief Retrieves named userdata keys from a recreation macro string
 ///
 /// @param recMacro recreation macro string
-/// @returns List of userdata keys
-Function/S GetUserdataKeys(recMacro)
-	string recMacro
+///
+/// @returns Textwave with all unqiue entries or `$""` if nothing could be found.
+Function/WAVE GetUserdataKeys(string recMacro)
 
-	string userKeys = ""
-	string key
-	variable pos1, pos2
+	variable pos1, pos2, count
 	variable prefixLength = strlen(USERDATA_PREFIX)
+
+	Make/T/FREE userKeys
 
 	do
 		pos1 = strsearch(recMacro, USERDATA_PREFIX, pos1)
+
 		if(pos1 == -1)
 			break
 		endif
+
 		pos2 = strsearch(recMacro, USERDATA_SUFFIX, pos1)
-		key = recMacro[pos1 + prefixLength, pos2 - 1]
-		userKeys = AddListItem(key, userKeys, ";", Inf)
+		ASSERT(pos2 != -1, "Invalid recreation macro")
+
+		EnsureLargeEnoughWave(userKeys, minimumSize = count)
+		userKeys[count++] = recMacro[pos1 + prefixLength, pos2 - 1]
+
 		pos1 = pos2
 	while(1)
 
-	if(ItemsInList(userKeys) > 1)
-		WAVE/T w = ListToTextWave(userKeys, ";")
-		FindDuplicates/FREE /RT=wClean w
-		wfprintf userKeys, "%s;", wClean
+	if(count == 0)
+		return $""
 	endif
 
-	return userKeys
+	Redimension/N=(count) userKeys
+
+	return GetUniqueEntries(userKeys)
 End
 
 /// @brief Converts an Igor control type number to control name

--- a/Packages/MIES/MIES_OverlaySweeps.ipf
+++ b/Packages/MIES/MIES_OverlaySweeps.ipf
@@ -187,7 +187,7 @@ Function OVS_UpdatePanel(string win, [variable fullUpdate])
 
 	// we select the first sweep when doing a fullUpdate and nothing selected
 	if(OVS_IsActive(win) && fullUpdate)
-		FindValue/I=(LISTBOX_CHECKBOX_SELECTED)/RMD=[][0] listBoxSelWave
+		FindValue/I=(LISTBOX_CHECKBOX | LISTBOX_CHECKBOX_SELECTED)/RMD=[][0] listBoxSelWave
 		if(V_Value == -1)
 			listBoxSelWave[0][%Sweep] = SetBit(listBoxSelWave[0][%Sweep], LISTBOX_CHECKBOX_SELECTED)
 		endif

--- a/Packages/MIES/MIES_PulseAveraging.ipf
+++ b/Packages/MIES/MIES_PulseAveraging.ipf
@@ -2198,6 +2198,9 @@ static Function PA_DrawScaleBarsHelper(string win, variable axisMode, variable d
 	SetDrawEnv/W=$graph push
 	SetDrawEnv/W=$graph linefgc=(0,0,0), textrgb=(0,0,0), fsize=10, linethick=1.5
 
+	sprintf msg, "win %s, horizAxis %s [%g, %g], vertAxis %s [%g, %g]\r", win, horizAxis, horiz_min, horiz_max, vertAxis, vert_min, vert_max
+	DEBUGPRINT(msg)
+
 	if(drawYScaleBar)
 		// only for non-diagonal elements
 
@@ -2223,7 +2226,7 @@ static Function PA_DrawScaleBarsHelper(string win, variable axisMode, variable d
 
 		yBarTop = yBarBottom + ylength
 
-		sprintf msg, "Y: (R%d, C%d)\r", activeRegionCount, activeChanCount
+		sprintf msg, "Y: (R%d, C%d), xBarBottom %g, xBarTop %g\r", activeRegionCount, activeChanCount, xBarBottom, xBarTop
 		DEBUGPRINT(msg)
 
 		drawLength = (activeChanCount == numActive) && (activeRegionCount == 1)

--- a/Packages/MIES/MIES_PulseAveraging.ipf
+++ b/Packages/MIES/MIES_PulseAveraging.ipf
@@ -182,7 +182,6 @@ static Function/S PA_GetGraph(string mainWin, STRUCT PulseAverageSettings &pa, v
 		SetWindow $win, userdata($MIES_BSP_PA_MAINPANEL) = mainWin
 		PA_GetTraceCountFromGraphData(win, clear = 1)
 		if(displayMode == PA_DISPLAYMODE_IMAGES && (!pa.multipleGraphs || activeRegionCount == numRegions))
-			SetWindow $win hook(marginResizeHook)=PA_ImageWindowHook
 			NewPanel/HOST=#/EXT=0/W=(0, 0, PA_COLORSCALE_PANEL_WIDTH, bottom - top) as ""
 			Display/FG=(FL,FT,FR,FB)/HOST=#
 		endif

--- a/Packages/MIES/MIES_PulseAveraging.ipf
+++ b/Packages/MIES/MIES_PulseAveraging.ipf
@@ -2155,7 +2155,7 @@ End
 
 static Function PA_DrawScaleBarsHelper(string win, variable axisMode, variable displayMode, WAVE/WAVE setWaves2, string vertAxis, string horizAxis, variable ylength, string xUnit, string yUnit, variable activeChanCount, variable activeRegionCount, variable numActive)
 
-	string graph, msg, str, axList
+	string graph, msg, str
 	variable vertAxis_y, vertAxis_x, xLength
 	variable vert_min, vert_max, horiz_min, horiz_max, drawLength
 	variable xBarBottom, xBarTop, yBarBottom, yBarTop, labelOffset
@@ -2232,10 +2232,6 @@ static Function PA_DrawScaleBarsHelper(string win, variable axisMode, variable d
 	endif
 
 	if(drawXScaleBar)
-
-		axList = AxisList(graph)
-		ASSERT(WhichListItem(horizAxis, axList) != -1, "Missing horizontal axis")
-		ASSERT(WhichListItem(vertAxis, axList) != -1, "Missing vertical axis")
 
 		SetDrawEnv/W=$graph xcoord=$horizAxis, ycoord=$vertAxis
 		SetDrawEnv/W=$graph save

--- a/Packages/MIES/MIES_PulseAveraging.ipf
+++ b/Packages/MIES/MIES_PulseAveraging.ipf
@@ -2212,8 +2212,15 @@ static Function PA_DrawScaleBarsHelper(string win, variable axisMode, variable d
 
 		xBarBottom = GetNumFromModifyStr(AxisInfo(graph, horizAxis), "axisEnab", "{", 0) - PA_X_AXIS_OFFSET
 		xBarTop    = xBarBottom
-		yBarBottom = 0
-		yBarTop    = ylength
+
+		if(sign(vert_min) != sign(vert_max))
+			yBarBottom = 0
+		else
+			// zero is not in range, use vert_min
+			yBarBottom = vert_min
+		endif
+
+		yBarTop = yBarBottom + ylength
 
 		sprintf msg, "Y: (R%d, C%d)\r", activeRegionCount, activeChanCount
 		DEBUGPRINT(msg)

--- a/Packages/MIES/MIES_PulseAveraging.ipf
+++ b/Packages/MIES/MIES_PulseAveraging.ipf
@@ -33,6 +33,8 @@ static StrConstant PA_DECONVOLUTION_WAVE_PREFIX = "deconv_"
 
 static StrConstant PA_SETTINGS = "PulseAverageSettings"
 
+static StrConstant PA_USER_DATA_X_START_RELATIVE_PREFIX = "XAxisStartPlotRelative_"
+
 /// Only present for diagonal pulses
 static StrConstant PA_NOTE_KEY_PULSE_FAILED = "PulseHasFailed"
 
@@ -1698,8 +1700,8 @@ static Function/S PA_ShowPulses(string win, STRUCT PulseAverageSettings &pa, STR
 		AccelerateModLineSizeTraces(graph, deconPlotTraces, deconPlotCount, PA_DECONVOLUTION_PLOT_LSIZE)
 	endif
 
-	PA_DrawScaleBars(win, pa, pasi, PA_DISPLAYMODE_TRACES, PA_USE_WAVE_SCALES)
 	PA_LayoutGraphs(win, pa, pasi, PA_DISPLAYMODE_TRACES)
+	PA_DrawScaleBars(win, pa, pasi, PA_DISPLAYMODE_TRACES, PA_USE_WAVE_SCALES)
 	PA_DrawXZeroLines(win, pa, pasi, PA_DISPLAYMODE_TRACES)
 
 	return usedGraphs
@@ -2209,7 +2211,7 @@ static Function PA_DrawScaleBarsHelper(string win, variable axisMode, variable d
 		sprintf str, "scalebar_Y_R%d_C%d", activeRegionCount, activeChanCount
 		SetDrawEnv/W=$graph gstart, gname=$str
 
-		xBarBottom = GetNumFromModifyStr(AxisInfo(graph, horizAxis), "axisEnab", "{", 0) - PA_X_AXIS_OFFSET
+		xBarBottom = str2num(GetUserData(win, "", PA_USER_DATA_X_START_RELATIVE_PREFIX + horizAxis))
 		xBarTop    = xBarBottom
 
 		if(sign(vert_min) != sign(vert_max))
@@ -2595,7 +2597,7 @@ End
 static Function PA_LayoutGraphs(string win, STRUCT PulseAverageSettings &pa, STRUCT PulseAverageSetIndices &pasi, variable displayMode)
 
 	variable i, j, numActive, numEntries
-	variable channelNumber, headstage, red, green, blue, region, xStart
+	variable channelNumber, headstage, region, xStart, xAxisPlotRelative
 	string graph, str, horizAxis, vertAxis, allAxes, vertAxes, horizAxes
 	STRUCT RGBColor s
 
@@ -2640,7 +2642,9 @@ static Function PA_LayoutGraphs(string win, STRUCT PulseAverageSettings &pa, STR
 				horizAxis = axesNames[1]
 
 				xStart = GetNumFromModifyStr(AxisInfo(graph, horizAxis), "axisEnab", "{", 0)
-				ModifyGraph/W=$graph/Z freePos($vertAxis)={xStart - PA_X_AXIS_OFFSET,kwFraction}
+				xAxisPlotRelative = xStart - PA_X_AXIS_OFFSET
+				SetWindow $graph, userData($(PA_USER_DATA_X_START_RELATIVE_PREFIX + horizAxis)) = num2str(xAxisPlotRelative)
+				ModifyGraph/W=$graph/Z freePos($vertAxis)={xAxisPlotRelative, kwFraction}
 			endfor
 
 			ModifyGraph/W=$graph/Z freePos($horizAxis)=0

--- a/Packages/Testing-MIES/UTF_Utils.ipf
+++ b/Packages/Testing-MIES/UTF_Utils.ipf
@@ -4473,3 +4473,53 @@ Function ZWI_Works3()
 End
 
 /// @}
+
+/// GetUserDataKeys
+/// @{
+
+Function GUD_ReturnsNullWaveIfNothingFound()
+	string recMacro, win
+
+	Display
+	win = s_name
+
+	recMacro = WinRecreation(win, 0)
+	WAVE/T/Z userDataKeys = GetUserdataKeys(recMacro)
+
+	CHECK_WAVE(userDataKeys, NULL_WAVE)
+End
+
+Function GUD_ReturnsFoundEntries()
+	string recMacro, win
+
+	Display
+	win = s_name
+	SetWindow $win, userdata(abcd)="123"
+	SetWindow $win, userData(efgh)="456"
+
+	recMacro = WinRecreation(win, 0)
+	WAVE/T userDataKeys = GetUserdataKeys(recMacro)
+
+	CHECK_EQUAL_TEXTWAVES(userDataKeys, {"abcd", "efgh"})
+End
+
+Function GUD_ReturnsFoundEntriesWithoutDuplicates()
+	string recMacro, win
+
+	Display
+	win = s_name
+
+	// create lines a la
+	//
+	//	SetWindow kwTopWin,userdata(abcd)=  "123456                                                                                              "
+	//	SetWindow kwTopWin,userdata(abcd) +=  "                                                                                                    "
+	SetWindow $win, userdata(abcd)="123"
+	SetWindow $win, userData(abcd)+=PadString("456", 1e3, 0x20)
+
+	recMacro = WinRecreation(win, 0)
+	WAVE/T userDataKeys = GetUserdataKeys(recMacro)
+
+	CHECK_EQUAL_TEXTWAVES(userDataKeys, {"abcd"})
+End
+
+/// @}


### PR DESCRIPTION
We have one x axis  and scale bar for each region (column). In order to
not clutter the image we only add one x scale bar the bottom right set.

We allow users zoomming in and out into each x axis, and then
dynamically resize the x scale bar to a fitting length.

This makes it really hard to know the exact physical length when
zooming.

We solve that by remembering the initial x bar length and always draw
the x bar length if it is different from the inital value.

Close #696.
Close #698.