### PR TITLE
Add CI support for IP9

### DIFF
--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -4798,6 +4798,10 @@ Function ScaleToIndexWrapper(wv, scale, dim)
 		index = sign(scale) * sign(DimDelta(wv, dim)) * inf
 	endif
 
+	if(dim >= WaveDims(wv))
+		return 0
+	endif
+
 	return min(DimSize(wv, dim) - 1, max(0, trunc(index)))
 End
 

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -2222,7 +2222,7 @@ Function InPlaceRandomShuffle(inwave, [noiseGenMode])
 
 	for(i = N; i>1; i-=1)
 		emax = i / 2
-		j =  floor(emax + enoise(emax))		//	random index
+		j =  floor(emax + enoise(emax, noiseGenMode))		//	random index
 // 		emax + enoise(emax) ranges in random value from 0 to 2*emax = i
 		temp		= inwave[j]
 		inwave[j]	= inwave[i-1]

--- a/Packages/MIES/MIES_WaveBuilder.ipf
+++ b/Packages/MIES/MIES_WaveBuilder.ipf
@@ -1615,7 +1615,7 @@ static Function/WAVE WB_PulseTrainSegment(pa, mode, pulseStartTimes, pulseToPuls
 		Make/D/FREE/N=(pa.numberOfPulses) interPulseIntervals = firstStep * dist^p * 1000 - pa.pulseDuration
 
 		if(pa.mixedFreqShuffle)
-			InPlaceRandomShuffle(interPulseIntervals, noiseGenMode = NOISE_GEN_MERSENNE_TWISTER)
+			InPlaceRandomShuffle(interPulseIntervals, noiseGenMode = NOISE_GEN_LINEAR_CONGRUENTIAL)
 		endif
 
 		pulseToPulseLength = 0

--- a/Packages/MIES_Include.ipf
+++ b/Packages/MIES_Include.ipf
@@ -21,7 +21,8 @@
 #pragma IgorVersion=8.04
 
 #if IgorVersion() >= 9.0
-#if (NumberByKey("BUILD", IgorInfo(0)) < 36607)
+// @todo this is currently out of sync with the above nightly link, the build version is beta2 exactly
+#if (NumberByKey("BUILD", IgorInfo(0)) < 36586)
 #define TOO_OLD_IGOR
 #endif
 #else

--- a/Packages/Testing-MIES/UTF_Utils.ipf
+++ b/Packages/Testing-MIES/UTF_Utils.ipf
@@ -3688,7 +3688,7 @@ Function STIW_TestDimensions()
 
 	REQUIRE_EQUAL_VAR(ScaleToIndex(testWave, -1, ROWS), DimOffset(testwave, ROWS) - 1 / DimDelta(testwave, ROWS))
 	REQUIRE_EQUAL_VAR(ScaleToIndexWrapper(testWave, -1, ROWS), 0)
-#if (NumberByKey("BUILD", IgorInfo(0)) < 36039)
+#if IgorVersion() < 9.0
 	REQUIRE_EQUAL_VAR(ScaleToIndex(testWave, -inf, ROWS), DimSize(testwave, ROWS) - 1)
 #else
 	REQUIRE_EQUAL_VAR(ScaleToIndex(testWave, -inf, ROWS), NaN)
@@ -3697,17 +3697,21 @@ Function STIW_TestDimensions()
 
 	REQUIRE_EQUAL_VAR(ScaleToIndex(testWave, 1e3, ROWS), DimOffset(testwave, ROWS) + 1e3 / DimDelta(testwave, ROWS))
 	REQUIRE_EQUAL_VAR(ScaleToIndexWrapper(testWave, 1e3, ROWS), DimSize(testwave, ROWS) - 1)
+#if IgorVersion() < 9.0
 	REQUIRE_EQUAL_VAR(ScaleToIndex(testWave, inf, ROWS), ScaleToIndexWrapper(testWave, inf, ROWS))
+#endif
 
 	SetScale/P x, 0, -0.1, testwave
 	REQUIRE_EQUAL_VAR(ScaleToIndex(testWave, -1, ROWS), DimOffset(testwave, ROWS) - 1 / DimDelta(testwave, ROWS))
 	REQUIRE_EQUAL_VAR(ScaleToIndexWrapper(testWave, 1, ROWS), 0)
-#if (NumberByKey("BUILD", IgorInfo(0)) < 36039)
+#if IgorVersion() < 9.0
 	REQUIRE_EQUAL_VAR(ScaleToIndex(testWave, -inf, ROWS), ScaleToIndexWrapper(testWave, -inf, ROWS))
 #endif
 	REQUIRE_EQUAL_VAR(ScaleToIndex(testWave, 1, ROWS), DimOffset(testwave, ROWS) + 1 / DimDelta(testwave, ROWS))
 	REQUIRE_EQUAL_VAR(ScaleToIndexWrapper(testWave, 1, ROWS), 0)
+#if IgorVersion() < 9.0
 	REQUIRE_EQUAL_VAR(ScaleToIndex(testWave, inf, ROWS), DimSize(testwave, ROWS) - 1)
+#endif
 	REQUIRE_EQUAL_VAR(ScaleToIndexWrapper(testWave, inf, ROWS), 0)
 End
 

--- a/Packages/Testing-MIES/UTF_Utils.ipf
+++ b/Packages/Testing-MIES/UTF_Utils.ipf
@@ -3677,14 +3677,8 @@ Function STIW_TestDimensions()
 	REQUIRE_EQUAL_VAR(ScaleToIndexWrapper(testwave, 0, ROWS), ScaleToIndex(testWave, 0, ROWS))
 	REQUIRE_EQUAL_VAR(ScaleToIndexWrapper(testwave, 1, ROWS), ScaleToIndex(testWave, 1, ROWS))
 	SetScale/P y, 0, 0.01, testwave
-	REQUIRE_EQUAL_VAR(ScaleToIndexWrapper(testwave, 0, COLS), ScaleToIndex(testWave, 0, COLS))
-	REQUIRE_EQUAL_VAR(ScaleToIndexWrapper(testwave, 1, COLS), ScaleToIndex(testWave, 1, COLS))
 	SetScale/P z, 0, 0.001, testwave
-	REQUIRE_EQUAL_VAR(ScaleToIndexWrapper(testwave, 0, LAYERS), ScaleToIndex(testWave, 0, LAYERS))
-	REQUIRE_EQUAL_VAR(ScaleToIndexWrapper(testwave, 1, LAYERS), ScaleToIndex(testWave, 1, LAYERS))
 	SetScale/P t, 0, 0.0001, testwave
-	REQUIRE_EQUAL_VAR(ScaleToIndexWrapper(testwave, 0, CHUNKS), ScaleToIndex(testWave, 0, CHUNKS))
-	REQUIRE_EQUAL_VAR(ScaleToIndexWrapper(testwave, 0.1, CHUNKS), ScaleToIndex(testWave, 0.1, CHUNKS))
 
 	REQUIRE_EQUAL_VAR(ScaleToIndex(testWave, -1, ROWS), DimOffset(testwave, ROWS) - 1 / DimDelta(testwave, ROWS))
 	REQUIRE_EQUAL_VAR(ScaleToIndexWrapper(testWave, -1, ROWS), 0)

--- a/tools/clean_mies_installation.sh
+++ b/tools/clean_mies_installation.sh
@@ -91,7 +91,7 @@ then
   base_folder=$top_level
 fi
 
-versions="8"
+versions="8 9"
 
 for i in $versions
 do


### PR DESCRIPTION
Packages/MIES_Include.ipf: Lower IP9 nightly version:
Only this is available on one of the CI boxes.

Close #745.