### PR TITLE
GetSizeOfAllWavesInExperiment: Fix sorting by ascending wave sizes

### DIFF
--- a/Packages/MIES/MIES_Debugging.ipf
+++ b/Packages/MIES/MIES_Debugging.ipf
@@ -535,7 +535,7 @@ Function GetSizeOfAllWavesInExperiment()
 
 	list[][1] = num2str(waveSizes[p])
 
-	SortColumns/KNDX=1 sortWaves={list}
+	SortColumns keyWaves={waveSizes}, sortWaves={list}
 
 	WaveStats/M=2/Q waveSizes
 	printf "Sum of all waves: %g\r", V_sum


### PR DESCRIPTION
That debug function creates a two column wave, where the second column
holds the size in MB of the wave.

But just using that column for sorting does not work with floating point
values converted to strings. By using the original wavesize wave with
floating point numbers we can fix that.