### PR TITLE
Feature/separate tp daq waves

### DIFF
--- a/Packages/MIES/MIES_AnalysisFunctionHelpers.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctionHelpers.ipf
@@ -98,7 +98,7 @@ Function AFH_GetDACFromHeadstage(panelTitle, headstage)
 	return NaN
 End
 
-/// @brief Return the column index into `ITCDataWave` for the given channel/type
+/// @brief Return the column index into `DAQDataWave` for the given channel/type
 ///        combination
 ///
 /// @param ITCChanConfigWave ITC configuration wave, most users need to call

--- a/Packages/MIES/MIES_AnalysisFunctionManagement.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctionManagement.ipf
@@ -104,7 +104,7 @@ Function AFM_CallAnalysisFunctions(panelTitle, eventType)
 		valid_f3 = FuncRefIsAssigned(FuncRefInfo(f3))
 
 		// all functions are valid
-		WAVE DAQDataWave = GetDAQDataWave(panelTitle)
+		WAVE DAQDataWave = GetDAQDataWave(panelTitle, DATA_ACQUISITION_MODE)
 		ChangeWaveLock(DAQDataWave, 1)
 
 		ChangeWaveLock(scaledDataWave, 1)

--- a/Packages/MIES/MIES_AnalysisFunctionManagement.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctionManagement.ipf
@@ -104,7 +104,7 @@ Function AFM_CallAnalysisFunctions(panelTitle, eventType)
 		valid_f3 = FuncRefIsAssigned(FuncRefInfo(f3))
 
 		// all functions are valid
-		WAVE DAQDataWave = GetHardwareDataWave(panelTitle)
+		WAVE DAQDataWave = GetDAQDataWave(panelTitle)
 		ChangeWaveLock(DAQDataWave, 1)
 
 		ChangeWaveLock(scaledDataWave, 1)

--- a/Packages/MIES/MIES_AnalysisFunctionPrototypes.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctionPrototypes.ipf
@@ -16,14 +16,14 @@
 /// @param panelTitle  device
 /// @param eventType   eventType, one of @ref EVENT_TYPE_ANALYSIS_FUNCTIONS,
 ///                    always compare `eventType` with the constants, never use the current numerical value directly
-/// @param ITCDataWave data wave (locked to prevent changes using `SetWaveLock`)
+/// @param DAQDataWave data wave (locked to prevent changes using `SetWaveLock`)
 /// @param headStage   active headstage index
 ///
 /// @return ignored
-Function AF_PROTO_ANALYSIS_FUNC_V1(panelTitle, eventType, ITCDataWave, headStage)
+Function AF_PROTO_ANALYSIS_FUNC_V1(panelTitle, eventType, DAQDataWave, headStage)
 	string panelTitle
 	variable eventType
-	Wave ITCDataWave
+	Wave DAQDataWave
 	variable headstage
 End
 
@@ -32,16 +32,16 @@ End
 /// @param panelTitle     device
 /// @param eventType      eventType, one of @ref EVENT_TYPE_ANALYSIS_FUNCTIONS,
 ///                       always compare `eventType` with the constants, never use the current numerical value directly
-/// @param ITCDataWave    data wave (locked to prevent changes using `SetWaveLock`)
+/// @param DAQDataWave    data wave (locked to prevent changes using `SetWaveLock`)
 /// @param headStage      active headstage index
-/// @param realDataLength number of rows in `ITCDataWave` with data, the total number of rows in `ITCDataWave` might be
+/// @param realDataLength number of rows in `DAQDataWave` with data, the total number of rows in `DAQDataWave` might be
 ///                       higher due to alignment requirements of the data acquisition hardware. `NaN` for #PRE_DAQ_EVENT events.
 ///
 /// @return see @ref AnalysisFunction_V3DescriptionTable
-Function AF_PROTO_ANALYSIS_FUNC_V2(panelTitle, eventType, ITCDataWave, headStage, realDataLength)
+Function AF_PROTO_ANALYSIS_FUNC_V2(panelTitle, eventType, DAQDataWave, headStage, realDataLength)
 	string panelTitle
 	variable eventType
-	Wave ITCDataWave
+	Wave DAQDataWave
 	variable headstage, realDataLength
 
 	return 0

--- a/Packages/MIES/MIES_AnalysisFunctions.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions.ipf
@@ -173,20 +173,20 @@ static Constant ITI_LOCAL         = 15                      ///< Inter-trial-int
 static Constant POST_DELAY = 150									 ///< Delay after stimulation event in which no other event can occur in ms
 ///@}
 
-Function TestAnalysisFunction_V1(panelTitle, eventType, ITCDataWave, headStage)
+Function TestAnalysisFunction_V1(panelTitle, eventType, DAQDataWave, headStage)
 	string panelTitle
 	variable eventType
-	Wave ITCDataWave
+	Wave DAQDataWave
 	variable headstage
 
 	printf "Analysis function version 1 called: device %s, eventType \"%s\", headstage %d\r", panelTitle, StringFromList(eventType, EVENT_NAME_LIST), headStage
 	printf "Next sweep: %d\r", DAG_GetNumericalValue(panelTitle, "SetVar_Sweep")
 End
 
-Function TestAnalysisFunction_V2(panelTitle, eventType, ITCDataWave, headStage, realDataLength)
+Function TestAnalysisFunction_V2(panelTitle, eventType, DAQDataWave, headStage, realDataLength)
 	string panelTitle
 	variable eventType
-	Wave ITCDataWave
+	Wave DAQDataWave
 	variable headstage, realDataLength
 
 	printf "Analysis function version 2 called: device %s, eventType \"%s\", headstage %d\r", panelTitle, StringFromList(eventType, EVENT_NAME_LIST), headStage
@@ -293,10 +293,10 @@ Function MeasureMidSweepTiming_V3(panelTitle, s)
 	return 0
 End
 
-Function Enforce_VC(panelTitle, eventType, ITCDataWave, headStage, realDataLength)
+Function Enforce_VC(panelTitle, eventType, DAQDataWave, headStage, realDataLength)
 	string panelTitle
 	variable eventType
-	Wave ITCDataWave
+	Wave DAQDataWave
 	variable headstage, realDataLength
 
 	if(eventType != PRE_DAQ_EVENT)
