### PR TITLE
HW_GetDeviceInfo: Allow compiling with older NIDAQmx XOPs

### DIFF
--- a/Packages/MIES/MIES_DAC-Hardware.ipf
+++ b/Packages/MIES/MIES_DAC-Hardware.ipf
@@ -2728,7 +2728,11 @@ Function/WAVE HW_NI_GetDeviceInfo(device, [flags])
 
 	DEBUGPRINTSTACKINFO()
 
+#if exists("DAQmx_DeviceInfo")
 	DAQmx_DeviceInfo/DEV=device
+#else
+	ASSERT(0, "Your NIDAQmx XOP is too old to be usable as it is missing DAQmx_DeviceInfo. Please contact the manufacturer for an updated version.")
+#endif
 
 	Make/FREE/T/N=(8) deviceInfo
 	SetDimLabel ROWS, 0, DeviceCategoryNum, deviceInfo


### PR DESCRIPTION
Close #793.