### PR TITLE
Feature/auto update text wave lbn entries

### DIFF
--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -1369,3 +1369,5 @@ StrConstant BUFFEREDDRAWDDAQAXES = "dDAQAxes"
 StrConstant TP_PROPERTIES_HASH = "TestPulsePropertiesHash"
 
 StrConstant DASHBOARD_PASSING_MESSAGE = "Pass"
+
+Constant MAX_DOUBLE_PRECISION = 15

--- a/Packages/MIES/MIES_DataBrowser.ipf
+++ b/Packages/MIES/MIES_DataBrowser.ipf
@@ -563,6 +563,8 @@ Function DB_UpdateToLastSweep(win)
 	if(SF_IsActive(win))
 		PGC_SetAndActivateControl(bsPanel, "button_sweepFormula_display")
 	endif
+
+	DB_UpdateTagsForTextualLBNEntries(win, last)
 End
 
 /// @brief procedure for the open button of the side panel
@@ -644,6 +646,35 @@ static Function DB_UnsetDynamicSettingsHistory(win)
 	shPanel = DB_GetSettingsHistoryPanel(win)
 	ASSERT(WindowExists(shPanel), "external SettingsHistory panel not found")
 	SetWindow $shPanel, hook(main)=$""
+End
+
+static Function DB_UpdateTagsForTextualLBNEntries(string databrowser, variable sweepNo)
+	string lbGraph, traceList, key, trace
+	variable i, numTraces
+
+	lbGraph = DB_GetLabNotebookGraph(databrowser)
+
+	WAVE/T textualValues = DB_GetTextualValues(databrowser)
+	WAVE/T textualKeys   = DB_GetTextualKeys(databrowser)
+
+	traceList = TraceNameList(lbGraph, ";", 0 + 1)
+	numTraces = ItemsInList(traceList)
+
+	if(!numTraces)
+		return NaN
+	endif
+
+	for(i = 0; i < numTraces; i += 1)
+		trace = StringFromList(i, traceList)
+
+		if(!str2num(GetUserData(lbGraph, trace, "IsTextData")))
+			continue
+		endif
+
+		key = GetUserData(lbGraph, trace, "key")
+		ASSERT(!IsEmpty(key), "Missing key")
+		AddTagsForTextualLBNEntries(lbGraph, textualKeys, textualValues, key, firstSweep = sweepNo)
+	endfor
 End
 
 /// @brief panel close hook for settings history panel

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -3384,7 +3384,7 @@ Function AddTraceToLBGraph(graph, keys, values, key)
 		ModifyGraph/W=$graph userData($trace)={key, USERDATA_MODIFYGRAPH_REPLACE, key}
 
 		[s] = GetHeadstageColor(i)
-		ModifyGraph/W=$graph rgb($trace)=(s.red, s.green, s.blue), marker($trace)=i
+		ModifyGraph/W=$graph rgb($trace)=(s.red, s.green, s.blue, IsTextData ? 0 : inf), marker($trace)=i
 		SetAxis/W=$graph/A=2 $axis
 	endfor
 

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -152,10 +152,13 @@ static Function/WAVE ExtractLBColumn(values, col, suffix)
 		SetDimLabel ROWS, -1, $colName, singleColumn
 	endif
 
+	SetNumberInWaveNote(singleColumn, NOTE_INDEX, nextRowIndex)
+
 	if(IsTextWave(singleColumn))
 		WAVE/T singleColumnFree = MakeWaveFree(singleColumn)
 		Make/O/D/N=(DimSize(singleColumnFree, ROWS), DimSize(singleColumnFree, COLS), DimSize(singleColumnFree, LAYERS), DimSize(singleColumnFree, CHUNKS)) dfr:$name/Wave=singleColumnFromText
 		CopyScales singleColumnFree, singleColumnFromText
+		Note/K singleColumnFromText, note(singleColumnFree)
 		singleColumnFromText = str2num(singleColumnFree)
 		return singleColumnFromText
 	endif
