### PR TITLE
Bugfix/ni acquisition pa tests

### DIFF
--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -4736,6 +4736,10 @@ Function DAP_LockDevice(panelTitle)
 		SetupBackgroundTasks()
 		CtrlNamedBackground _all_, noevents=1
 		UploadCrashDumpsDaily()
+		// avoid problems with IP not keeping the dimension labels
+		// of columns when we have no rows
+		// we kill the wave here so that it is recreated properly
+		KillOrMoveToTrash(wv = GetDQMActiveDeviceList())
 	endif
 
 	WAVE deviceInfo = GetDeviceInfoWave(panelTitle)

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -4642,8 +4642,7 @@ static Function DAP_UpdateDataFolderDisplay(panelTitle, locked)
 	GroupBox group_Hardware_FolderPath win = $panelTitle, title = title
 End
 
-Function DAP_LockDevice(panelTitle)
-	string panelTitle
+Function DAP_LockDevice(string win)
 
 	variable locked, hardwareType, headstage
 	string panelTitleLocked, msg
@@ -4654,7 +4653,7 @@ Function DAP_LockDevice(panelTitle)
 		DEBUGPRINT_OR_ABORT("The MIES version is unknown, locking devices is therefore only allowed in debug mode.")
 	endif
 
-	panelTitleLocked = GetPopupMenuString(panelTitle, "popup_MoreSettings_Devices")
+	panelTitleLocked = GetPopupMenuString(win, "popup_MoreSettings_Devices")
 	if(windowExists(panelTitleLocked))
 		DoAbortNow("Attempt to duplicate device connection! Please choose another device number as that one is already in use.")
 	endif
@@ -4663,7 +4662,7 @@ Function DAP_LockDevice(panelTitle)
 		DoAbortNow("Please select a valid device.")
 	endif
 
-	if(!HasPanelLatestVersion(panelTitle, DA_EPHYS_PANEL_VERSION))
+	if(!HasPanelLatestVersion(win, DA_EPHYS_PANEL_VERSION))
 		DoAbortNow("Can not lock the device. The DA_Ephys panel is too old to be usable. Please close it and open a new one.")
 	endif
 
@@ -4680,10 +4679,10 @@ Function DAP_LockDevice(panelTitle)
 #endif
 	endif
 
-	DisableControls(panelTitle,"button_SettingsPlus_LockDevice;popup_MoreSettings_Devices;button_hardware_rescan")
-	EnableControl(panelTitle,"button_SettingsPlus_unLockDevic")
+	DisableControls(win,"button_SettingsPlus_LockDevice;popup_MoreSettings_Devices;button_hardware_rescan")
+	EnableControl(win,"button_SettingsPlus_unLockDevic")
 
-	DoWindow/W=$panelTitle/C $panelTitleLocked
+	DoWindow/W=$win/C $panelTitleLocked
 
 	KillOrMoveToTrash(wv = GetDA_EphysGuiStateNum(panelTitleLocked))
 	KillOrMoveToTrash(wv = GetDA_EphysGuiStateTxT(panelTitleLocked))

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -4742,7 +4742,7 @@ Function DAP_LockDevice(panelTitle)
 		KillOrMoveToTrash(wv = GetDQMActiveDeviceList())
 	endif
 
-	WAVE deviceInfo = GetDeviceInfoWave(panelTitle)
+	WAVE deviceInfo = GetDeviceInfoWave(panelTitleLocked)
 	HW_WriteDeviceInfo(hardwareType, ITCDeviceIDGlobal, deviceInfo)
 End
 

--- a/Packages/MIES/MIES_DataAcquisition_Multi.ipf
+++ b/Packages/MIES/MIES_DataAcquisition_Multi.ipf
@@ -392,7 +392,6 @@ End
 /// @brief Removes a device from the ActiveDeviceList
 ///
 /// @param panelTitle panel title
-///
 /// @param ITCDeviceIDGlobal device id of the device to be removed
 static Function DQM_RemoveDevice(panelTitle, ITCDeviceIDGlobal)
 	string panelTitle

--- a/Packages/MIES/MIES_DataAcquisition_Multi.ipf
+++ b/Packages/MIES/MIES_DataAcquisition_Multi.ipf
@@ -397,23 +397,28 @@ static Function DQM_RemoveDevice(panelTitle, ITCDeviceIDGlobal)
 	string panelTitle
 	variable ITCDeviceIDGlobal
 
+	variable row
+
 	WAVE ActiveDeviceList = GetDQMActiveDeviceList()
 
-	WAVE ListOfITCDeviceIDGlobal = DQM_GetActiveDeviceIDs()
-	FindValue/V=(ITCDeviceIDGlobal) ListOfITCDeviceIDGlobal
-	DeleteWavePoint(ActiveDeviceList, ROWS, V_Value)
+	row = DQM_GetActiveDeviceRow(ITCDeviceIDGlobal)
+	DeleteWavePoint(ActiveDeviceList, ROWS, row)
 End
 
-/// @brief Returns a 1D wave containing all active device IDs
-Function/WAVE DQM_GetActiveDeviceIDs()
+/// @brief Return the row into `ActiveDeviceList` for the given deviceID
+Function DQM_GetActiveDeviceRow(variable deviceID)
 
 	variable idCol
 	WAVE ActiveDeviceList = GetDQMActiveDeviceList()
 
 	idCol = FindDimLabel(ActiveDeviceList, COLS, "DeviceID")
-	Duplicate/FREE/R=[][idCol] ActiveDeviceList ListOfITCDeviceIDGlobal
+	FindValue/V=(deviceID)/RMD=[][idCol] ActiveDeviceList
 
