### PR TITLE
Packages/Testing-MIES/UserAnalysisFunctions.ipf: Mark it as special

### DIFF
--- a/Packages/Testing-MIES/UTF_HardwareMain.ipf
+++ b/Packages/Testing-MIES/UTF_HardwareMain.ipf
@@ -6,8 +6,11 @@
 #include "MIES_include"
 #include "unit-testing"
 
+// If the next line fails, you are including the MIES created
+// "UserAnalysisFunctions.ipf" and not the one from "Packages/Testing-MIES"
+#include "UserAnalysisFunctions", version >= 10000
+
 #include "UTF_AnalysisFunctionManagement"
-#include "UserAnalysisFunctions"
 #include "UTF_AnalysisFunctionParameters"
 #include "UTF_VeryBasicHardwareTests"
 #include "UTF_DAEphys"

--- a/Packages/Testing-MIES/UTF_VeryBasicHardwareTests.ipf
+++ b/Packages/Testing-MIES/UTF_VeryBasicHardwareTests.ipf
@@ -8,6 +8,15 @@ static Function CheckInstallation()
    CHECK_EQUAL_VAR(CHI_CheckInstallation(), 0)
 End
 
+static Function CheckTestingInstallation()
+
+	string str
+
+	// this function is present in our special UserAnalysisFunctions.ipf
+	str = FunctionList("CorrectFileMarker", ";", "")
+	REQUIRE_PROPER_STR(str)
+End
+
 // UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
 static Function TestLocking([str])
 	string str

--- a/Packages/Testing-MIES/UserAnalysisFunctions.ipf
+++ b/Packages/Testing-MIES/UserAnalysisFunctions.ipf
@@ -1,10 +1,16 @@
 #pragma rtGlobals=3 // Use modern global access method and strict wave access.
 #pragma rtFunctionErrors=1
+#pragma version=10000
 
 #ifndef AUTOMATED_TESTING
 
 	#define **error** Can only be used with automated testing
 #endif
+
+Function CorrectFileMarker()
+
+	FAIL()
+End
 
 Function InvalidSignature()
 


### PR DESCRIPTION
We create in MIES a file with the same name for user analysis functions.
This can lead to difficult to diagnose error message when that file is
included instead of the correct one.

Fix that by using a version for the correct file and also have a test
which searched for a marker function.