### PR TITLE
RemoveUnusedRows: Handle non-existing NOTE_INDEX gracefully

### DIFF
--- a/Packages/Conversion/MIES_MassExperimentProcessing.ipf
+++ b/Packages/Conversion/MIES_MassExperimentProcessing.ipf
@@ -106,6 +106,7 @@ static Function ProcessCurrentExperiment(prefs)
 		try
 			PerformMiesTasks(outputFilePath); AbortOnRTE
 		catch
+			ClearRTError()
 			print "Caught an RTE"
 			JSON_AddBoolean(jsonID, "/log/" + num2str(index) + "/error", 1)
 			JSON_SetVariable(jsonID, "/errors", JSON_GetVariable(jsonID, "/errors") + 1)

--- a/Packages/Conversion/MIES_MassExperimentProcessing.ipf
+++ b/Packages/Conversion/MIES_MassExperimentProcessing.ipf
@@ -5,6 +5,7 @@
 ///
 /// Installation:
 /// - Stop Igor Pro
+/// - Install MIES from the installer
 /// - Create a shortcut to this file and place it in the `Igor Procedures` folder
 /// - Ensure that only MIES is installed and no other Igor Pro packages
 /// - In the MIES installation folder (All Users: `C:\Program Files\MIES`, User: `C:\Users\$User\Documents\MIES`)

--- a/Packages/Conversion/MIES_MassExperimentProcessing.ipf
+++ b/Packages/Conversion/MIES_MassExperimentProcessing.ipf
@@ -38,16 +38,10 @@ Menu "Macros"
 	"Mass convert PXPs to NWBv2", /Q, StartMultiExperimentProcess()
 End
 
-// NOTE: If you use these procedures for your own purposes, change the package name
-// to a distinctive name so that you don't clash with other people's preferences.
 static StrConstant kPackageName = "MIES PXP to NWBv2"
 static StrConstant kPreferencesFileName = "ProcessPrefsMIESNWBv2.bin"
 static Constant kPrefsRecordID = 0    // The recordID is a unique number identifying a record within the preference file.
-// In this example we store only one record in the preference file.
 
-// The structure stored in preferences to keep track of what experiment to load next.
-// If you add, remove or change fields you must delete your old prefs file. See the help
-// topic "Saving Package Preferences" for details.
 static Structure MultiExperimentProcessPrefs
 	uint32 version          // Prefs version
 	uint32 processRunning   // Truth that we are running the mult-experiment process
@@ -85,8 +79,6 @@ static Function SavePackagePrefs(prefs)
 	SavePackagePreferences kPackageName, kPreferencesFileName, kPrefsRecordID, prefs
 End
 
-//  This is the routine that you would need to change to use this procedure file for your own purposes.
-//  See comments about labeled "TO USE FOR YOUR OWN PURPOSES".
 static Function ProcessCurrentExperiment(prefs)
 	STRUCT MultiExperimentProcessPrefs &prefs
 

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -5420,11 +5420,14 @@ Function/WAVE RemoveUnusedRows(WAVE wv)
 	variable index
 
 	index = GetNumberFromWaveNote(wv, NOTE_INDEX)
-	ASSERT(IsInteger(index), "Unexpected index")
 
-	if(index == 0)
+	if(IsNaN(index))
+		return wv
+	elseif(index == 0)
 		return $""
 	endif
+
+	ASSERT(IsInteger(index) && index > 0, "Expected strictly positive and integer NOTE_INDEX")
 
 	Duplicate/FREE/RMD=[0, index - 1] wv, dup
 

--- a/Packages/Testing-MIES/UTF_Utils.ipf
+++ b/Packages/Testing-MIES/UTF_Utils.ipf
@@ -650,9 +650,32 @@ End
 /// RemoveUnusedRows
 /// @{
 
-Function RUR_ChecksNote()
+Function RUR_WorksWithRandomWave()
 
 	Make/FREE wv
+
+	WAVE ret = RemoveUnusedRows(wv)
+	CHECK(WaveRefsEqual(ret, wv))
+End
+
+Function RUR_ChecksNote1()
+
+	Make/FREE wv
+	SetNumberInWaveNote(wv, NOTE_INDEX, -1)
+
+	try
+		RemoveUnusedRows(wv); AbortOnRTE
+		FAIL()
+	catch
+		PASS()
+	endtry
+End
+
+Function RUR_ChecksNote2()
+
+	Make/FREE wv
+	SetNumberInWaveNote(wv, NOTE_INDEX, inf)
+
 	try
 		RemoveUnusedRows(wv); AbortOnRTE
 		FAIL()


### PR DESCRIPTION
When exporting experiments to NWB prior to e96222a6 (TPStorage: Unify on
NOTE_INDEX, 2018-10-17) the TPStorage waves don't have a NOTE_INDEX key.
And the assertion triggers as index is NaN. This was introduced in
c5b1ad32 (NWB_AddDeviceSpecificData: Only write the used rows into the
NWB files, 2020-09-24).

Now we could add a fallback path to try "TPCycleCount" instead. But that
would add a workaround to an optional optimization and is therefore
deemed to complicated.

Therefore we just return the original wave in this case.