### PR TITLE
Databrowser: Fix overlaying sweeps doing an incremental update for ex…

### DIFF
--- a/Packages/MIES/MIES_BrowserSettingsPanel.ipf
+++ b/Packages/MIES/MIES_BrowserSettingsPanel.ipf
@@ -1136,29 +1136,15 @@ End
 Function BSP_CheckProc_OverlaySweeps(cba) : CheckBoxControl
 	STRUCT WMCheckBoxAction &cba
 
-	string graph, bsPanel, scPanel
-	variable index, sweepNo
+	string graph, bsPanel
 
 	switch(cba.eventCode)
 		case 2: // mouse up
 			graph   = GetMainWindow(cba.win)
 			bsPanel = BSP_GetPanel(graph)
-			scPanel = BSP_GetSweepControlsPanel(graph)
 
 			BSP_SetOVSControlStatus(bsPanel)
 			OVS_UpdatePanel(graph, fullUpdate = 1)
-
-			WAVE/Z sweeps = GetPlainSweepList(graph)
-
-			if(OVS_IsActive(graph) && WaveExists(sweeps))
-				if(BSP_IsDataBrowser(graph))
-					sweepNo = GetSetVariable(scPanel, "setvar_SweepControl_SweepNo")
-					OVS_ChangeSweepSelectionState(bsPanel, CHECKBOX_SELECTED, sweepNo=sweepNo)
-				else
-					index = GetPopupMenuIndex(scPanel, "popup_SweepControl_Selector")
-					OVS_ChangeSweepSelectionState(bsPanel, CHECKBOX_SELECTED, index=index)
-				endif
-			endif
 
 			break
 	endswitch

--- a/Packages/MIES/MIES_OverlaySweeps.ipf
+++ b/Packages/MIES/MIES_OverlaySweeps.ipf
@@ -113,10 +113,12 @@ End
 
 /// @brief Update the overlay sweep waves
 ///
+/// @param win        databrowser panel or graph
+/// @param fullUpdate [optional, defaults to false] Performs a full update instead
+///                   of an incremental one. Selects the first sweep if nothing is selected as well.
+///
 /// Must be called after the sweeps changed.
-Function OVS_UpdatePanel(win, [fullUpdate])
-	string win
-	variable fullUpdate
+Function OVS_UpdatePanel(string win, [variable fullUpdate])
 
 	variable i, numEntries, sweepNo, lastEntry, newCycleHasStartedRAC, newCycleHasStartedSCI
 	string extPanel
@@ -177,6 +179,14 @@ Function OVS_UpdatePanel(win, [fullUpdate])
 		listBoxSelWave[lastEntry][%Sweep] = LISTBOX_CHECKBOX | LISTBOX_CHECKBOX_SELECTED
 	else
 		listBoxSelWave[][%Sweep] = listBoxSelWave[p] & LISTBOX_CHECKBOX_SELECTED ? LISTBOX_CHECKBOX | LISTBOX_CHECKBOX_SELECTED : LISTBOX_CHECKBOX
+	endif
+
+	// we select the first sweep when doing a fullUpdate and nothing selected
+	if(OVS_IsActive(win) && fullUpdate)
+		FindValue/I=(LISTBOX_CHECKBOX_SELECTED)/RMD=[][0] listBoxSelWave
+		if(V_Value == -1)
+			listBoxSelWave[0][%Sweep] = SetBit(listBoxSelWave[0][%Sweep], LISTBOX_CHECKBOX_SELECTED)
+		endif
 	endif
 
 	OVS_EndIncrementalUpdate(win, updateHandle)


### PR DESCRIPTION
…isting sweeps

Recipe for reproduction:
- Open Databrowser
- Open PA plot
- Enable OVS

You know have duplicated traces in the PA plot. The reason is the
incremental OVS update introduced in ffca2076 (Add incremental update
support for overlay sweeps, 2020-07-15). The call to OVS_UpdatePanel in
BSP_CheckProc_OverlaySweeps does not recognize any new sweeps, the
selected sweeps list will be empty, but we do a full update
including calling UpdateSweepPlot. But as we have no sweeps selected we
take the early return in DB_UpdateSweepPlot, and thus don't update the
PA plot as well.

Then we select a sweep with OVS_ChangeSweepSelectionState, this new
sweep is found with the incremental update and we plot the new data from
that sweep in the PA plot.

But as that data is already shown in the PA plot we now have
duplicated traces.

The fix is to make the sweep selection when nothing is selected already
in OVS_UpdatePanel, thus replotting everything correctly, and skipping
the incorrect update later on.

Close #709.