-	return ListOfITCDeviceIDGlobal
+	if(V_Value == -1)
+		return NaN
+	endif
+
+	return V_Value
 End
 
 /// @brief Adds a device to the ActiveDeviceList

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -4907,8 +4907,7 @@ Function IsDeviceActiveWithBGTask(panelTitle, task)
 	NVAR ITCDeviceIDGlobal = $GetITCDeviceIDGlobal(panelTitle)
 
 	// running in multi device mode
-	Duplicate/FREE/R=[][0] deviceIDList, deviceIDs
-	FindValue/V=(ITCDeviceIDGlobal) deviceIDs
+	FindValue/V=(ITCDeviceIDGlobal)/RMD=[][0] deviceIDList
 	return V_Value != -1
 End
 

--- a/Packages/MIES/MIES_RepeatedAcquisition.ipf
+++ b/Packages/MIES/MIES_RepeatedAcquisition.ipf
@@ -372,12 +372,12 @@ End
 
 static Function RA_AreLeaderAndFollowerFinished()
 
-	variable numCandidates, i
+	variable numCandidates, i, row
 	string listOfCandidates, candidate
 
-	WAVE activeIDs = DQM_GetActiveDeviceIDs()
+	WAVE ActiveDeviceList = GetDQMActiveDeviceList()
 
-	if(DimSize(activeIDs, ROWS) == 0)
+	if(DimSize(ActiveDeviceList, ROWS) == 0)
 		return 1
 	endif
 
@@ -388,8 +388,8 @@ static Function RA_AreLeaderAndFollowerFinished()
 		candidate = StringFromList(i, listOfCandidates)
 		NVAR ITCDeviceIDGlobal = $GetITCDeviceIDGlobal(candidate)
 
-		FindValue/V=(ITCDeviceIDGlobal) activeIDs
-		if(V_Value != -1) // device still active
+		row = DQM_GetActiveDeviceRow(ITCDeviceIDGlobal)
+		if(IsFinite(row)) // device still active
 			return 0
 		endif
 	endfor

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -876,18 +876,15 @@ static Constant DQM_ACTIVE_DEV_WAVE_VERSION = 3
 /// The wave is used in data acquisition in multiple device mode to keep track of active devices.
 ///
 /// Columns:
-/// DeviceID id of an active device
-/// ADChannelToMonitor index of first active AD channel in HardwareDataWave
-/// StopCollectionPoint number of samples to acquire
-/// hardwareType type of hardware of the device
-/// activeChunk if a channel of the device is used for TP while DAQ this column saves the number of the last evaluated test pulse
+/// - DeviceID id of an active device
+/// - ADChannelToMonitor index of first active AD channel in HardwareDataWave
+/// - HardwareType type of hardware of the device
+/// - ActiveChunk if a channel of the device is used for TP while DAQ this column saves the number of the last evaluated test pulse
 ///
-/// Changes in version 1:
-/// added column activeChunk
-/// Changes in version 2:
-/// changed precision to double
-/// Changes in version 3:
-/// removed column 2 with StopCollectionPoint as it is no longer used
+/// Version changes:
+/// - 1: Added column activeChunk
+/// - 2: Changed precision to double
+/// - 3: Removed column 2 with StopCollectionPoint as it is no longer used
 Function/Wave GetDQMActiveDeviceList()
 
 	DFREF dfr = GetActiveITCDevicesFolder()

--- a/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
+++ b/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
@@ -3968,3 +3968,45 @@ Function TestSweepRollback_REENTRY_REENTRY([str])
 	refList = SortList("Config_Sweep_0;Sweep_0;Config_Sweep_1;Sweep_1;Config_Sweep_2;Sweep_2;Config_Sweep_3;Sweep_3;")
 	CHECK_EQUAL_STR(refList, list)
 End
+
+/// UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
+Function TestAcquiringNewDataOnOldData([str])
+	string str
+
+	STRUCT DAQSettings s
+	InitDAQSettingsFromString(s, "MD1_RA1_I0_L0_BKG_1")
+
+	AcquireData(s, str)
+End
+
+Function TestAcquiringNewDataOnOldData_REENTRY([str])
+	string str
+
+	variable sweepNo
+
+	CHECK_EQUAL_VAR(GetSetVariable(str, "SetVar_Sweep"), 3)
+
+	sweepNo = AFH_GetLastSweepAcquired(str)
+	CHECK_EQUAL_VAR(sweepNo, 2)
+
+	KillWindow $str
+
+	// restart data acquisition
+	STRUCT DAQSettings s
+	InitDAQSettingsFromString(s, "MD1_RA1_I0_L0_BKG_1")
+
+	AcquireData(s, str)
+
+	RegisterReentryFunction(GetRTStackInfo(1))
+End
+
+Function TestAcquiringNewDataOnOldData_REENTRY_REENTRY([str])
+	string str
+
+	variable sweepNo
+
+	CHECK_EQUAL_VAR(GetSetVariable(str, "SetVar_Sweep"), 6)
+
+	sweepNo = AFH_GetLastSweepAcquired(str)
+	CHECK_EQUAL_VAR(sweepNo, 5)
+End


### PR DESCRIPTION
@MichaelHuth This fixes the issue here with acquiring data again in the PA_Tests.pxp experiment.

@timjarsky This PR fixes some bugs which surface if you acquired data, close the panel, reopen it, lock it again, and acquire data again. This is probably only a developer issue, but still quite annoying.

Close #712.