@@ -3466,7 +3469,7 @@ Function AddTagsForTextualLBNEntries(string graph, WAVE/T keys, WAVE/T values, s
 		WAVE xPos = valuesDat
 	endif
 
-	numRows    = DimSize(values, ROWS)
+	numRows    = GetNumberFromWaveNote(values, NOTE_INDEX)
 	numEntries = DimSize(values, LAYERS)
 
 	if(ParamIsDefault(firstSweep))

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -3310,6 +3310,10 @@ Function UpdateLBGraphLegend(graph, [traceList])
 	for(i = 0 ; i < numEntries; i += 1)
 		trace = StringFromList(i, traceList)
 
+		if(str2num(GetUserData(graph, trace, "IsTextData")))
+			continue
+		endif
+
 		str += "\\s(" + PossiblyQuoteName(trace) + ") "
 
 		if(i < NUM_HEADSTAGES)
@@ -3389,10 +3393,16 @@ Function AddTraceToLBGraph(graph, keys, values, key)
 		endif
 
 		ModifyGraph/W=$graph userData($trace)={key, USERDATA_MODIFYGRAPH_REPLACE, key}
+		ModifyGraph/W=$graph userData($trace)={IsTextData, USERDATA_MODIFYGRAPH_REPLACE, num2str(isTextData)}
 
 		[s] = GetHeadstageColor(i)
 		ModifyGraph/W=$graph rgb($trace)=(s.red, s.green, s.blue, IsTextData ? 0 : inf), marker($trace)=i
 		SetAxis/W=$graph/A=2 $axis
+
+		// we only need one trace, all the info is in the tag
+		if(isTextData)
+			break
+		endif
 	endfor
 
 	if(isTextData)

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -3287,7 +3287,7 @@ End
 Function UpdateLBGraphLegend(graph, [traceList])
 	string graph, traceList
 
-	string str
+	string str, trace, header
 	variable numEntries, i
 
 	if(!windowExists(graph))
@@ -3303,11 +3303,14 @@ Function UpdateLBGraphLegend(graph, [traceList])
 		return NaN
 	endif
 
-	str = "\\JCHeadstage\r"
+	header = "\\JCHeadstage\r"
+	str = ""
 
 	numEntries = ItemsInList(traceList)
 	for(i = 0 ; i < numEntries; i += 1)
-		str += "\\s(" + PossiblyQuoteName(StringFromList(i, traceList)) + ") "
+		trace = StringFromList(i, traceList)
+
+		str += "\\s(" + PossiblyQuoteName(trace) + ") "
 
 		if(i < NUM_HEADSTAGES)
 			str += num2str(i + 1)
@@ -3320,7 +3323,11 @@ Function UpdateLBGraphLegend(graph, [traceList])
 		endif
 	endfor
 
-	str = RemoveEnding(str, "\r")
+	if(IsEmpty(str))
+		return NaN
+	endif
+
+	str = RemoveEnding(header + str, "\r")
 	TextBox/C/W=$graph/N=text0/F=2 str
 End
 

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -3386,7 +3386,7 @@ Function AddTraceToLBGraph(graph, keys, values, key)
 
 		ModifyGraph/W=$graph userData($trace)={key, USERDATA_MODIFYGRAPH_REPLACE, key}
 
-		[s] = GetTraceColor(i)
+		[s] = GetHeadstageColor(i)
 		ModifyGraph/W=$graph rgb($trace)=(s.red, s.green, s.blue), marker($trace)=i
 		SetAxis/W=$graph/A=2 $axis
 	endfor
@@ -3412,7 +3412,7 @@ Function AddTraceToLBGraph(graph, keys, values, key)
 					continue
 				endif
 
-				[s] = GetTraceColor(j)
+				[s] = GeHeadstageColor(j)
 				sprintf tmp, "\\K(%d, %d, %d)%d:\\K(0, 0, 0)", s.red, s.green, s.blue, j + 1
 				text = ReplaceString("\\", text, "\\\\")
 				tagString = tagString + tmp + text + "\r"

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -4318,7 +4318,7 @@ End
 /// If val is complex only the real part is converted to a string.
 /// @param[in] val       number that should be converted to a string
 /// @param[in] precision [optional, default 5] number of precision digits after the decimal dot using "round-half-to-even" rounding rule.
-///                      Precision must be in the range 0 to 15.
+///                      Precision must be in the range 0 to #MAX_DOUBLE_PRECISION.
 /// @return string with textual number representation
 Function/S num2strHighPrec(val, [precision])
 	variable val, precision
@@ -4326,7 +4326,7 @@ Function/S num2strHighPrec(val, [precision])
 	string str
 
 	precision = ParamIsDefault(precision) ? 5 : precision
-	ASSERT(precision >= 0 && precision <= 15, "Invalid precision, must be >= 0 and <= 15.")
+	ASSERT(precision >= 0 && precision <= MAX_DOUBLE_PRECISION, "Invalid precision, must be >= 0 and <= MAX_DOUBLE_PRECISION")
 
 	sprintf str, "%.*f", precision, val
 


### PR DESCRIPTION
Having text entries in the labnotebook browser open during DAQ, now updates them. This was always done for numerical entries.

Close #17.