### PR TITLE
NWB_ExportAllData: Handle missing config waves

### DIFF
--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -1919,7 +1919,7 @@ End
 Function/Wave GetConfigWave(sweepWave)
 	WAVE sweepWave
 
-	WAVE/SDFR=GetWavesDataFolderDFR(sweepWave) config = $GetConfigWaveName(ExtractSweepNumber(NameOfWave(sweepWave)))
+	WAVE/SDFR=GetWavesDataFolderDFR(sweepWave)/Z config = $GetConfigWaveName(ExtractSweepNumber(NameOfWave(sweepWave)))
 
 	return config
 End

--- a/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
+++ b/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
@@ -435,8 +435,16 @@ Function NWB_ExportAllData(nwbVersion, [overrideFilePath, writeStoredTestPulses,
 
 			name = StringFromList(j, list)
 			WAVE/SDFR=dfr sweepWave = $name
-			WAVE configWave = GetConfigWave(sweepWave)
+			WAVE/Z configWave = GetConfigWave(sweepWave)
+
 			sweep = ExtractSweepNumber(name)
+
+			if(!WaveExists(configWave))
+				printf "Sweep %d can not be exported as the config wave is missing.", sweep
+				ControlWindowToFront()
+				continue
+			endif
+
 			NWB_AppendSweepLowLevel(locationID, nwbVersion, panelTitle, sweepWave, configWave, sweep, compressionMode = compressionMode)
 			stimsetList += NWB_GetStimsetFromPanel(panelTitle, sweep)
 		endfor


### PR DESCRIPTION
We have a report of a PXP file which has a sweep wave but no config
wave. At this point it is not clear how that can happen, but we need to
allow exporting that data as well.

Reported by Rusty Mann (AI).

This can happen when sweep rollback is used as that was buggy prior to merging #731.