### PR TITLE
Bugfix/ovs sweep selection

### DIFF
--- a/Packages/MIES/MIES_OverlaySweeps.ipf
+++ b/Packages/MIES/MIES_OverlaySweeps.ipf
@@ -314,9 +314,9 @@ Function OVS_ChangeSweepSelectionState(win, newState, [sweepNo, index, sweeps, i
 		FindValue/RMD=[][0]/TEXT=num2str(sweepNo)/TXOP=4 listboxWave
 		ASSERT(V_Value >= 0, "Could not find sweep")
 		Make/FREE/N=(1, 2) indices = {{V_Value}, {0}}
-		index = V_Value
 	elseif(!ParamIsDefault(index))
 		Make/FREE/N=(1, 2) indices = {{index}, {0}}
+		ASSERT(index >= 0 && index < DimSize(listboxWave, ROWS), "Could not find index")
 	elseif(!ParamIsDefault(sweeps))
 		if(WaveExists(sweeps))
 			numEntries = DimSize(sweeps, ROWS)
@@ -332,10 +332,6 @@ Function OVS_ChangeSweepSelectionState(win, newState, [sweepNo, index, sweeps, i
 		endif
 	else
 		ASSERT(0, "Requires one of index or sweepNo")
-	endif
-
-	if(index < 0 || index >= DimSize(listBoxWave, ROWS) || !IsFinite(index))
-		return NaN
 	endif
 
 	WAVE updateHandle = OVS_BeginIncrementalUpdate(win)

--- a/Packages/MIES/MIES_OverlaySweeps.ipf
+++ b/Packages/MIES/MIES_OverlaySweeps.ipf
@@ -313,10 +313,10 @@ Function OVS_ChangeSweepSelectionState(win, newState, [sweepNo, index, sweeps, i
 	if(!ParamIsDefault(sweepNo))
 		FindValue/RMD=[][0]/TEXT=num2str(sweepNo)/TXOP=4 listboxWave
 		ASSERT(V_Value >= 0, "Could not find sweep")
-		Make/FREE indices = {V_Value, 0}
+		Make/FREE/N=(1, 2) indices = {{V_Value}, {0}}
 		index = V_Value
 	elseif(!ParamIsDefault(index))
-		Make/FREE indices = {index, 0}
+		Make/FREE/N=(1, 2) indices = {{index}, {0}}
 	elseif(!ParamIsDefault(sweeps))
 		if(WaveExists(sweeps))
 			numEntries = DimSize(sweeps, ROWS)


### PR DESCRIPTION
bug: 1st sweep is selected with `next sweep` regardless of `setvar_SweepControl_SweepNo` no.