### PR TITLE
Fixed: PA plot HS removal now removes also the same regions in the vertical direction

### DIFF
--- a/Packages/MIES/MIES_BrowserSettingsPanel.ipf
+++ b/Packages/MIES/MIES_BrowserSettingsPanel.ipf
@@ -1207,9 +1207,9 @@ End
 Function/WAVE BSP_FetchSelectedChannels(string graph, [variable index, variable sweepNo])
 
 	if(ParamIsDefault(index) && !ParamIsDefault(sweepNo))
-		WAVE/Z activeHS = OVS_ParseIgnoreList(graph, sweepNo=sweepNo)
+		WAVE/Z activeHS = OVS_GetHeadstageRemoval(graph, sweepNo=sweepNo)
 	elseif(!ParamIsDefault(index) && ParamIsDefault(sweepNo))
-		WAVE/Z activeHS = OVS_ParseIgnoreList(graph, index=index)
+		WAVE/Z activeHS = OVS_GetHeadstageRemoval(graph, index=index)
 	else
 		ASSERT(0, "Invalid optional flags")
 	endif

--- a/Packages/MIES/MIES_PulseAveraging.ipf
+++ b/Packages/MIES/MIES_PulseAveraging.ipf
@@ -628,6 +628,8 @@ static Function [STRUCT PulseAverageSetIndices pasi] PA_GenerateAllPulseWaves(st
 		regionList = AddListItem(num2istr(regions[i]), regionList, PA_PROPERTIES_STRLIST_SEP, inf)
 	endfor
 
+	Make/FREE/N=(MINIMUM_WAVE_SIZE)/WAVE headstageRemovalPerSweep
+
 	// There is one case where we generate errorneous output:
 	// If we have multiple sweeps that are acquired with more than 1 HS and
 	// on a subsequent sweep the channels previously associated to the headstages are now swapped.
@@ -741,6 +743,14 @@ static Function [STRUCT PulseAverageSetIndices pasi] PA_GenerateAllPulseWaves(st
 			sweepNo = str2num(sweepNoStr)
 			if(WhichListItem(sweepNoStr, sweepList, PA_PROPERTIES_STRLIST_SEP) == -1)
 				sweepList = AddListItem(sweepNoStr, sweepList, PA_PROPERTIES_STRLIST_SEP, inf)
+
+				EnsureLargeEnoughWave(headstageRemovalPerSweep, minimumSize = sweepNo)
+				headstageRemovalPerSweep[sweepNo] = OVS_GetHeadstageRemoval(win, sweepNo = sweepNo)
+			endif
+
+			WAVE/Z activeHS = headstageRemovalPerSweep[sweepNo]
+			if(WaveExists(activeHS) && activeHS[region] == 0)
+				continue
 			endif
 
 			experiment = traceData[idx][lblTraceExperiment]

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -3266,7 +3266,8 @@ End
 /// @param dim          dimension to extract
 ///
 /// @returns 2-dim wave with the start, stop, step as columns and rows as
-///          number of elements. Returns -1 instead of `*` or ``.
+///          number of elements. Returns -1 instead of `*` or ``. An invalid
+///          wave reference is returned on parsing errors.
 Function/WAVE ExtractFromSubrange(listOfRanges, dim)
 	string listOfRanges
 	variable dim
@@ -3324,7 +3325,7 @@ Function/WAVE ExtractFromSubrange(listOfRanges, dim)
 				ranges[i][1] = IsFinite(stop) ? stop : -1
 				ranges[i][2] = step
 			else
-				ASSERT(0, "Unexpected state")
+				return $""
 			endif
 		endif
 	endfor

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -3259,7 +3259,7 @@ End
 /// \rst
 /// .. code-block:: igorpro
 ///
-/// 	wAVE ranges = ExtractFromSubrange("[3,4]_[*]_[1, *;4]_[]_[5][]", 0)
+/// 	WAVE ranges = ExtractFromSubrange("[3,4]_[*]_[1, *;4]_[]_[5][]", 0)
 /// \endrst
 ///
 /// @param listOfRanges list of subrange specifications separated by **_**

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -5923,6 +5923,34 @@ Function/WAVE GetOverlaySweepsListSelWave(dfr)
 	return wv
 End
 
+/// @brief Return the overlay sweeps wave with the parsed headstage removal
+/// info
+///
+/// Rows:
+/// - Same index as in GetOverlaySweepsListWave() and GetOverlaySweepsListSelWave()
+///
+/// Cols:
+/// - #NUM_HEADSTAGES, 1 if active and 0 if removed
+Function/WAVE GetOverlaySweepHeadstageRemoval(DFREF dfr)
+	variable versionOfNewWave = 1
+
+	ASSERT(DataFolderExistsDFR(dfr), "Invalid dfr")
+	WAVE/Z/SDFR=dfr wv = overlaySweepsHeadstageRemoval
+
+	if(ExistsWithCorrectLayoutVersion(wv, versionOfNewWave))
+		return wv
+	elseif(WaveExists(wv))
+		// handle upgrade
+	else
+		Make/R/N=(MINIMUM_WAVE_SIZE, NUM_HEADSTAGES) dfr:overlaySweepsHeadstageRemoval/Wave=wv
+	endif
+
+	wv = 1
+
+	SetWaveVersion(wv, versionOfNewWave)
+	return wv
+End
+
 /// @brief Return the overlay sweeps wave with all sweep selection choices
 /// for the databrowser or the sweepbrowser
 Function/WAVE GetOverlaySweepSelectionChoices(win, dfr, [skipUpdate])

--- a/Packages/Testing-MIES/UTF_PA_Tests.ipf
+++ b/Packages/Testing-MIES/UTF_PA_Tests.ipf
@@ -2053,7 +2053,6 @@ static Function PAT_IncrementalSweepAddPartialAvgCheck()
 	CHECK_EQUAL_VAR(traceNum, 4)
 End
 
-// UTF_EXPECTED_FAILURE
 static Function PAT_HSRemoval1()
 
 	string bspName, graph


### PR DESCRIPTION
Previously HS removal only removed the associated channel of the set sweep but left all other regions in the plot.

Removed expected failure from test.

close https://github.com/AllenInstitute/MIES/issues/729
close #737