### PR TITLE
SetupBackgroundTasks: Don't allow dialogs during background function …

### DIFF
--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -6169,13 +6169,13 @@ End
 
 // @brief Common setup routine for all MIES background tasks for DAQ, TP and pressure control
 Function SetupBackgroundTasks()
-	CtrlNamedBackground $TASKNAME_TIMERMD, period = 6, proc=DQM_Timer
-	CtrlNamedBackground $TASKNAME_FIFOMONMD, period=1, proc=DQM_FIFOMonitor
-	CtrlNamedBackground $TASKNAME_FIFOMON, period = 5, proc=DQS_FIFOMonitor
-	CtrlNamedBackground $TASKNAME_TIMER, period = 5, proc=DQS_Timer
-	CtrlNamedBackground $TASKNAME_TPMD, period=5, proc=TPM_BkrdTPFuncMD
-	CtrlNamedBackground $TASKNAME_TP, period = 5, proc=TPS_TestPulseFunc
-	CtrlNamedBackground P_ITC_FIFOMonitor, period = 10, proc=P_ITC_FIFOMonitorProc
+	CtrlNamedBackground $TASKNAME_TIMERMD, dialogsOK = 0, period = 6, proc=DQM_Timer
+	CtrlNamedBackground $TASKNAME_FIFOMONMD, dialogsOK = 0, period=1, proc=DQM_FIFOMonitor
+	CtrlNamedBackground $TASKNAME_FIFOMON, dialogsOK = 0, period = 5, proc=DQS_FIFOMonitor
+	CtrlNamedBackground $TASKNAME_TIMER, dialogsOK = 0, period = 5, proc=DQS_Timer
+	CtrlNamedBackground $TASKNAME_TPMD, dialogsOK = 0, period=5, proc=TPM_BkrdTPFuncMD
+	CtrlNamedBackground $TASKNAME_TP, dialogsOK = 0, period = 5, proc=TPS_TestPulseFunc
+	CtrlNamedBackground P_ITC_FIFOMonitor, dialogsOK = 0, period = 10, proc=P_ITC_FIFOMonitorProc
 End
 
 /// @brief Zero the wave using differentiation and integration


### PR DESCRIPTION
…execution

Since forever we did not set the dialogsOK parameter for the background
tasks. And the default is dialogsOK = 1 which means that dialogs can run
during background execution.

The Igor help is pretty clear on that, that this can cause crashes when
removing traces from a graph etc.

And that can happen as we call SWS_SaveAcquiredData from the DAQ
background functions and user analysis function as well.

So let's disable that.

Found with user uploaded crash dumps and help from Adam Light
(WaveMetrics).