### PR TITLE
OVS_UpdatePanel: Select the current sweep when enabled

### DIFF
--- a/Packages/MIES/MIES_DataBrowser_Macro.ipf
+++ b/Packages/MIES/MIES_DataBrowser_Macro.ipf
@@ -687,7 +687,7 @@ Window DataBrowser() : Graph
 	GroupBox group_pulseAver_deconv,userdata(ResizeControlsInfo) += A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
 	CheckBox check_BrowserSettings_OVS,pos={164.00,47.00},size={51.00,15.00},disable=1,proc=BSP_CheckProc_OverlaySweeps
 	CheckBox check_BrowserSettings_OVS,title="enable"
-	CheckBox check_BrowserSettings_OVS,help={"Adds unplotted sweep to graph. Removes plotted sweep from graph."}
+	CheckBox check_BrowserSettings_OVS,help={"Toggle plotting plot multiple sweeps overlayed in the same graph"}
 	CheckBox check_BrowserSettings_OVS,userdata(tabnum)=  "1"
 	CheckBox check_BrowserSettings_OVS,userdata(tabcontrol)=  "Settings"
 	CheckBox check_BrowserSettings_OVS,userdata(ResizeControlsInfo)= A"!!,G4!!#>J!!#>Z!!#<(z!!#`-A7TLfzzzzzzzzzzzzzz!!#r+D.OhkBk2=!z"

--- a/Packages/MIES/MIES_OverlaySweeps.ipf
+++ b/Packages/MIES/MIES_OverlaySweeps.ipf
@@ -125,7 +125,7 @@ End
 Function OVS_UpdatePanel(string win, [variable fullUpdate])
 
 	variable i, numEntries, sweepNo, lastEntry, newCycleHasStartedRAC, newCycleHasStartedSCI
-	string extPanel
+	string extPanel, scPanel
 
 	if(ParamIsDefault(fullUpdate))
 		fullUpdate = 0
@@ -190,7 +190,10 @@ Function OVS_UpdatePanel(string win, [variable fullUpdate])
 	if(OVS_IsActive(win) && fullUpdate)
 		FindValue/I=(LISTBOX_CHECKBOX | LISTBOX_CHECKBOX_SELECTED)/RMD=[][0] listBoxSelWave
 		if(V_Value == -1)
-			listBoxSelWave[0][%Sweep] = SetBit(listBoxSelWave[0][%Sweep], LISTBOX_CHECKBOX_SELECTED)
+			scPanel = BSP_GetSweepControlsPanel(win)
+			sweepNo = GetSetVariable(scPanel, "setvar_SweepControl_SweepNo")
+
+			listBoxSelWave[sweepNo][%Sweep] = SetBit(listBoxSelWave[sweepNo][%Sweep], LISTBOX_CHECKBOX_SELECTED)
 		endif
 	endif
 


### PR DESCRIPTION
We used to select the first sweep if nothing is checked for overlay sweeps. But that is counter-intuitive, so let's check the current sweep instead.

Accompanying fix to 34d00ea9 (OVS_ChangeSweepSelectionState: Avoid always selecting the first sweep, 2020-10-30) and 2e6e9e4e (OVS_UpdatePanel: Fix OVS enabling selecting the very first sweep, 2020-11-13).

Close #817.