### PR TITLE
CONF_RestoreHeadstageAssociation: Warn if Mies to MCC sync is not che…

### DIFF
--- a/Packages/MIES/MIES_AmplifierInteraction.ipf
+++ b/Packages/MIES/MIES_AmplifierInteraction.ipf
@@ -1018,7 +1018,7 @@ Function AI_SelectMultiClamp(panelTitle, headStage)
 	string panelTitle
 	variable headStage
 
-	variable channel, axonSerial, debugOnError
+	variable channel, axonSerial, err
 	string mccSerial
 
 	// checking axonSerial is done as a service to the caller
@@ -1030,18 +1030,13 @@ Function AI_SelectMultiClamp(panelTitle, headStage)
 		return AMPLIFIER_CONNECTION_INVAL_SER
 	endif
 
-	debugOnError = DisableDebugOnError()
+	ClearRTError()
+	MCC_SelectMultiClamp700B(mccSerial, channel); err = GetRTError(1)
 
-	try
-		ClearRTError()
-		MCC_SelectMultiClamp700B(mccSerial, channel); AbortOnRTE
-	catch
-		ClearRTError()
-		ResetDebugOnError(debugOnError)
+	if(err)
 		return AMPLIFIER_CONNECTION_MCC_FAILED
-	endtry
+	endif
 
-	ResetDebugOnError(debugOnError)
 	return AMPLIFIER_CONNECTION_SUCCESS
 end
 

--- a/Packages/MIES/MIES_AmplifierInteraction.ipf
+++ b/Packages/MIES/MIES_AmplifierInteraction.ipf
@@ -503,7 +503,9 @@ Function AI_SyncGUIToAmpStorageAndMCCApp(panelTitle, headStage, clampMode)
 		return NaN
 	endif
 
-	AI_EnsureCorrectMode(panelTitle, headStage, selectAmp = 1)
+	if(AI_EnsureCorrectMode(panelTitle, headStage, selectAmp = 1))
+		return NaN
+	endif
 
 	if(clampMode == V_CLAMP_MODE)
 		list = AMPLIFIER_CONTROLS_VC

--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -1437,8 +1437,9 @@ Function CONF_WindowToJSON(wName, saveMask[, excCtrlTypes])
 
 		Make/FREE/T/N=(numCtrl) arrayNames
 		arrayNames[] = GetUserData(wName, ctrlNames[p][%CTRLNAME], EXPCONFIG_UDATA_CTRLARRAY)
+
 		if(numCtrl > 1)
-			FindDuplicates/FREE/RT=arrayNamesRedux arrayNames
+			WAVE/T arrayNamesRedux = GetUniqueEntries(arrayNames)
 			arrayNamesRedux[] = LowerStr(arrayNamesRedux[p])
 			FindValue/TXOP=4/TEXT="" arrayNamesRedux
 			if(V_Value >= 0)
@@ -1456,11 +1457,9 @@ Function CONF_WindowToJSON(wName, saveMask[, excCtrlTypes])
 			duplicateCheck[numCtrl, numCtrl + numUniqueCtrlArray - 1] = arrayNamesRedux[p - numCtrl]
 		endif
 
+		ASSERT(!SearchForDuplicates(duplicateCheck), "Human readable control names combined with internal control names have duplicates: " + TextWaveToList(duplicateCheck, ";"))
+
 		numDupCheck = DimSize(duplicateCheck, ROWS)
-		if(numDupCheck > 1)
-			FindDuplicates/FREE/DT=duplicates duplicateCheck
-			ASSERT(!DimSize(duplicates, ROWS), "Human readable control names combined with internal control names have duplicates: " + TextWaveToList(duplicates, ";"))
-		endif
 		Make/FREE/I/N=(numDupCheck) groupEndingCheck
 		groupEndingCheck[] = StringEndsWith(duplicateCheck[p], LowerStr(EXPCONFIG_CTRLGROUP_SUFFIX))
 		FindValue/I=1 groupEndingCheck

--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -990,13 +990,10 @@ Function/S CONF_JSONToWindow(wName, restoreMask, jsonID)
 			CONF_GatherControlsFromJSON(ctrlData, jsonID, srcWinNames[winNum])
 
 			colNiceName = FindDimLabel(ctrlData, COLS, "NICENAME")
-			numCtrl = DimSize(ctrlData, ROWS)
-			if(numCtrl > 1)
-				Duplicate/FREE/RMD=[][colNiceName] ctrlData ctrlNiceNames
-				Redimension/N=(numCtrl) ctrlNiceNames
-				FindDuplicates/DT=dupWave ctrlNiceNames
-				ASSERT(DimSize(dupWave, ROWS) == 0, "Found duplicates in control names in configuration file for window " + subWinTarget)
-			endif
+			Duplicate/FREE/RMD=[][colNiceName] ctrlData ctrlNiceNames
+			Redimension/N=(DimSize(ctrlNiceNames, ROWS)) ctrlNiceNames
+
+			ASSERT(!SearchForDuplicates(ctrlNiceNames), "Found duplicates in control names in configuration file for window " + subWinTarget)
 
 			WAVE/T ctrlArrays = CONF_GetControlArrayList(subWinTarget)
 			Make/FREE/B/U/N=(DimSize(ctrlArrays, ROWS)) ctrlArrayAdded

--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -1806,7 +1806,7 @@ static Function CONF_RestoreHeadstageAssociation(panelTitle, jsonID, midExp)
 	string panelTitle
 	variable jsonID, midExp
 
-	variable i, type, numRows, ampSerial, ampChannel, index, value
+	variable i, type, numRows, ampSerial, ampChannel, index, value, warnMissingMCCSync
 	string jsonPath, jsonBasePath
 	string ampSerialList = ""
 	string ampTitleList = ""
@@ -1847,6 +1847,8 @@ static Function CONF_RestoreHeadstageAssociation(panelTitle, jsonID, midExp)
 
 	PGC_SetAndActivateControl(panelTitle, "button_Settings_UpdateAmpStatus")
 	PGC_SetAndActivateControl(panelTitle, "button_Settings_UpdateDACList")
+
+	warnMissingMCCSync = !GetCheckBoxState(panelTitle, "check_Settings_SyncMiesToMCC")
 
 	for(i = 0; i < NUM_HEADSTAGES; i += 1)
 		PGC_SetAndActivateControl(panelTitle, "Popup_Settings_HeadStage", val = i)
@@ -1903,6 +1905,11 @@ static Function CONF_RestoreHeadstageAssociation(panelTitle, jsonID, midExp)
 
 			if(IsFinite(ampSerial))
 				if(!midExp)
+					if(warnMissingMCCSync)
+						printf "The sync MIES to MCC settings checkbox is not checked.\rRestored amplifier settings will not be applied to Multiclamp commander."
+						warnMissingMCCSync = 0
+					endif
+
 					CONF_RestoreAmplifierSettings(panelTitle, i, jsonID, jsonBasePath)
 				else
 					CONF_MCC_MidExp(panelTitle, i, jsonID)


### PR DESCRIPTION
…cked when restoring amplifier settings

This will most likely not do what the user expects, as MCC and MIES are
then unsynchronized.

Close #818