### PR TITLE
DataBrowser: Added grouped drawing when sweeps are added.

### DIFF
--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -1331,3 +1331,16 @@ Constant PA_PROPERTIESWAVES_INDEX_PULSE = 0
 Constant PA_PROPERTIESWAVES_INDEX_PULSENOTE = 1
 
 /// @}
+
+/// @name Header labels for draw groups within the json of a BufferedDrawInfo structure
+///       Currently this method is only used in @sa CreateTiledChannelGraph
+/// @anchor BDIHeaderLabels
+///
+/// @{
+
+StrConstant BUFFEREDDRAWAPPEND = "AppendToGraph"
+StrConstant BUFFEREDDRAWLABEL = "Label"
+StrConstant BUFFEREDDRAWHIDDENTRACES = "HiddenTraces"
+StrConstant BUFFEREDDRAWDDAQAXES = "dDAQAxes"
+
+/// @}

--- a/Packages/MIES/MIES_DataBrowser.ipf
+++ b/Packages/MIES/MIES_DataBrowser.ipf
@@ -829,7 +829,11 @@ Function DB_ButtonProc_SwitchXAxis(ba) : ButtonControl
 	return 0
 End
 
-Function DB_AddSweepToGraph(string win, variable index)
+/// @brief Adds traces of a sweep to the databrowser graph
+/// @param win Name of the DataBrowser
+/// @param index Index of the sweep
+/// @param bdi [optional, default = n/a] BufferedDrawInfo structure, when given buffered draw is used.
+Function DB_AddSweepToGraph(string win, variable index[, STRUCT BufferedDrawInfo &bdi])
 	STRUCT TiledGraphSettings tgs
 
 	variable sweepNo, traceIndex
@@ -860,8 +864,14 @@ Function DB_AddSweepToGraph(string win, variable index)
 	WAVE axisLabelCache = GetAxisLabelCacheWave()
 
 	traceIndex = GetNextTraceIndex(graph)
-	CreateTiledChannelGraph(graph, config, sweepNo, numericalValues, textualValues, tgs, dfr, axisLabelCache, \
+
+	if(ParamIsDefault(bdi))
+		CreateTiledChannelGraph(graph, config, sweepNo, numericalValues, textualValues, tgs, dfr, axisLabelCache, \
 							traceIndex, experiment, sweepChannelSel)
+	else
+		CreateTiledChannelGraph(graph, config, sweepNo, numericalValues, textualValues, tgs, dfr, axisLabelCache, \
+							traceIndex, experiment, sweepChannelSel, bdi = bdi)
+	endif
 
 	AR_UpdateTracesIfReq(graph, dfr, sweepNo)
 End

--- a/Packages/MIES/MIES_OverlaySweeps.ipf
+++ b/Packages/MIES/MIES_OverlaySweeps.ipf
@@ -728,6 +728,7 @@ static Function OVS_EndIncrementalUpdate(string win, WAVE/WAVE updateHandle)
 	variable editableAfter, editableBefore, changedHeadstages
 	variable updatedSweeps, addedSweeps, removedSweeps, mode
 	string headstageBefore, headstageAfter, msg
+	STRUCT BufferedDrawInfo bdi
 
 	DFREF dfr = BSP_GetFolder(win, MIES_BSP_PANEL_FOLDER)
 	WAVE/T listBoxWaveAfterOriginal = GetOverlaySweepsListWave(dfr)
@@ -764,6 +765,7 @@ static Function OVS_EndIncrementalUpdate(string win, WAVE/WAVE updateHandle)
 
 	Make/FREE/N=(newSize) addedIndizes = NaN
 	Make/FREE/N=(newSize) removedIndizes = NaN
+	InitBufferedDrawInfo(bdi)
 
 	// now we have the list of changed sweeps
 	// so let's figure out what to do
@@ -805,11 +807,13 @@ static Function OVS_EndIncrementalUpdate(string win, WAVE/WAVE updateHandle)
 		elseif(!displayedBefore && displayedAfter)
 			needsPostProcessing += 1
 			addedIndizes[addedSweeps++] = i
-			AddSweepToGraph(win, i)
+			AddSweepToGraph(win, i, bdi = bdi)
 		else
 			ASSERT(0, "Impossible case")
 		endif
 	endfor
+
+	TiledGraphAccelerateDraw(bdi)
 
 	if(needsPostProcessing)
 		if(updatedSweeps)

--- a/Packages/MIES/MIES_Structures.ipf
+++ b/Packages/MIES/MIES_Structures.ipf
@@ -328,3 +328,26 @@ Structure HardwareDataTPInput
 	WAVE DAGain, DACAmpTP
 	variable testPulseLength, baselineFrac
 EndStructure
+
+/// @brief initializes a BufferedDrawInfo structure
+///        The json path for AppendTracesToGraph and Labels is set empty by default
+///        @sa TiledGraphAccelerateDraw
+Function InitBufferedDrawInfo(STRUCT BufferedDrawInfo &s)
+
+	s.jsonID = JSON_Parse("{}")
+	JSON_AddTreeObject (s.jsonID, BUFFEREDDRAWAPPEND)
+	JSON_AddTreeObject (s.jsonID, BUFFEREDDRAWLABEL)
+	JSON_AddTreeObject (s.jsonID, BUFFEREDDRAWHIDDENTRACES)
+	JSON_AddTreeObject (s.jsonID, BUFFEREDDRAWDDAQAXES)
+	Make/FREE/WAVE/N=(MINIMUM_WAVE_SIZE_LARGE) tw
+	WAVE/WAVE s.traceWaves = tw
+	SetNumberInWaveNote(s.traceWaves, NOTE_INDEX, 0)
+End
+
+/// @brief Stores information for buffered draw
+///        jsonID - stores information about traces and labels to draw/setup
+///        traceWaves - wave ref wave with references to the trace waves (which are always non-free)
+Structure BufferedDrawInfo
+	variable jsonID
+	WAVE/WAVE traceWaves
+EndStructure


### PR DESCRIPTION
This increases the speed when the DataBrowser graph is updated.

The same logic as in the grouped drawing for the PA plot is used,
with the expension that a structure is introduced to carry the draw
information. This allows to draw the graph elements at a later point in
the code.

close https://github.com/AllenInstitute/MIES/issues/749