@@ -314,10 +314,10 @@ Function Enforce_VC(panelTitle, eventType, ITCDataWave, headStage, realDataLengt
 	return 0
 End
 
-Function Enforce_IC(panelTitle, eventType, ITCDataWave, headStage, realDataLength)
+Function Enforce_IC(panelTitle, eventType, DAQDataWave, headStage, realDataLength)
 	string panelTitle
 	variable eventType
-	Wave ITCDataWave
+	Wave DAQDataWave
 	variable headstage, realDataLength
 
 	if(eventType != PRE_DAQ_EVENT)
@@ -339,10 +339,10 @@ End
 // Starts with a pop-up menu to set initial parameters and then switches holding potential midway through total number of sweeps
 
 /// @brief Force active headstages into voltage clamp
-Function SetStimConfig_Vclamp(panelTitle, eventType, ITCDataWave, headStage)
+Function SetStimConfig_Vclamp(panelTitle, eventType, DAQDataWave, headStage)
 	string panelTitle
 	variable eventType
-	Wave ITCDataWave
+	Wave DAQDataWave
 	variable headstage
 
 	setVClampMode()
@@ -352,10 +352,10 @@ Function SetStimConfig_Vclamp(panelTitle, eventType, ITCDataWave, headStage)
 End
 
 /// @brief Force active headstages into current clamp
-Function SetStimConfig_Iclamp(panelTitle, eventType, ITCDataWave, headStage)
+Function SetStimConfig_Iclamp(panelTitle, eventType, DAQDataWave, headStage)
 	string panelTitle
 	variable eventType
-	Wave ITCDataWave
+	Wave DAQDataWave
 	variable headstage
 
 	setIClampMode()
@@ -365,10 +365,10 @@ Function SetStimConfig_Iclamp(panelTitle, eventType, ITCDataWave, headStage)
 End
 
 /// @brief Change holding potential midway through stim set
-Function ChangeHoldingPotential(panelTitle, eventType, ITCDataWave, headStage)
+Function ChangeHoldingPotential(panelTitle, eventType, DAQDataWave, headStage)
 	string panelTitle
 	variable eventType
-	Wave ITCDataWave
+	Wave DAQDataWave
 	variable headstage
 
 	variable SweepsRemaining = switchHolding(VM2_LOCAL)
@@ -377,10 +377,10 @@ Function ChangeHoldingPotential(panelTitle, eventType, ITCDataWave, headStage)
 End
 
 /// @brief Print last Stim Set run and headstage mode and holding potential
-Function LastStimSet(panelTitle, eventType, ITCDataWave, headStage)
+Function LastStimSet(panelTitle, eventType, DAQDataWave, headStage)
 	string panelTitle
 	variable eventType
-	Wave ITCDataWave
+	Wave DAQDataWave
 	variable headstage
 
 	PGC_SetAndActivateControl(panelTitle, "check_Settings_TPAfterDAQ", val = CHECKBOX_SELECTED)
@@ -591,10 +591,10 @@ End
 ///        the left over time at the 20th call.
 ///
 /// This function needs to be set for Pre DAQ, Mid Sweep and Post Sweep Event.
-Function TestPrematureSweepStop(panelTitle, eventType, ITCDataWave, headStage, realDataLength)
+Function TestPrematureSweepStop(panelTitle, eventType, DAQDataWave, headStage, realDataLength)
 	string panelTitle
 	variable eventType
-	Wave ITCDataWave
+	Wave DAQDataWave
 	variable headstage, realDataLength
 
 	variable num
@@ -617,10 +617,10 @@ Function TestPrematureSweepStop(panelTitle, eventType, ITCDataWave, headStage, r
 	return 0
 End
 
-Function preDAQ_MP_mainConfig(panelTitle, eventType, ITCDataWave, headStage, realDataLength)
+Function preDAQ_MP_mainConfig(panelTitle, eventType, DAQDataWave, headStage, realDataLength)
 	string panelTitle
 	variable eventType
-	Wave ITCDataWave
+	Wave DAQDataWave
 	variable headstage, realDataLength
 
 	ASSERT(eventType == PRE_DAQ_EVENT, "Invalid event type")
@@ -632,10 +632,10 @@ Function preDAQ_MP_mainConfig(panelTitle, eventType, ITCDataWave, headStage, rea
 	PGC_SetAndActivateControl(panelTitle, "Check_DataAcq1_RepeatAcq", val = 1)
 End
 
-Function preDAQ_MP_IfMixed(panelTitle, eventType, ITCDataWave, headStage, realDataLength)
+Function preDAQ_MP_IfMixed(panelTitle, eventType, DAQDataWave, headStage, realDataLength)
 	string panelTitle
 	variable eventType
-	Wave ITCDataWave
+	Wave DAQDataWave
 	variable headstage, realDataLength
 
 	ASSERT(eventType == PRE_DAQ_EVENT, "Invalid event type")
@@ -647,10 +647,10 @@ Function preDAQ_MP_IfMixed(panelTitle, eventType, ITCDataWave, headStage, realDa
 	PGC_SetAndActivateControl(panelTitle, "Check_DataAcq1_RepeatAcq", val = 1)
 End
 
-Function preDAQ_MP_ChirpBlowout(panelTitle, eventType, ITCDataWave, headStage, realDataLength)
+Function preDAQ_MP_ChirpBlowout(panelTitle, eventType, DAQDataWave, headStage, realDataLength)
 	string panelTitle
 	variable eventType
-	Wave ITCDataWave
+	Wave DAQDataWave
 	variable headstage, realDataLength
 
 	ASSERT(eventType == PRE_DAQ_EVENT, "Invalid event type")
@@ -671,10 +671,10 @@ End
 /// - Does currently nothing for "Mid Sweep" Event
 /// - Does not support DA/AD channels not associated with a MIES headstage (aka unassociated DA/AD Channels)
 /// - All active headstages must be in "Current Clamp"
-Function AdjustDAScale(panelTitle, eventType, ITCDataWave, headStage, realDataLength)
+Function AdjustDAScale(panelTitle, eventType, DAQDataWave, headStage, realDataLength)
 	string panelTitle
 	variable eventType
-	Wave ITCDataWave
+	Wave DAQDataWave
 	variable headstage, realDataLength
 
 	variable val, index, DAC, ADC

--- a/Packages/MIES/MIES_AnalysisFunctions_MultiPatchSeq.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_MultiPatchSeq.ipf
@@ -124,7 +124,7 @@ static Function/WAVE MSQ_DeterminePulseDuration(panelTitle, sweepNo, totalOnsetD
 	WAVE/Z sweepWave = GetSweepWave(panelTitle, sweepNo)
 
 	if(!WaveExists(sweepWave))
-		WAVE sweepWave = GetHardwareDataWave(panelTitle)
+		WAVE sweepWave = GetDAQDataWave(panelTitle)
 		WAVE config    = GetITCChanConfigWave(panelTitle)
 	else
 		WAVE config = GetConfigWave(sweepWave)
@@ -627,7 +627,7 @@ static Function/WAVE MSQ_SearchForSpikes(panelTitle, type, sweepWave, headstage,
 	variable minVal, maxVal
 	string msg
 
-	if(WaveRefsEqual(sweepWave, GetHardwareDataWave(panelTitle)))
+	if(WaveRefsEqual(sweepWave, GetDAQDataWave(panelTitle)))
 		WAVE config = GetITCChanConfigWave(panelTitle)
 	else
 		WAVE config = GetConfigWave(sweepWave)

--- a/Packages/MIES/MIES_AnalysisFunctions_MultiPatchSeq.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_MultiPatchSeq.ipf
@@ -124,7 +124,7 @@ static Function/WAVE MSQ_DeterminePulseDuration(panelTitle, sweepNo, totalOnsetD
 	WAVE/Z sweepWave = GetSweepWave(panelTitle, sweepNo)
 
 	if(!WaveExists(sweepWave))
-		WAVE sweepWave = GetDAQDataWave(panelTitle)
+		WAVE sweepWave = GetDAQDataWave(panelTitle, DATA_ACQUISITION_MODE)
 		WAVE config    = GetITCChanConfigWave(panelTitle)
 	else
 		WAVE config = GetConfigWave(sweepWave)
@@ -627,7 +627,7 @@ static Function/WAVE MSQ_SearchForSpikes(panelTitle, type, sweepWave, headstage,
 	variable minVal, maxVal
 	string msg
 
-	if(WaveRefsEqual(sweepWave, GetDAQDataWave(panelTitle)))
+	if(WaveRefsEqual(sweepWave, GetDAQDataWave(panelTitle, DATA_ACQUISITION_MODE)))
 		WAVE config = GetITCChanConfigWave(panelTitle)
 	else
 		WAVE config = GetConfigWave(sweepWave)

--- a/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
@@ -147,7 +147,7 @@ static Function/WAVE PSQ_DeterminePulseDuration(panelTitle, sweepNo, type, total
 	WAVE/Z sweepWave = GetSweepWave(panelTitle, sweepNo)
 
 	if(!WaveExists(sweepWave))
-		WAVE sweepWave = GetHardwareDataWave(panelTitle)
+		WAVE sweepWave = GetDAQDataWave(panelTitle)
 		WAVE config    = GetITCChanConfigWave(panelTitle)
 	else
 		WAVE config = GetConfigWave(sweepWave)
@@ -470,12 +470,12 @@ static Function PSQ_GetNumberOfChunks(panelTitle, sweepNo, headstage, type)
 
 	variable length, nonBL, totalOnsetDelay
 
-	WAVE HardwareDataWave    = GetHardwareDataWave(panelTitle)
+	WAVE DAQDataWave    = GetDAQDataWave(panelTitle)
 	NVAR stopCollectionPoint = $GetStopCollectionPoint(panelTitle)
 	totalOnsetDelay = DAG_GetNumericalValue(panelTitle, "setvar_DataAcq_OnsetDelayUser") \
 					  + GetValDisplayAsNum(panelTitle, "valdisp_DataAcq_OnsetDelayAuto")
 
-	length = stopCollectionPoint * DimDelta(HardwareDataWave, ROWS)
+	length = stopCollectionPoint * DimDelta(DAQDataWave, ROWS)
 
 	switch(type)
 		case PSQ_DA_SCALE:
@@ -732,7 +732,7 @@ static Function/WAVE PSQ_SearchForSpikes(panelTitle, type, sweepWave, headstage,
 
 	Make/FREE/D/N=(LABNOTEBOOK_LAYER_COUNT) spikeDetection = (p == headstage ? 0 : NaN)
 
-	if(WaveRefsEqual(sweepWave, GetHardwareDataWave(panelTitle)))
+	if(WaveRefsEqual(sweepWave, GetDAQDataWave(panelTitle)))
 		WAVE config = GetITCChanConfigWave(panelTitle)
 	else
 		WAVE config = GetConfigWave(sweepWave)
@@ -2651,7 +2651,7 @@ Function PSQ_Ramp(panelTitle, s)
 				ASSERT(fifoPos > 0, "Invalid fifo position, has the thread died?")
 
 				// wait until the hardware is finished with writing this chunk
-				// this is to avoid that two threads write simultaneously into the ITCDataWave
+				// this is to avoid that two threads write simultaneously into the DAQDataWave
 				for(;;)
 					val = TS_GetNewestFromThreadQueue(tgID, "fifoPos")
 

--- a/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
@@ -147,7 +147,7 @@ static Function/WAVE PSQ_DeterminePulseDuration(panelTitle, sweepNo, type, total
 	WAVE/Z sweepWave = GetSweepWave(panelTitle, sweepNo)
 
 	if(!WaveExists(sweepWave))
-		WAVE sweepWave = GetDAQDataWave(panelTitle)
+		WAVE sweepWave = GetDAQDataWave(panelTitle, DATA_ACQUISITION_MODE)
 		WAVE config    = GetITCChanConfigWave(panelTitle)
 	else
 		WAVE config = GetConfigWave(sweepWave)
@@ -470,7 +470,7 @@ static Function PSQ_GetNumberOfChunks(panelTitle, sweepNo, headstage, type)
 
 	variable length, nonBL, totalOnsetDelay
 
-	WAVE DAQDataWave    = GetDAQDataWave(panelTitle)
+	WAVE DAQDataWave    = GetDAQDataWave(panelTitle, DATA_ACQUISITION_MODE)
 	NVAR stopCollectionPoint = $GetStopCollectionPoint(panelTitle)
 	totalOnsetDelay = DAG_GetNumericalValue(panelTitle, "setvar_DataAcq_OnsetDelayUser") \
 					  + GetValDisplayAsNum(panelTitle, "valdisp_DataAcq_OnsetDelayAuto")
@@ -732,7 +732,7 @@ static Function/WAVE PSQ_SearchForSpikes(panelTitle, type, sweepWave, headstage,
 
 	Make/FREE/D/N=(LABNOTEBOOK_LAYER_COUNT) spikeDetection = (p == headstage ? 0 : NaN)
 
-	if(WaveRefsEqual(sweepWave, GetDAQDataWave(panelTitle)))
+	if(WaveRefsEqual(sweepWave, GetDAQDataWave(panelTitle, DATA_ACQUISITION_MODE)))
 		WAVE config = GetITCChanConfigWave(panelTitle)
 	else
 		WAVE config = GetConfigWave(sweepWave)
@@ -2630,7 +2630,7 @@ Function PSQ_Ramp(panelTitle, s)
 				fifoOffset = TS_GetNewestFromThreadQueue(tgID, "fifoPos")
 				TFH_StopFIFODaemon(HARDWARE_ITC_DAC, deviceID)
 				HW_StopAcq(HARDWARE_ITC_DAC, deviceID)
-				HW_ITC_PrepareAcq(deviceID, offset=fifoOffset)
+				HW_ITC_PrepareAcq(deviceID, DATA_ACQUISITION_MODE, offset=fifoOffset)
 
 				WAVE wv = s.rawDACWave
 

--- a/Packages/MIES/MIES_Cache.ipf
+++ b/Packages/MIES/MIES_Cache.ipf
@@ -347,13 +347,13 @@ Function/S CA_HWDeviceInfoKey(panelTitle, hardwareType, deviceID)
 	return num2istr(crc) + "HW Device Info Version 1"
 End
 
-/// @brief Generate a key for the HardwareDataWave in TEST_PULSE_MODE
+/// @brief Generate a key for the DAQDataWave in TEST_PULSE_MODE
 ///
 /// Properties which influence the Testpulse:
 /// - hardwareType
 /// - numDA (filled columns)
 /// - numActiveChannels (number of columns)
-/// - number of rows, return from DC_CalculateITCDataWaveLength(panelTitle, TEST_PULSE_MODE)
+/// - number of rows, return from DC_CalculateDAQDataWaveLength(panelTitle, TEST_PULSE_MODE)
 /// - samplingInterval
 /// - DAGain
 /// - DACAmp[][%TPAmp] column

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -483,7 +483,7 @@ StrConstant STIM_WAVE_NAME_KEY = "Stim Wave Name"
 /// Last valid row index for storing epoch types in #GetSegmentTypeWave
 Constant SEGMENT_TYPE_WAVE_LAST_IDX = 93
 
-/// Minimum logarithm to base two for the ITCDataWave size
+/// Minimum logarithm to base two for the DAQDataWave size for ITC hardware
 Constant MINIMUM_ITCDATAWAVE_EXPONENT = 20
 
 /// Minimum value for the baseline fraction of the Testpulse in percent

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -1344,3 +1344,5 @@ StrConstant BUFFEREDDRAWHIDDENTRACES = "HiddenTraces"
 StrConstant BUFFEREDDRAWDDAQAXES = "dDAQAxes"
 
 /// @}
+
+StrConstant TP_PROPERTIES_HASH = "TestPulsePropertiesHash"

--- a/Packages/MIES/MIES_DAC-Hardware.ipf
+++ b/Packages/MIES/MIES_DAC-Hardware.ipf
@@ -1361,7 +1361,7 @@ End
 ///
 /// @param deviceID    device identifier
 /// @param data        ITC data wave
-/// @param dataFunc    [optional, defaults to GetITCDataWave()] override wave getter for the ITC data wave
+/// @param dataFunc    [optional, defaults to GetDAQDataWave()] override wave getter for the ITC data wave
 /// @param config      ITC config wave
 /// @param configFunc  [optional, defaults to GetITCChanConfigWave()] override wave getter for the ITC config wave
 /// @param offset      [optional, defaults to zero] offset into the data wave in points
@@ -1380,7 +1380,7 @@ Function HW_ITC_PrepareAcq(deviceID, [data, dataFunc, config, configFunc, flags,
 
 	if(ParamIsDefault(data))
 		if(ParamIsDefault(dataFunc))
-			WAVE data = GetHardwareDataWave(panelTitle)
+			WAVE data = GetDAQDataWave(panelTitle)
 		else
 			WAVE data = dataFunc(panelTitle)
 		endif
@@ -1982,7 +1982,7 @@ End
 ///
 /// @param deviceID    device identifier
 /// @param data        ITC data wave
-/// @param dataFunc    [optional, defaults to GetITCDataWave()] override wave getter for the ITC data wave
+/// @param dataFunc    [optional, defaults to GetDAQDataWave()] override wave getter for the ITC data wave
 /// @param config      ITC config wave
 /// @param configFunc  [optional, defaults to GetITCChanConfigWave()] override wave getter for the ITC config wave
 /// @param offset      [optional, defaults to zero] offset into the data wave in points
@@ -2003,7 +2003,7 @@ Function HW_NI_PrepareAcq(deviceID, [data, dataFunc, config, configFunc, flags, 
 
 	if(ParamIsDefault(data))
 		if(ParamIsDefault(dataFunc))
-			WAVE/WAVE NIDataWave = GetHardwareDataWave(panelTitle)
+			WAVE/WAVE NIDataWave = GetDAQDataWave(panelTitle)
 		else
 			WAVE/WAVE NIDataWave = dataFunc(panelTitle)
 		endif

--- a/Packages/MIES/MIES_DAC-Hardware.ipf
+++ b/Packages/MIES/MIES_DAC-Hardware.ipf
@@ -86,25 +86,26 @@ static Constant HW_ITC_RUNNING_STATE = 0x10
 /// @brief Prepare for data acquisition
 ///
 /// @param hardwareType One of @ref HardwareDACTypeConstants
-/// @param deviceID    device identifier
-/// @param data        hardware data wave
-/// @param dataFunc    [optional, defaults to GetITCDataWave()] override wave getter for the ITC data wave
-/// @param config      ITC config wave
-/// @param configFunc  [optional, defaults to GetITCChanConfigWave()] override wave getter for the ITC config wave
-/// @param flags       [optional, default none] One or multiple flags from @ref HardwareInteractionFlags
-/// @param offset      [optional, defaults to zero] offset into the data wave in points
-Function HW_PrepareAcq(hardwareType, deviceID, [data, dataFunc, config, configFunc, flags, offset])
-	variable hardwareType, deviceID
+/// @param deviceID     device identifier
+/// @param mode         one of #DATA_ACQUISITION_MODE or #TEST_PULSE_MODE
+/// @param data         hardware data wave
+/// @param dataFunc     [optional, defaults to GetDAQDataWave()] override wave getter for the ITC data wave
+/// @param config       ITC config wave
+/// @param configFunc   [optional, defaults to GetITCChanConfigWave()] override wave getter for the ITC config wave
+/// @param flags        [optional, default none] One or multiple flags from @ref HardwareInteractionFlags
+/// @param offset       [optional, defaults to zero] offset into the data wave in points
+Function HW_PrepareAcq(hardwareType, deviceID, mode, [data, dataFunc, config, configFunc, flags, offset])
+	variable hardwareType, deviceID, mode
 	WAVE/Z data, config
 	FUNCREF HW_WAVE_GETTER_PROTOTYPE dataFunc, configFunc
 	variable flags, offset
 
 	switch(hardwareType)
 		case HARDWARE_ITC_DAC:
-			return HW_ITC_PrepareAcq(deviceID, flags=flags)
+			return HW_ITC_PrepareAcq(deviceID, mode, flags=flags)
 			break
 		case HARDWARE_NI_DAC:
-			return HW_NI_PrepareAcq(deviceID, flags=flags)
+			return HW_NI_PrepareAcq(deviceID, mode, flags=flags)
 			break
 	endswitch
 	return 0
@@ -1362,12 +1363,13 @@ End
 /// @param deviceID    device identifier
 /// @param data        ITC data wave
 /// @param dataFunc    [optional, defaults to GetDAQDataWave()] override wave getter for the ITC data wave
+/// @param mode        one of #DATA_ACQUISITION_MODE or #TEST_PULSE_MODE
 /// @param config      ITC config wave
 /// @param configFunc  [optional, defaults to GetITCChanConfigWave()] override wave getter for the ITC config wave
 /// @param offset      [optional, defaults to zero] offset into the data wave in points
 /// @param flags       [optional, default none] One or multiple flags from @ref HardwareInteractionFlags
-Function HW_ITC_PrepareAcq(deviceID, [data, dataFunc, config, configFunc, flags, offset])
-	variable deviceID
+Function HW_ITC_PrepareAcq(deviceID, mode, [data, dataFunc, config, configFunc, flags, offset])
+	variable deviceID, mode
 	WAVE/Z data, config
 	FUNCREF HW_WAVE_GETTER_PROTOTYPE dataFunc, configFunc
 	variable flags, offset
@@ -1380,7 +1382,7 @@ Function HW_ITC_PrepareAcq(deviceID, [data, dataFunc, config, configFunc, flags,
 
 	if(ParamIsDefault(data))
 		if(ParamIsDefault(dataFunc))
-			WAVE data = GetDAQDataWave(panelTitle)
+			WAVE data = GetDAQDataWave(panelTitle, mode)
 		else
 			WAVE data = dataFunc(panelTitle)
 		endif
@@ -1706,8 +1708,8 @@ Function HW_ITC_DebugMode(state, [flags])
 	DEBUGPRINT("Unimplemented")
 End
 
-Function HW_ITC_PrepareAcq(deviceID, [data, dataFunc, config, configFunc, flags, offset])
-	variable deviceID
+Function HW_ITC_PrepareAcq(deviceID, mode, [data, dataFunc, config, configFunc, flags, offset])
+	variable deviceID, mode
 	WAVE/Z data, config
 	FUNCREF HW_WAVE_GETTER_PROTOTYPE dataFunc, configFunc
 	variable flags, offset
@@ -1981,14 +1983,15 @@ End
 /// @brief Prepare for data acquisition
 ///
 /// @param deviceID    device identifier
+/// @param mode        one of #DATA_ACQUISITION_MODE or #TEST_PULSE_MODE
 /// @param data        ITC data wave
 /// @param dataFunc    [optional, defaults to GetDAQDataWave()] override wave getter for the ITC data wave
 /// @param config      ITC config wave
 /// @param configFunc  [optional, defaults to GetITCChanConfigWave()] override wave getter for the ITC config wave
 /// @param offset      [optional, defaults to zero] offset into the data wave in points
 /// @param flags       [optional, default none] One or multiple flags from @ref HardwareInteractionFlags
-Function HW_NI_PrepareAcq(deviceID, [data, dataFunc, config, configFunc, flags, offset])
-	variable deviceID
+Function HW_NI_PrepareAcq(deviceID, mode, [data, dataFunc, config, configFunc, flags, offset])
+	variable deviceID, mode
 	WAVE/Z data, config
 	FUNCREF HW_WAVE_GETTER_PROTOTYPE dataFunc, configFunc
 	variable flags, offset
@@ -2003,7 +2006,7 @@ Function HW_NI_PrepareAcq(deviceID, [data, dataFunc, config, configFunc, flags, 
 
 	if(ParamIsDefault(data))
 		if(ParamIsDefault(dataFunc))
-			WAVE/WAVE NIDataWave = GetDAQDataWave(panelTitle)
+			WAVE/WAVE NIDataWave = GetDAQDataWave(panelTitle, mode)
 		else
 			WAVE/WAVE NIDataWave = dataFunc(panelTitle)
 		endif
@@ -2758,8 +2761,9 @@ Function HW_NI_StartAcq(deviceID, triggerMode, [flags, repeat])
 	DoAbortNow("NI-DAQ XOP is not available")
 End
 
-Function HW_NI_PrepareAcq(deviceID, [data, dataFunc, config, configFunc, flags, offset])
+Function HW_NI_PrepareAcq(deviceID, mode, [data, dataFunc, config, configFunc, flags, offset])
 	variable deviceID
+	variable mode
 	WAVE/Z data, config
 	FUNCREF HW_WAVE_GETTER_PROTOTYPE dataFunc, configFunc
 	variable flags, offset

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -2510,7 +2510,7 @@ Function DAP_CheckSettings(panelTitle, mode)
 
 		// unlock DAQDataWave, this happens if user functions error out and we don't catch it
 		// note: seems to work even if WAVE/WAVE would be required for NI
-		WAVE DAQDataWave = GetDAQDataWave(panelTitle)
+		WAVE DAQDataWave = GetDAQDataWave(panelTitle, mode)
 		if(NumberByKey("LOCK", WaveInfo(DAQDataWave, 0)))
 			printf "(%s) Removing leftover lock on DAQDataWave\r", panelTitle
 			ControlWindowToFront()

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -2508,13 +2508,13 @@ Function DAP_CheckSettings(panelTitle, mode)
 			endif
 		endif
 
-		// unlock ITCDataWave, this happens if user functions error out and we don't catch it
+		// unlock DAQDataWave, this happens if user functions error out and we don't catch it
 		// note: seems to work even if WAVE/WAVE would be required for NI
-		WAVE HardwareDataWave = GetHardwareDataWave(panelTitle)
-		if(NumberByKey("LOCK", WaveInfo(HardwareDataWave, 0)))
-			printf "(%s) Removing leftover lock on ITCDataWave\r", panelTitle
+		WAVE DAQDataWave = GetDAQDataWave(panelTitle)
+		if(NumberByKey("LOCK", WaveInfo(DAQDataWave, 0)))
+			printf "(%s) Removing leftover lock on DAQDataWave\r", panelTitle
 			ControlWindowToFront()
-			SetWaveLock 0, HardwareDataWave
+			SetWaveLock 0, DAQDataWave
 		endif
 	endfor
 

--- a/Packages/MIES/MIES_DataAcquisition_Multi.ipf
+++ b/Packages/MIES/MIES_DataAcquisition_Multi.ipf
@@ -44,7 +44,7 @@ Function DQM_FIFOMonitor(s)
 						continue // no new data -> next device
 					endif
 
-					WAVE/WAVE NIDataWave = GetDAQDataWave(panelTitle)
+					WAVE/WAVE NIDataWave = GetDAQDataWave(panelTitle, DATA_ACQUISITION_MODE)
 					for(j = 0; j < V_FIFOnchans; j += 1)
 
 						fifoChannelName = StringByKey("NAME" + num2str(j), S_Info)
@@ -188,7 +188,7 @@ Function DQM_StartDAQMultiDevice(panelTitle, [initialSetupReq])
 
 	// configure passed device
 	NVAR ITCDeviceIDGlobal = $GetITCDeviceIDGlobal(panelTitle)
-	HW_PrepareAcq(GetHardwareType(panelTitle), ITCDeviceIDGlobal, flags=HARDWARE_ABORT_ON_ERROR)
+	HW_PrepareAcq(GetHardwareType(panelTitle), ITCDeviceIDGlobal, DATA_ACQUISITION_MODE, flags=HARDWARE_ABORT_ON_ERROR)
 
 	if(!DeviceHasFollower(panelTitle))
 		DAP_UpdateITIAcrossSets(panelTitle, maxITI)
@@ -237,7 +237,7 @@ Function DQM_StartDAQMultiDevice(panelTitle, [initialSetupReq])
 		followerPanelTitle = StringFromList(i, listOfFollowerDevices)
 
 		NVAR ITCDeviceIDGlobal = $GetITCDeviceIDGlobal(followerPanelTitle)
-		HW_ITC_PrepareAcq(ITCDeviceIDGlobal, flags=HARDWARE_ABORT_ON_ERROR)
+		HW_ITC_PrepareAcq(ITCDeviceIDGlobal, DATA_ACQUISITION_MODE, flags=HARDWARE_ABORT_ON_ERROR)
 	endfor
 
 	// start lead device

--- a/Packages/MIES/MIES_DataAcquisition_Multi.ipf
+++ b/Packages/MIES/MIES_DataAcquisition_Multi.ipf
@@ -44,7 +44,7 @@ Function DQM_FIFOMonitor(s)
 						continue // no new data -> next device
 					endif
 
-					WAVE/WAVE NIDataWave = GetHardwareDataWave(panelTitle)
+					WAVE/WAVE NIDataWave = GetDAQDataWave(panelTitle)
 					for(j = 0; j < V_FIFOnchans; j += 1)
 
 						fifoChannelName = StringByKey("NAME" + num2str(j), S_Info)

--- a/Packages/MIES/MIES_DataAcquisition_Single.ipf
+++ b/Packages/MIES/MIES_DataAcquisition_Single.ipf
@@ -54,7 +54,7 @@ Function DQS_DataAcq(panelTitle)
 
 	NVAR ITCDeviceIDGlobal = $GetITCDeviceIDGlobal(panelTitle)
 
-	HW_PrepareAcq(HARDWARE_ITC_DAC, ITCDeviceIDGlobal, flags=HARDWARE_ABORT_ON_ERROR)
+	HW_PrepareAcq(HARDWARE_ITC_DAC, ITCDeviceIDGlobal, DATA_ACQUISITION_MODE, flags=HARDWARE_ABORT_ON_ERROR)
 
 	if(DAG_GetNumericalValue(panelTitle, "Check_DataAcq1_RepeatAcq"))
 		DQ_StartITCDeviceTimer(panelTitle) // starts a timer for each ITC device. Timer is used to do real time ITI timing.
@@ -92,7 +92,7 @@ Function DQS_BkrdDataAcq(panelTitle)
 	string panelTitle
 
 	NVAR ITCDeviceIDGlobal = $GetITCDeviceIDGlobal(panelTitle)
-	HW_PrepareAcq(HARDWARE_ITC_DAC, ITCDeviceIDGlobal, flags=HARDWARE_ABORT_ON_ERROR)
+	HW_PrepareAcq(HARDWARE_ITC_DAC, ITCDeviceIDGlobal, DATA_ACQUISITION_MODE, flags=HARDWARE_ABORT_ON_ERROR)
 
 	if(DAG_GetNumericalValue(panelTitle, "Check_DataAcq1_RepeatAcq"))
 		DQ_StartITCDeviceTimer(panelTitle) // starts a timer for each ITC device. Timer is used to do real time ITI timing.

--- a/Packages/MIES/MIES_DataConfiguratorITC.ipf
+++ b/Packages/MIES/MIES_DataConfiguratorITC.ipf
@@ -68,7 +68,7 @@ Function DC_ConfigureDataForITC(panelTitle, dataAcqOrTP, [multiDevice])
 		endif
 	endif
 
-	// prevent crash in ITC XOP as it must not run if we resize the ITCDataWave
+	// prevent crash in ITC XOP as it must not run if we resize the DAQDataWave
 	NVAR ITCDeviceIDGlobal = $GetITCDeviceIDGlobal(panelTitle)
 	variable hardwareType = GetHardwareType(panelTitle)
 	ASSERT(!HW_IsRunning(hardwareType, ITCDeviceIDGlobal, flags=HARDWARE_ABORT_ON_ERROR | HARDWARE_PREVENT_ERROR_POPUP), "Hardware is still running and it shouldn't. Please report that as a bug.")
@@ -91,7 +91,7 @@ Function DC_ConfigureDataForITC(panelTitle, dataAcqOrTP, [multiDevice])
 		TP_CreateTestPulseWave(panelTitle)
 	endif
 
-	DC_PlaceDataInHardwareDataWave(panelTitle, numActiveChannels, dataAcqOrTP, multiDevice)
+	DC_PlaceDataInDAQDataWave(panelTitle, numActiveChannels, dataAcqOrTP, multiDevice)
 
 	WAVE ITCChanConfigWave = GetITCChanConfigWave(panelTitle)
 	WAVE ADCs = GetADCListFromConfig(ITCChanConfigWave)
@@ -111,10 +111,10 @@ Function DC_ConfigureDataForITC(panelTitle, dataAcqOrTP, [multiDevice])
 		AFM_CallAnalysisFunctions(panelTitle, PRE_SWEEP_EVENT)
 	endif
 
-	WAVE HardwareDataWave = GetHardwareDataWave(panelTitle)
+	WAVE DAQDataWave = GetDAQDataWave(panelTitle)
 	WAVE ITCChanConfigWave = GetITCChanConfigWave(panelTitle)
 
-	ASSERT(IsValidSweepAndConfig(HardwareDataWave, ITCChanConfigWave), "Invalid sweep and config combination")
+	ASSERT(IsValidSweepAndConfig(DAQDataWave, ITCChanConfigWave), "Invalid sweep and config combination")
 End
 
 static Function DC_UpdateHSProperties(panelTitle, ADCs)
@@ -256,8 +256,8 @@ static Function DC_LongestOutputWave(panelTitle, dataAcqOrTP, channelType)
 		   && DAG_GetNumericalValue(panelTitle, "check_Settings_MD"))
 			// ITC hardware requires us to use a pulse train for TP MD,
 			// so we need to determine the number of TP pulses here (numPulses)
-			// In DC_PlaceDataInHardwareDataWave we write as many pulses into the
-			// HardwareDataWave which fit in
+			// In DC_PlaceDataInDAQDataWave we write as many pulses into the
+			// DAQDataWave which fit in
 			singlePulseLength = DimSize(wv, ROWS)
 			numPulses = max(10, ceil((2^(MINIMUM_ITCDATAWAVE_EXPONENT + 1) * 0.90) / singlePulseLength))
 			maxNumRows = max(maxNumRows, numPulses * singlePulseLength)
@@ -269,14 +269,18 @@ static Function DC_LongestOutputWave(panelTitle, dataAcqOrTP, channelType)
 	return maxNumRows
 End
 
-//// @brief Calculate the required length of the ITCDataWave
+//// @brief Calculate the required length of the DAQDataWave
 ///
-/// The ITCdatawave length = 2^x where is the first integer large enough to contain the longest output wave plus one.
-/// X also has a minimum value of 17 to ensure sufficient time for communication with the ITC device to prevent FIFO overflow or underrun.
+/// ITC Hardware:
+/// - The DAQDataWave length = 2^x where is the first integer large enough to contain the longest output wave plus one.
+///   X also has a minimum value of 17 to ensure sufficient time for communication with the ITC device to prevent FIFO overflow or underrun.
+///
+/// NI Hardware:
+/// - Returns stopCollectionPoint
 ///
 /// @param panelTitle  panel title
 /// @param dataAcqOrTP acquisition mode, one of #DATA_ACQUISITION_MODE or #TEST_PULSE_MODE
-static Function DC_CalculateITCDataWaveLength(panelTitle, dataAcqOrTP)
+static Function DC_CalculateDAQDataWaveLength(panelTitle, dataAcqOrTP)
 	string panelTitle
 	variable dataAcqOrTP
 
@@ -318,7 +322,7 @@ static Function DC_MakeITCConfigAllConfigWave(panelTitle, numActiveChannels)
 	ASSERT(IsValidConfigWave(config), "Invalid config wave")
 End
 
-/// @brief Creates HardwareDataWave; The wave that the device takes DA and TTL data from and passes AD data to for all channels.
+/// @brief Creates DAQDataWave; The wave that the device takes DA and TTL data from and passes AD data to for all channels.
 ///
 /// Config all refers to configuring all the channels at once
 ///
@@ -327,13 +331,13 @@ End
 /// @param numActiveChannels   number of active channels as returned by DC_ChanCalcForITCChanConfigWave()
 /// @param samplingInterval    sampling interval as returned by DAP_GetSampInt()
 /// @param dataAcqOrTP         one of #DATA_ACQUISITION_MODE or #TEST_PULSE_MODE
-static Function [WAVE/Z ITCDataWave, WAVE/WAVE NIDataWave] DC_MakeAndGetHardwareDataWave(string panelTitle, variable hardwareType, variable numActiveChannels, variable samplingInterval, variable dataAcqOrTP)
+static Function [WAVE/Z DAQDataWave, WAVE/WAVE NIDataWave] DC_MakeAndGetDAQDataWave(string panelTitle, variable hardwareType, variable numActiveChannels, variable samplingInterval, variable dataAcqOrTP)
 	variable numRows, i
 
-	numRows = DC_CalculateITCDataWaveLength(panelTitle, dataAcqOrTP)
+	numRows = DC_CalculateDAQDataWaveLength(panelTitle, dataAcqOrTP)
 	switch(hardwareType)
 		case HARDWARE_ITC_DAC:
-			WAVE ITCDataWave = GetHardwareDataWave(panelTitle)
+			WAVE ITCDataWave = GetDAQDataWave(panelTitle)
 
 			Redimension/N=(numRows, numActiveChannels) ITCDataWave
 
@@ -343,7 +347,7 @@ static Function [WAVE/Z ITCDataWave, WAVE/WAVE NIDataWave] DC_MakeAndGetHardware
 			return [ITCDataWave, $""]
 			break
 		case HARDWARE_NI_DAC:
-			WAVE/WAVE NIDataWave = GetHardwareDataWave(panelTitle)
+			WAVE/WAVE NIDataWave = GetDAQDataWave(panelTitle)
 			Redimension/N=(numActiveChannels) NIDataWave
 
 			SetScale/P x 0, samplingInterval / 1000, "ms", NIDataWave
@@ -398,8 +402,8 @@ static Function DC_MakeHelperWaves(panelTitle, dataAcqOrTP)
 	WAVE OscilloscopeData = GetOscilloscopeWave(panelTitle)
 	WAVE TPOscilloscopeData = GetTPOscilloscopeWave(panelTitle)
 	WAVE scaledDataWave = GetScaledDataWave(panelTitle)
-	WAVE ITCDataWave = GetHardwareDataWave(panelTitle)
-	WAVE/WAVE NIDataWave = GetHardwareDataWave(panelTitle)
+	WAVE ITCDataWave = GetDAQDataWave(panelTitle)
+	WAVE/WAVE NIDataWave = GetDAQDataWave(panelTitle)
 
 	tpLength = ROVAR(GetTestPulseLengthInPoints(panelTitle, TEST_PULSE_MODE))
 	hardwareType = GetHardwareType(panelTitle)
@@ -767,7 +771,7 @@ static Function DC_CalculateGeneratedDataSize(panelTitle, dataAcqOrTP, genLength
 	endif
 End
 
-/// @brief Places data from appropriate DA and TTL stimulus set(s) into HardwareDataWave.
+/// @brief Places data from appropriate DA and TTL stimulus set(s) into DAQDataWave.
 /// Also records certain DA_Ephys GUI settings into sweepDataLNB and sweepDataTxTLNB
 /// @param panelTitle        panel title
 /// @param numActiveChannels number of active channels as returned by DC_ChanCalcForITCChanConfigWave()
@@ -775,7 +779,7 @@ End
 /// @param multiDevice       Fine tune data handling for single device (false) or multi device (true)
 ///
 /// @exception Abort configuration failure
-static Function DC_PlaceDataInHardwareDataWave(panelTitle, numActiveChannels, dataAcqOrTP, multiDevice)
+static Function DC_PlaceDataInDAQDataWave(panelTitle, numActiveChannels, dataAcqOrTP, multiDevice)
 	string panelTitle
 	variable numActiveChannels, dataAcqOrTP, multiDevice
 
@@ -1103,7 +1107,7 @@ static Function DC_PlaceDataInHardwareDataWave(panelTitle, numActiveChannels, da
 		s.hardwareType = hardwareType
 		s.numDACs = numDACEntries
 		s.numActiveChannels = numActiveChannels
-		s.numberOfRows = DC_CalculateITCDataWaveLength(panelTitle, TEST_PULSE_MODE)
+		s.numberOfRows = DC_CalculateDAQDataWaveLength(panelTitle, TEST_PULSE_MODE)
 		s.samplingInterval = samplingInterval
 		WAVE s.DAGain = DAGain
 		Duplicate/FREE/RMD=[][FindDimLabel(DACAmp, COLS, "TPAMP")] DACAmp, DACAmpTP
@@ -1116,7 +1120,7 @@ static Function DC_PlaceDataInHardwareDataWave(panelTitle, numActiveChannels, da
 		WAVE/Z result = CA_TryFetchingEntryFromCache(key)
 
 		if(WaveExists(result))
-			WAVE DAQDataWave = GetHardwareDataWave(panelTitle)
+			WAVE DAQDataWave = GetDAQDataWave(panelTitle)
 			if(IsWaveRefWave(DAQDataWave))
 				WAVE/WAVE DAQDataWaveRef = DAQDataWave
 				Redimension/N=(numActiveChannels) DAQDataWaveRef
@@ -1127,7 +1131,7 @@ static Function DC_PlaceDataInHardwareDataWave(panelTitle, numActiveChannels, da
 			WAVE/Z ITCDataWave
 			WAVE/WAVE/Z NIDataWave
 
-			[ITCDataWave, NIDataWave] = DC_MakeAndGetHardwareDataWave(panelTitle, hardwareType, numActiveChannels, \
+			[ITCDataWave, NIDataWave] = DC_MakeAndGetDAQDataWave(panelTitle, hardwareType, numActiveChannels, \
 																				   samplingInterval, dataAcqOrTP)
 
 			switch(hardwareType)
@@ -1172,7 +1176,7 @@ static Function DC_PlaceDataInHardwareDataWave(panelTitle, numActiveChannels, da
 		WAVE/Z ITCDataWave
 		WAVE/WAVE/Z NIDataWave
 
-		[ITCDataWave, NIDataWave] = DC_MakeAndGetHardwareDataWave(panelTitle, hardwareType, numActiveChannels, \
+		[ITCDataWave, NIDataWave] = DC_MakeAndGetDAQDataWave(panelTitle, hardwareType, numActiveChannels, \
 																			   samplingInterval, dataAcqOrTP)
 
 		for(i = 0; i < numDACEntries; i += 1)
@@ -1524,14 +1528,13 @@ static Function DC_GenerateStimsetFingerprint(raCycleID, setName, setCycleCount,
 	return crc
 End
 
-static Function DC_CheckIfDataWaveHasBorderVals(panelTitle)
-	string panelTitle
+static Function DC_CheckIfDataWaveHasBorderVals(string panelTitle)
 
 	variable hardwareType = GetHardwareType(panelTitle)
 	switch(hardwareType)
 		case HARDWARE_ITC_DAC:
-			WAVE/Z ITCDataWave = GetHardwareDataWave(panelTitle)
-			ASSERT(WaveExists(ITCDataWave), "Missing HardwareDataWave")
+			WAVE/Z ITCDataWave = GetDAQDataWave(panelTitle)
+			ASSERT(WaveExists(ITCDataWave), "Missing DAQDataWave")
 			ASSERT(WaveType(ITCDataWave) == IGOR_TYPE_16BIT_INT, "Unexpected wave type: " + num2str(WaveType(ITCDataWave)))
 
 			FindValue/UOFV/I=(SIGNED_INT_16BIT_MIN) ITCDataWave
@@ -1549,7 +1552,7 @@ static Function DC_CheckIfDataWaveHasBorderVals(panelTitle)
 			return 0
 			break
 		case HARDWARE_NI_DAC:
-			WAVE/WAVE NIDataWave = GetHardwareDataWave(panelTitle)
+			WAVE/WAVE NIDataWave = GetDAQDataWave(panelTitle)
 			ASSERT(IsWaveRefWave(NIDataWave), "Unexpected wave type")
 			variable channels = numpnts(NIDataWave)
 			variable i
@@ -1853,7 +1856,7 @@ static Function [variable column, variable setCycleCount] DC_CalculateChannelCol
 	return [column, setCycleCount]
 End
 
-/// @brief Returns the length increase of the ITCDataWave following onset/termination delay insertion and
+/// @brief Returns the length increase of the DAQDataWave following onset/termination delay insertion and
 /// distributed data aquisition. Does not incorporate adaptations for oodDAQ.
 ///
 /// All returned values are in number of points, *not* in time.

--- a/Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf
+++ b/Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf
@@ -343,7 +343,7 @@ End
 
 /// @brief Return the ADC to monitor
 ///
-/// This is the first actice AD channel in ITCDataWave and ITCChanConfigWave.
+/// This is the first actice AD channel in DAQDataWave and ITCChanConfigWave.
 Function/S GetADChannelToMonitor(panelTitle)
 	string panelTitle
 

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -5841,7 +5841,7 @@ Function UpdateLeftOverSweepTime(panelTitle, fifoPos)
 
 	ASSERT(IsFinite(fifoPos), "Unexpected non-finite fifoPos")
 
-	WAVE DAQDataWave         = GetDAQDataWave(panelTitle)
+	WAVE DAQDataWave         = GetDAQDataWave(panelTitle, DATA_ACQUISITION_MODE)
 	NVAR repurposedTime      = $GetRepurposedSweepTime(panelTitle)
 	NVAR stopCollectionPoint = $GetStopCollectionPoint(panelTitle)
 

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -2409,7 +2409,7 @@ Function CreateTiledChannelGraph(string graph, WAVE config, variable sweepNo, WA
 	numADCs = DimSize(ADCs, ROWS)
 	numTTLs = DimSize(TTLs, ROWS)
 
-	// introduced in db531d20 (DC_PlaceDataInITCDataWave: Document the digitizer hardware type, 2018-07-30)
+	// introduced in db531d20 (DC_PlaceDataIn ITCDataWave: Document the digitizer hardware type, 2018-07-30)
 	// before that we only had ITC hardware
 	hardwareType           = GetLastSettingIndep(numericalValues, sweepNo, "Digitizer Hardware Type", DATA_ACQUISITION_MODE, defValue = HARDWARE_ITC_DAC)
 	WAVE/Z statusHS        = GetLastSetting(numericalValues, sweepNo, "Headstage Active", DATA_ACQUISITION_MODE)
@@ -5660,11 +5660,11 @@ Function StartZeroMQMessageHandler()
 #endif
 End
 
-/// @brief Split an ITCDataWave into one 1D-wave per channel/ttlBit
+/// @brief Split an DAQDataWave into one 1D-wave per channel/ttlBit
 ///
 /// @param numericalValues numerical labnotebook
 /// @param sweep           sweep number
-/// @param sweepWave       ITCDataWave
+/// @param sweepWave       DAQDataWave
 /// @param configWave      ITCChanConfigWave
 /// @param targetDFR       [optional, defaults to the sweep wave DFR] datafolder where to put the waves, can be a free datafolder
 /// @param rescale         One of @ref TTLRescalingOptions
@@ -5841,11 +5841,11 @@ Function UpdateLeftOverSweepTime(panelTitle, fifoPos)
 
 	ASSERT(IsFinite(fifoPos), "Unexpected non-finite fifoPos")
 
-	WAVE ITCDataWave         = GetHardwareDataWave(panelTitle)
+	WAVE DAQDataWave         = GetDAQDataWave(panelTitle)
 	NVAR repurposedTime      = $GetRepurposedSweepTime(panelTitle)
 	NVAR stopCollectionPoint = $GetStopCollectionPoint(panelTitle)
 
-	repurposedTime += max(0, IndexToScale(ITCDataWave, stopCollectionPoint - fifoPos, ROWS)) / 1e3
+	repurposedTime += max(0, IndexToScale(DAQDataWave, stopCollectionPoint - fifoPos, ROWS)) / 1e3
 
 	sprintf msg, "Repurposed time in seconds due to premature sweep stopping: %g\r", repurposedTime
 	DEBUGPRINT(msg)
@@ -6032,7 +6032,7 @@ threadsafe Function IsValidConfigWave(config, [version])
 	return 0
 End
 
-/// @brief Check if the given wave is a valid HardwareDataWave
+/// @brief Check if the given wave is a valid DAQDataWave
 threadsafe Function IsValidSweepWave(sweep)
 	WAVE/Z sweep
 

--- a/Packages/MIES/MIES_Oscilloscope.ipf
+++ b/Packages/MIES/MIES_Oscilloscope.ipf
@@ -629,7 +629,7 @@ static Function SCOPE_NI_UpdateOscilloscope(panelTitle, dataAcqOrTP, deviceiD, f
 
 	WAVE scaledDataWave    = GetScaledDataWave(panelTitle)
 	WAVE OscilloscopeData = GetOscilloscopeWave(panelTitle)
-	WAVE/WAVE NIDataWave = GetDAQDataWave(panelTitle)
+	WAVE/WAVE NIDataWave = GetDAQDataWave(panelTitle, dataAcqOrTP)
 
 	fifoName = GetNIFIFOName(deviceID)
 	FIFOStatus/Q $fifoName
@@ -677,7 +677,7 @@ static Function SCOPE_ITC_UpdateOscilloscope(panelTitle, dataAcqOrTP, chunk, fif
 	variable length, first, last
 	variable startOfADColumns, numEntries, decMethod, decFactor
 	WAVE scaledDataWave    = GetScaledDataWave(panelTitle)
-	WAVE DAQDataWave       = GetDAQDataWave(panelTitle)
+	WAVE DAQDataWave       = GetDAQDataWave(panelTitle, dataAcqOrTP)
 	WAVE ITCChanConfigWave = GetITCChanConfigWave(panelTitle)
 	WAVE ADCs = GetADCListFromConfig(ITCChanConfigWave)
 	startOfADColumns = DimSize(GetDACListFromConfig(ITCChanConfigWave), ROWS)

--- a/Packages/MIES/MIES_PressureControl.ipf
+++ b/Packages/MIES/MIES_PressureControl.ipf
@@ -1053,7 +1053,7 @@ static Function P_DataAcq(panelTitle, headStage)
 	pressureDataWv[headStage][%OngoingPessurePulse] = 1 // record headstage with ongoing pressure pulse
 
 	if(hwType == HARDWARE_ITC_DAC)
-		HW_ITC_PrepareAcq(deviceID, dataFunc=P_GetITCData, configFunc=P_GetITCChanConfig)
+		HW_ITC_PrepareAcq(deviceID, UNKNOWN_MODE, dataFunc=P_GetITCData, configFunc=P_GetITCChanConfig)
 		HW_StartAcq(hwType, deviceID, flags=HARDWARE_ABORT_ON_ERROR)
 
 		CtrlNamedBackground P_ITC_FIFOMonitor, start

--- a/Packages/MIES/MIES_SamplingInterval.ipf
+++ b/Packages/MIES/MIES_SamplingInterval.ipf
@@ -292,7 +292,7 @@ Function SI_CreateLookupWave(panelTitle, [ignoreChannelOrder])
 
 	DC_ConfigureDataForITC(panelTitle, DATA_ACQUISITION_MODE)
 
-	WAVE DAQDataWave = GetDAQDataWave(panelTitle)
+	WAVE DAQDataWave = GetDAQDataWave(panelTitle, DATA_ACQUISITION_MODE)
 	WAVE ITCChanConfigWave = GetITCChanConfigWave(panelTitle)
 
 	NVAR ITCDeviceIDGlobal = $GetITCDeviceIDGlobal(panelTitle)
@@ -440,7 +440,7 @@ static Function SI_TestSampInt(panelTitle)
 	variable numConsecutive = -1
 	variable numTries = 1001
 
-	WAVE DAQDataWave = GetDAQDataWave(panelTitle)
+	WAVE DAQDataWave = GetDAQDataWave(panelTitle, DATA_ACQUISITION_MODE)
 	WAVE ITCChanConfigWave = GetITCChanConfigWave(panelTitle)
 	numChannels = DimSize(ITCChanConfigWave, ROWS)
 

--- a/Packages/MIES/MIES_SamplingInterval.ipf
+++ b/Packages/MIES/MIES_SamplingInterval.ipf
@@ -292,7 +292,7 @@ Function SI_CreateLookupWave(panelTitle, [ignoreChannelOrder])
 
 	DC_ConfigureDataForITC(panelTitle, DATA_ACQUISITION_MODE)
 
-	WAVE ITCDataWave = GetHardwareDataWave(panelTitle)
+	WAVE DAQDataWave = GetDAQDataWave(panelTitle)
 	WAVE ITCChanConfigWave = GetITCChanConfigWave(panelTitle)
 
 	NVAR ITCDeviceIDGlobal = $GetITCDeviceIDGlobal(panelTitle)
@@ -362,7 +362,7 @@ Function SI_CreateLookupWave(panelTitle, [ignoreChannelOrder])
 				numChannels += results[idx][%numADRack1]  + results[idx][%numADRack2]
 				numChannels += results[idx][%numTTLRack1] + results[idx][%numTTLRack2]
 
-				Redimension/N=(-1, numChannels) ITCDataWave
+				Redimension/N=(-1, numChannels) DAQDataWave
 				Redimension/N=(numChannels, -1) ITCChanConfigWave
 
 				if(!mod(idx,1000))
@@ -403,7 +403,7 @@ Function SI_CreateLookupWave(panelTitle, [ignoreChannelOrder])
 				continue
 			endif
 
-			Redimension/N=(-1, numChannels) ITCDataWave
+			Redimension/N=(-1, numChannels) DAQDataWave
 			Redimension/N=(numChannels, -1) ITCChanConfigWave
 
 			numDA  = PopCount(DA)
@@ -440,7 +440,7 @@ static Function SI_TestSampInt(panelTitle)
 	variable numConsecutive = -1
 	variable numTries = 1001
 
-	WAVE ITCDataWave = GetHardwareDataWave(panelTitle)
+	WAVE DAQDataWave = GetDAQDataWave(panelTitle)
 	WAVE ITCChanConfigWave = GetITCChanConfigWave(panelTitle)
 	numChannels = DimSize(ITCChanConfigWave, ROWS)
 
@@ -456,7 +456,7 @@ static Function SI_TestSampInt(panelTitle)
 		ITCChanConfigWave[][2] = sampInt
 
 		WAVE config_t = HW_ITC_TransposeAndToDouble(ITCChanConfigWave)
-		ITCConfigAllChannels2/Z config_t, ITCDataWave
+		ITCConfigAllChannels2/Z config_t, DAQDataWave
 
 		if(!V_ITCError)
 			// we could set the sampling interval

--- a/Packages/MIES/MIES_Structures.ipf
+++ b/Packages/MIES/MIES_Structures.ipf
@@ -227,7 +227,7 @@ Structure OOdDAQParams
 	///@{
 	WAVE offsets               ///< Result of the optimization in points
 	WAVE/T regions             ///< List of the form `%begin-%end;...` which denotes the x-coordinates of
-	                           ///< the smeared regions in units of time of the ITCDataWave. @sa OOD_GetFeatureRegions()
+	                           ///< the smeared regions in units of time of the DAQDataWave. @sa OOD_GetFeatureRegions()
 	///@}
 EndStructure
 
@@ -238,7 +238,7 @@ Structure AnalysisFunction_V3
 
 	/// raw data wave for interacting with the DAC hardware (locked to prevent
 	/// changes using `SetWaveLock`). The exact wave format depends on the hardware.
-	/// @sa GetHardwareDataWave()
+	/// @sa GetDAQDataWave()
 	WAVE rawDACWave
 
 	/// scaled and undecimated data from the DAC hardware, 2D floating-point wave

--- a/Packages/MIES/MIES_SweepSaving.ipf
+++ b/Packages/MIES/MIES_SweepSaving.ipf
@@ -24,7 +24,7 @@ Function SWS_SaveAcquiredData(panelTitle, [forcedStop])
 
 	sweepNo = DAG_GetNumericalValue(panelTitle, "SetVar_Sweep")
 
-	WAVE DAQDataWave = GetDAQDataWave(panelTitle)
+	WAVE DAQDataWave = GetDAQDataWave(panelTitle, DATA_ACQUISITION_MODE)
 	WAVE hardwareConfigWave = GetITCChanConfigWave(panelTitle)
 	WAVE scaledDataWave = GetScaledDataWave(panelTitle)
 

--- a/Packages/MIES/MIES_SweepSaving.ipf
+++ b/Packages/MIES/MIES_SweepSaving.ipf
@@ -24,11 +24,11 @@ Function SWS_SaveAcquiredData(panelTitle, [forcedStop])
 
 	sweepNo = DAG_GetNumericalValue(panelTitle, "SetVar_Sweep")
 
-	WAVE hardwareDataWave = GetHardwareDataWave(panelTitle)
+	WAVE DAQDataWave = GetDAQDataWave(panelTitle)
 	WAVE hardwareConfigWave = GetITCChanConfigWave(panelTitle)
 	WAVE scaledDataWave = GetScaledDataWave(panelTitle)
 
-	ASSERT(IsValidSweepAndConfig(hardwareDataWave, hardwareConfigWave), "Data and config wave are not compatible")
+	ASSERT(IsValidSweepAndConfig(DAQDataWave, hardwareConfigWave), "Data and config wave are not compatible")
 
 	DFREF dfr = GetDeviceDataPath(panelTitle)
 
@@ -122,7 +122,7 @@ End
 /// @param panelTitle device
 /// @param timing     One of @ref GainTimeParameter
 ///
-/// @see GetHardwareDataWave()
+/// @see GetDAQDataWave()
 Function/WAVE SWS_GetChannelGains(panelTitle, [timing])
 	string panelTitle
 	variable timing

--- a/Packages/MIES/MIES_TestPulse.ipf
+++ b/Packages/MIES/MIES_TestPulse.ipf
@@ -497,7 +497,7 @@ static Function TP_RecordTP(panelTitle, BaselineSSAvg, InstResistance, SSResista
 	if((now - lastRescaling) > TP_DIMENSION_SCALING_INTERVAL)
 
 		if(!count) // initial estimate
-			WAVE DAQDataWave = GetDAQDataWave(panelTitle)
+			WAVE DAQDataWave = GetDAQDataWave(panelTitle, TEST_PULSE_MODE)
 			delta = ROVAR(GetTestPulseLengthInPoints(panelTitle, TEST_PULSE_MODE)) * DimDelta(DAQDataWave, ROWS) / 1000
 		else
 			delta = TPStorage[count][0][%DeltaTimeInSeconds] / count
@@ -686,7 +686,7 @@ Function TP_Setup(panelTitle, runMode, [fast])
 		runModeGlobal = runMode
 
 		NVAR ITCDeviceIDGlobal = $GetITCDeviceIDGlobal(panelTitle)
-		HW_PrepareAcq(GetHardwareType(panelTitle), ITCDeviceIDGlobal, flags=HARDWARE_ABORT_ON_ERROR)
+		HW_PrepareAcq(GetHardwareType(panelTitle), ITCDeviceIDGlobal, TEST_PULSE_MODE, flags=HARDWARE_ABORT_ON_ERROR)
 		return NaN
 	endif
 
@@ -705,7 +705,7 @@ Function TP_Setup(panelTitle, runMode, [fast])
 	DC_ConfigureDataForITC(panelTitle, TEST_PULSE_MODE, multiDevice=multiDevice)
 
 	NVAR ITCDeviceIDGlobal = $GetITCDeviceIDGlobal(panelTitle)
-	HW_PrepareAcq(GetHardwareType(panelTitle), ITCDeviceIDGlobal, flags=HARDWARE_ABORT_ON_ERROR)
+	HW_PrepareAcq(GetHardwareType(panelTitle), ITCDeviceIDGlobal, TEST_PULSE_MODE, flags=HARDWARE_ABORT_ON_ERROR)
 End
 
 /// @brief Common setup calls for TP and TP during DAQ

--- a/Packages/MIES/MIES_TestPulse.ipf
+++ b/Packages/MIES/MIES_TestPulse.ipf
@@ -497,8 +497,8 @@ static Function TP_RecordTP(panelTitle, BaselineSSAvg, InstResistance, SSResista
 	if((now - lastRescaling) > TP_DIMENSION_SCALING_INTERVAL)
 
 		if(!count) // initial estimate
-			WAVE HardwareDataWave = GetHardwareDataWave(panelTitle)
-			delta = ROVAR(GetTestPulseLengthInPoints(panelTitle, TEST_PULSE_MODE)) * DimDelta(HardwareDataWave, ROWS) / 1000
+			WAVE DAQDataWave = GetDAQDataWave(panelTitle)
+			delta = ROVAR(GetTestPulseLengthInPoints(panelTitle, TEST_PULSE_MODE)) * DimDelta(DAQDataWave, ROWS) / 1000
 		else
 			delta = TPStorage[count][0][%DeltaTimeInSeconds] / count
 		endif

--- a/Packages/MIES/MIES_TestPulse_Multi.ipf
+++ b/Packages/MIES/MIES_TestPulse_Multi.ipf
@@ -218,7 +218,7 @@ Function TPM_BkrdTPFuncMD(s)
 					ASSERT(V_Flag != 0,"FIFO does not exist!")
 					endOfPulse = datapoints * tpCounter + datapoints
 					if(V_FIFOChunks >= endOfPulse)
-						WAVE/WAVE NIDataWave = GetDAQDataWave(panelTitle)
+						WAVE/WAVE NIDataWave = GetDAQDataWave(panelTitle, TEST_PULSE_MODE)
 
 						try
 							ClearRTError()
@@ -251,14 +251,14 @@ Function TPM_BkrdTPFuncMD(s)
 					endif
 					if(V_FIFOChunks > TPM_NI_FIFO_THRESHOLD_SIZE)
 						HW_NI_StopAcq(deviceID)
-						HW_NI_PrepareAcq(deviceID)
+						HW_NI_PrepareAcq(deviceID, TEST_PULSE_MODE)
 						HW_NI_StartAcq(deviceID, HARDWARE_DAC_DEFAULT_TRIGGER)
 						tpCounter = 0
 					endif
 				while(checkAgain)
 			break
 		case HARDWARE_ITC_DAC:
-			WAVE ITCDataWave = GetDAQDataWave(panelTitle)
+			WAVE ITCDataWave = GetDAQDataWave(panelTitle, TEST_PULSE_MODE)
 
 			NVAR tgID = $GetThreadGroupIDFIFO(panelTitle)
 			if(DeviceHasFollower(panelTitle))

--- a/Packages/MIES/MIES_TestPulse_Multi.ipf
+++ b/Packages/MIES/MIES_TestPulse_Multi.ipf
@@ -218,7 +218,7 @@ Function TPM_BkrdTPFuncMD(s)
 					ASSERT(V_Flag != 0,"FIFO does not exist!")
 					endOfPulse = datapoints * tpCounter + datapoints
 					if(V_FIFOChunks >= endOfPulse)
-						WAVE/WAVE NIDataWave = GetHardwareDataWave(panelTitle)
+						WAVE/WAVE NIDataWave = GetDAQDataWave(panelTitle)
 
 						try
 							ClearRTError()
@@ -258,7 +258,7 @@ Function TPM_BkrdTPFuncMD(s)
 				while(checkAgain)
 			break
 		case HARDWARE_ITC_DAC:
-			WAVE ITCDataWave = GetHardwareDataWave(panelTitle)
+			WAVE ITCDataWave = GetDAQDataWave(panelTitle)
 
 			NVAR tgID = $GetThreadGroupIDFIFO(panelTitle)
 			if(DeviceHasFollower(panelTitle))

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -719,26 +719,23 @@ Function/Wave GetDAQDataWave(string panelTitle, variable mode)
 			ASSERT(0, "Invalid dataAcqOrTP")
 	endswitch
 
+	WAVE/W/Z/SDFR=dfr wv = $name
+
+	if(WaveExists(wv))
+		return wv
+	endif
+
 	switch(hardwareType)
 		case HARDWARE_ITC_DAC:
-			WAVE/W/Z/SDFR=dfr wv = $name
-
-			if(WaveExists(wv))
-				return wv
-			endif
-
 			Make/W/N=(1, NUM_DA_TTL_CHANNELS) dfr:$name/Wave=wv
-			return wv
 			break
 		case HARDWARE_NI_DAC:
-			WAVE/WAVE/Z/SDFR=dfr wv_ni = $name
-			if(WaveExists(wv_ni))
-				return wv_ni
-			endif
 			Make/WAVE/N=(NUM_DA_TTL_CHANNELS) dfr:$name/Wave=wv_ni
-			return wv_ni
+			WAVE wv = wv_ni
 			break
 	endswitch
+
+	return wv
 End
 
 /// @brief Get the single NI channel waves

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -683,7 +683,7 @@ Function/S GetSingleSweepFolderAsString(dfr, sweepNo)
 	return GetDataFolder(1, dfr) + "X_" + num2str(sweepNo)
 End
 
-/// @brief Return the hardware data wave
+/// @brief Return the DAQ data wave
 ///
 /// ITC hardware:
 /// - 2D signed 16bit integer wave, the colums are for the channel
@@ -698,7 +698,7 @@ End
 /// - one for each active DA, AD, TTL channel (in that order)
 ///
 /// For scaling and gain information see SWS_GetChannelGains().
-Function/Wave GetHardwareDataWave(panelTitle)
+Function/Wave GetDAQDataWave(panelTitle)
 	string panelTitle
 
 	DFREF dfr = GetDevicePath(panelTitle)
@@ -706,21 +706,21 @@ Function/Wave GetHardwareDataWave(panelTitle)
 
 	switch(hardwareType)
 		case HARDWARE_ITC_DAC:
-			WAVE/W/Z/SDFR=dfr wv = HardwareDataWave
+			WAVE/W/Z/SDFR=dfr wv = DAQDataWave
 
 			if(WaveExists(wv))
 				return wv
 			endif
 
-			Make/W/N=(1, NUM_DA_TTL_CHANNELS) dfr:HardwareDataWave/Wave=wv
+			Make/W/N=(1, NUM_DA_TTL_CHANNELS) dfr:DAQDataWave/Wave=wv
 			return wv
 			break
 		case HARDWARE_NI_DAC:
-			WAVE/WAVE/Z/SDFR=dfr wv_ni = HardwareDataWave
+			WAVE/WAVE/Z/SDFR=dfr wv_ni = DAQDataWave
 			if(WaveExists(wv_ni))
 				return wv_ni
 			endif
-			Make/WAVE/N=(NUM_DA_TTL_CHANNELS) dfr:HardwareDataWave/Wave=wv_ni
+			Make/WAVE/N=(NUM_DA_TTL_CHANNELS) dfr:DAQDataWave/Wave=wv_ni
 			return wv_ni
 			break
 	endswitch
@@ -728,7 +728,7 @@ End
 
 /// @brief Get the single NI channel waves
 ///
-/// Special use function, normal callers should use GetHardwareDataWave()
+/// Special use function, normal callers should use GetDAQDataWave()
 /// instead.
 Function/WAVE GetNIDAQChannelWave(panelTitle, channel)
 	string panelTitle
@@ -796,7 +796,7 @@ End
 /// @brief Return the ITC channel config wave
 ///
 /// Rows:
-/// - One for each channel, the order is DA, AD, TTL (same as in the ITCDataWave)
+/// - One for each channel, the order is DA, AD, TTL (same as in the DAQDataWave)
 ///
 /// Columns:
 /// - channel type, one of @ref ItcXopChannelConstants
@@ -877,7 +877,7 @@ static Constant DQM_ACTIVE_DEV_WAVE_VERSION = 3
 ///
 /// Columns:
 /// - DeviceID id of an active device
-/// - ADChannelToMonitor index of first active AD channel in HardwareDataWave
+/// - ADChannelToMonitor index of first active AD channel in DAQDataWave
 /// - HardwareType type of hardware of the device
 /// - ActiveChunk if a channel of the device is used for TP while DAQ this column saves the number of the last evaluated test pulse
 ///
@@ -2379,7 +2379,7 @@ End
 /// - Holds exactly one TP
 ///
 /// Cols:
-/// - DA/AD/TTLs data, same order as GetHardwareDataWave()
+/// - DA/AD/TTLs data, same order as GetDAQDataWave()
 Function/Wave GetTPOscilloscopeWave(panelTitle)
 	string panelTitle
 
@@ -4287,7 +4287,7 @@ Function/DF P_PressureFolderReference(panelTitle)
 	return CreateDFWithAllParents(P_GetPressureFolderAS(panelTitle))
 End
 
-/// @brief Returns a wave reference to the ITCDataWave used for pressure pulses
+/// @brief Returns a wave reference to the DAQ data wave used for pressure pulses
 ///
 /// Rows:
 /// - data points, see P_GetITCChanConfig() for the sampling interval
@@ -6385,7 +6385,7 @@ Function/WAVE GetAnalysisFunctionStorage(panelTitle)
 End
 
 /// @brief Used for storing a true/false state that the pre and/or post set event
-/// should be fired *after* the sweep which is currently prepared in DC_PlaceDataInITCDataWave().
+/// should be fired *after* the sweep which is currently prepared in DC_PlaceDataInDAQDataWave().
 ///
 /// Rows:
 /// - NUM_DA_TTL_CHANNELS

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -698,29 +698,44 @@ End
 /// - one for each active DA, AD, TTL channel (in that order)
 ///
 /// For scaling and gain information see SWS_GetChannelGains().
-Function/Wave GetDAQDataWave(panelTitle)
-	string panelTitle
+///
+/// @param panelTitle device
+/// @param mode       One of #DATA_ACQUISITION_MODE or #TEST_PULSE_MODE
+Function/Wave GetDAQDataWave(string panelTitle, variable mode)
+
+	string name
 
 	DFREF dfr = GetDevicePath(panelTitle)
 	variable hardwareType = GetHardwareType(panelTitle)
 
+	switch(mode)
+		case DATA_ACQUISITION_MODE:
+			name = "DAQDataWave_DAQ"
+			break
+		case TEST_PULSE_MODE:
+			name = "DAQDataWave_TP"
+			break
+		default:
+			ASSERT(0, "Invalid dataAcqOrTP")
+	endswitch
+
 	switch(hardwareType)
 		case HARDWARE_ITC_DAC:
-			WAVE/W/Z/SDFR=dfr wv = DAQDataWave
+			WAVE/W/Z/SDFR=dfr wv = $name
 
 			if(WaveExists(wv))
 				return wv
 			endif
 
-			Make/W/N=(1, NUM_DA_TTL_CHANNELS) dfr:DAQDataWave/Wave=wv
+			Make/W/N=(1, NUM_DA_TTL_CHANNELS) dfr:$name/Wave=wv
 			return wv
 			break
 		case HARDWARE_NI_DAC:
-			WAVE/WAVE/Z/SDFR=dfr wv_ni = DAQDataWave
+			WAVE/WAVE/Z/SDFR=dfr wv_ni = $name
 			if(WaveExists(wv_ni))
 				return wv_ni
 			endif
-			Make/WAVE/N=(NUM_DA_TTL_CHANNELS) dfr:DAQDataWave/Wave=wv_ni
+			Make/WAVE/N=(NUM_DA_TTL_CHANNELS) dfr:$name/Wave=wv_ni
 			return wv_ni
 			break
 	endswitch

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -699,6 +699,9 @@ End
 ///
 /// For scaling and gain information see SWS_GetChannelGains().
 ///
+/// Note:
+/// #TP_PROPERTIES_HASH: Unique hash for a combination of all properties which influence the test pulse.
+///
 /// @param panelTitle device
 /// @param mode       One of #DATA_ACQUISITION_MODE or #TEST_PULSE_MODE
 Function/Wave GetDAQDataWave(string panelTitle, variable mode)
@@ -734,6 +737,8 @@ Function/Wave GetDAQDataWave(string panelTitle, variable mode)
 			WAVE wv = wv_ni
 			break
 	endswitch
+
+	SetStringInWaveNote(wv, TP_PROPERTIES_HASH, "n. a.")
 
 	return wv
 End

--- a/Packages/Testing-MIES/UserAnalysisFunctions.ipf
+++ b/Packages/Testing-MIES/UserAnalysisFunctions.ipf
@@ -22,28 +22,28 @@ Function/WAVE InvalidSignatureAndReturnType()
 	FAIL()
 End
 
-Function/WAVE InvalidReturnTypeAndValidSig_V1(panelTitle, eventType, HardwareDataWave, headStage)
+Function/WAVE InvalidReturnTypeAndValidSig_V1(panelTitle, eventType, DAQDataWave, headStage)
 	string panelTitle
 	variable eventType
-	Wave HardwareDataWave
+	Wave DAQDataWave
 	variable headstage
 
 	FAIL()
 End
 
-Function/WAVE InvalidReturnTypeAndValidSig_V2(panelTitle, eventType, HardwareDataWave, headStage, realDataLength)
+Function/WAVE InvalidReturnTypeAndValidSig_V2(panelTitle, eventType, DAQDataWave, headStage, realDataLength)
 	string panelTitle
 	variable eventType
-	Wave HardwareDataWave
+	Wave DAQDataWave
 	variable headstage, realDataLength
 
 	FAIL()
 End
 
-Function ValidFunc_V1(panelTitle, eventType, HardwareDataWave, headStage)
+Function ValidFunc_V1(panelTitle, eventType, DAQDataWave, headStage)
 	string panelTitle
 	variable eventType
-	Wave HardwareDataWave
+	Wave DAQDataWave
 	variable headstage
 
 	CHECK_NON_EMPTY_STR(panelTitle)
@@ -51,14 +51,14 @@ Function ValidFunc_V1(panelTitle, eventType, HardwareDataWave, headStage)
 
 	switch(GetHardwareType(panelTitle))
 		case HARDWARE_ITC_DAC:
-			CHECK_WAVE(HardwareDataWave, NUMERIC_WAVE)
+			CHECK_WAVE(DAQDataWave, NUMERIC_WAVE)
 			break
 		case HARDWARE_NI_DAC:
-			CHECK_WAVE(HardwareDataWave, WAVE_WAVE)
+			CHECK_WAVE(DAQDataWave, WAVE_WAVE)
 			break
 	endswitch
 
-	CHECK_EQUAL_VAR(NumberByKey("LOCK", WaveInfo(HardwareDataWave, 0)), 1)
+	CHECK_EQUAL_VAR(NumberByKey("LOCK", WaveInfo(DAQDataWave, 0)), 1)
 	CHECK_EQUAL_VAR(headstage, 0)
 
 	WAVE anaFuncTracker = TrackAnalysisFunctionCalls()
@@ -67,10 +67,10 @@ Function ValidFunc_V1(panelTitle, eventType, HardwareDataWave, headStage)
 	anaFuncTracker[eventType] += 1
 End
 
-Function ValidFunc_V2(panelTitle, eventType, HardwareDataWave, headStage, realDataLength)
+Function ValidFunc_V2(panelTitle, eventType, DAQDataWave, headStage, realDataLength)
 	string panelTitle
 	variable eventType
-	Wave HardwareDataWave
+	Wave DAQDataWave
 	variable headstage, realDataLength
 
 	CHECK_NON_EMPTY_STR(panelTitle)
@@ -78,23 +78,23 @@ Function ValidFunc_V2(panelTitle, eventType, HardwareDataWave, headStage, realDa
 
 	switch(GetHardwareType(panelTitle))
 		case HARDWARE_ITC_DAC:
-			CHECK_WAVE(HardwareDataWave, NUMERIC_WAVE)
+			CHECK_WAVE(DAQDataWave, NUMERIC_WAVE)
 			break
 		case HARDWARE_NI_DAC:
-			CHECK_WAVE(HardwareDataWave, WAVE_WAVE)
+			CHECK_WAVE(DAQDataWave, WAVE_WAVE)
 			break
 	endswitch
 
-	CHECK_EQUAL_VAR(NumberByKey("LOCK", WaveInfo(HardwareDataWave, 0)), 1)
+	CHECK_EQUAL_VAR(NumberByKey("LOCK", WaveInfo(DAQDataWave, 0)), 1)
 	CHECK_EQUAL_VAR(headstage, 0)
 
 	if(eventType == PRE_DAQ_EVENT || eventType == PRE_SET_EVENT)
 		CHECK_EQUAL_VAR(numType(realDataLength), 2)
 	elseif(GetHardWareType(panelTitle) == HARDWARE_ITC_DAC)
-		CHECK(realDataLength >= 0 && realDataLength < DimSize(HardwareDataWave, ROWS))
+		CHECK(realDataLength >= 0 && realDataLength < DimSize(DAQDataWave, ROWS))
 	elseif(GetHardWareType(panelTitle) == HARDWARE_NI_DAC)
-		WAVE/WAVE HardwareDataWaveRef = HardwareDataWave
-		Make/FREE/N=(DimSize(HardwareDataWaveRef, ROWS)) sizes = DimSize(HardwareDataWaveRef[p], ROWS)
+		WAVE/WAVE DAQDataWaveRef = DAQDataWave
+		Make/FREE/N=(DimSize(DAQDataWaveRef, ROWS)) sizes = DimSize(DAQDataWaveRef[p], ROWS)
 		CHECK(realDataLength >= 0 && realDataLength <= WaveMax(sizes))
 	else
 		FAIL()
@@ -106,10 +106,10 @@ Function ValidFunc_V2(panelTitle, eventType, HardwareDataWave, headStage, realDa
 	anaFuncTracker[eventType] += 1
 End
 
-Function ValidMultHS_V1(panelTitle, eventType, HardwareDataWave, headStage)
+Function ValidMultHS_V1(panelTitle, eventType, DAQDataWave, headStage)
 	string panelTitle
 	variable eventType
-	Wave HardwareDataWave
+	Wave DAQDataWave
 	variable headstage
 
 	CHECK_NON_EMPTY_STR(panelTitle)
@@ -117,14 +117,14 @@ Function ValidMultHS_V1(panelTitle, eventType, HardwareDataWave, headStage)
 
 	switch(GetHardwareType(panelTitle))
 		case HARDWARE_ITC_DAC:
-			CHECK_WAVE(HardwareDataWave, NUMERIC_WAVE)
+			CHECK_WAVE(DAQDataWave, NUMERIC_WAVE)
 			break
 		case HARDWARE_NI_DAC:
-			CHECK_WAVE(HardwareDataWave, WAVE_WAVE)
+			CHECK_WAVE(DAQDataWave, WAVE_WAVE)
 			break
 	endswitch
 
-	CHECK_EQUAL_VAR(NumberByKey("LOCK", WaveInfo(HardwareDataWave, 0)), 1)
+	CHECK_EQUAL_VAR(NumberByKey("LOCK", WaveInfo(DAQDataWave, 0)), 1)
 
 	WAVE anaFuncTracker = TrackAnalysisFunctionCalls()
 
@@ -132,19 +132,19 @@ Function ValidMultHS_V1(panelTitle, eventType, HardwareDataWave, headStage)
 	anaFuncTracker[eventType][headstage] += 1
 End
 
-Function NotCalled_V1(panelTitle, eventType, HardwareDataWave, headStage)
+Function NotCalled_V1(panelTitle, eventType, DAQDataWave, headStage)
 	string panelTitle
 	variable eventType
-	Wave HardwareDataWave
+	Wave DAQDataWave
 	variable headstage
 
 	FAIL()
 End
 
-Function preDAQHardAbort(panelTitle, eventType, HardwareDataWave, headStage, realDataLength)
+Function preDAQHardAbort(panelTitle, eventType, DAQDataWave, headStage, realDataLength)
 	string panelTitle
 	variable eventType
-	Wave HardwareDataWave
+	Wave DAQDataWave
 	variable headstage, realDataLength
 
 	WAVE anaFuncTracker = TrackAnalysisFunctionCalls()
@@ -157,10 +157,10 @@ Function preDAQHardAbort(panelTitle, eventType, HardwareDataWave, headStage, rea
 	endif
 End
 
-Function preDAQ(panelTitle, eventType, HardwareDataWave, headStage, realDataLength)
+Function preDAQ(panelTitle, eventType, DAQDataWave, headStage, realDataLength)
 	string panelTitle
 	variable eventType
-	Wave HardwareDataWave
+	Wave DAQDataWave
 	variable headstage, realDataLength
 
 	WAVE anaFuncTracker = TrackAnalysisFunctionCalls()
@@ -169,10 +169,10 @@ Function preDAQ(panelTitle, eventType, HardwareDataWave, headStage, realDataLeng
 	anaFuncTracker[eventType][headstage] += 1
 End
 
-Function preSet(panelTitle, eventType, HardwareDataWave, headStage, realDataLength)
+Function preSet(panelTitle, eventType, DAQDataWave, headStage, realDataLength)
 	string panelTitle
 	variable eventType
-	Wave HardwareDataWave
+	Wave DAQDataWave
 	variable headstage, realDataLength
 
 	WAVE anaFuncTracker = TrackAnalysisFunctionCalls()
@@ -181,10 +181,10 @@ Function preSet(panelTitle, eventType, HardwareDataWave, headStage, realDataLeng
 	anaFuncTracker[eventType][headstage] += 1
 End
 
-Function preSweep(panelTitle, eventType, HardwareDataWave, headStage, realDataLength)
+Function preSweep(panelTitle, eventType, DAQDataWave, headStage, realDataLength)
 	string panelTitle
 	variable eventType
-	Wave HardwareDataWave
+	Wave DAQDataWave
 	variable headstage, realDataLength
 
 	WAVE anaFuncTracker = TrackAnalysisFunctionCalls()
@@ -193,10 +193,10 @@ Function preSweep(panelTitle, eventType, HardwareDataWave, headStage, realDataLe
 	anaFuncTracker[eventType][headstage] += 1
 End
 
-Function midSweep(panelTitle, eventType, HardwareDataWave, headStage, realDataLength)
+Function midSweep(panelTitle, eventType, DAQDataWave, headStage, realDataLength)
 	string panelTitle
 	variable eventType
-	Wave HardwareDataWave
+	Wave DAQDataWave
 	variable headstage, realDataLength
 
 	WAVE anaFuncTracker = TrackAnalysisFunctionCalls()
@@ -205,10 +205,10 @@ Function midSweep(panelTitle, eventType, HardwareDataWave, headStage, realDataLe
 	anaFuncTracker[eventType][headstage] += 1
 End
 
-Function postSweep(panelTitle, eventType, HardwareDataWave, headStage, realDataLength)
+Function postSweep(panelTitle, eventType, DAQDataWave, headStage, realDataLength)
 	string panelTitle
 	variable eventType
-	Wave HardwareDataWave
+	Wave DAQDataWave
 	variable headstage, realDataLength
 
 	WAVE anaFuncTracker = TrackAnalysisFunctionCalls()
@@ -217,10 +217,10 @@ Function postSweep(panelTitle, eventType, HardwareDataWave, headStage, realDataL
 	anaFuncTracker[eventType][headstage] += 1
 End
 
-Function postSet(panelTitle, eventType, HardwareDataWave, headStage, realDataLength)
+Function postSet(panelTitle, eventType, DAQDataWave, headStage, realDataLength)
 	string panelTitle
 	variable eventType
-	Wave HardwareDataWave
+	Wave DAQDataWave
 	variable headstage, realDataLength
 
 	WAVE anaFuncTracker = TrackAnalysisFunctionCalls()
@@ -229,10 +229,10 @@ Function postSet(panelTitle, eventType, HardwareDataWave, headStage, realDataLen
 	anaFuncTracker[eventType][headstage] += 1
 End
 
-Function postDAQ(panelTitle, eventType, HardwareDataWave, headStage, realDataLength)
+Function postDAQ(panelTitle, eventType, DAQDataWave, headStage, realDataLength)
 	string panelTitle
 	variable eventType
-	Wave HardwareDataWave
+	Wave DAQDataWave
 	variable headstage, realDataLength
 
 	WAVE anaFuncTracker = TrackAnalysisFunctionCalls()
@@ -241,10 +241,10 @@ Function postDAQ(panelTitle, eventType, HardwareDataWave, headStage, realDataLen
 	anaFuncTracker[eventType][headstage] += 1
 End
 
-Function AbortPreDAQ(panelTitle, eventType, HardwareDataWave, headStage, realDataLength)
+Function AbortPreDAQ(panelTitle, eventType, DAQDataWave, headStage, realDataLength)
 	string panelTitle
 	variable eventType
-	Wave HardwareDataWave
+	Wave DAQDataWave
 	variable headstage, realDataLength
 
 	WAVE anaFuncTracker = TrackAnalysisFunctionCalls()
@@ -256,10 +256,10 @@ Function AbortPreDAQ(panelTitle, eventType, HardwareDataWave, headStage, realDat
 	return 1
 End
 
-Function StopMidSweep(panelTitle, eventType, HardwareDataWave, headStage, realDataLength)
+Function StopMidSweep(panelTitle, eventType, DAQDataWave, headStage, realDataLength)
 	string panelTitle
 	variable eventType
-	Wave HardwareDataWave
+	Wave DAQDataWave
 	variable headstage, realDataLength
 
 	WAVE anaFuncTracker = TrackAnalysisFunctionCalls()
@@ -496,20 +496,20 @@ Function Params5_V3(panelTitle, s)
 	anaFuncTracker[s.eventType] += 1
 End
 
-Function ChangeToSingleDeviceDAQAF(panelTitle, eventType, HardwareDataWave, headStage, realDataLength)
+Function ChangeToSingleDeviceDAQAF(panelTitle, eventType, DAQDataWave, headStage, realDataLength)
 	string panelTitle
 	variable eventType
-	Wave HardwareDataWave
+	Wave DAQDataWave
 	variable headstage, realDataLength
 
 	PGC_SetAndActivateControl(panelTitle, "check_Settings_MD", val = CHECKBOX_UNSELECTED)
 	return 0
 End
 
-Function ChangeToMultiDeviceDAQAF(panelTitle, eventType, HardwareDataWave, headStage, realDataLength)
+Function ChangeToMultiDeviceDAQAF(panelTitle, eventType, DAQDataWave, headStage, realDataLength)
 	string panelTitle
 	variable eventType
-	Wave HardwareDataWave
+	Wave DAQDataWave
 	variable headstage, realDataLength
 
 	PGC_SetAndActivateControl(panelTitle, "check_Settings_MD", val = CHECKBOX_SELECTED)


### PR DESCRIPTION
- [x] Reuse DAQDataWave_TP directly if possible, this keeps WaveData pointer fixed

This PR introduces separate DAQDataWaves waves for DAQ and TP. And also renames them as mentioned in https://github.com/AllenInstitute/MIES/issues/67.