### PR TITLE
Only compile the background watcher panel when required

### DIFF
--- a/Packages/MIES/MIES_Menu.ipf
+++ b/Packages/MIES/MIES_Menu.ipf
@@ -49,7 +49,7 @@ Menu "Mies Panels"
 		"Turn off ASLR (requires UAC elevation)"   , /Q, TurnOffASLR()
 		"Open debug panel"                         , /Q, DP_OpenDebugPanel()
 		"Check Installation"                       , /Q, CHI_CheckInstallation()
-		"Start Background Task watcher panel"      , /Q, BkgWatcher#BW_StartPanel()
+		"Start Background Task watcher panel"      , /Q, OpenBackgroundWatcherPanel()
 		"Enable Independent Module editing"        , /Q, SetIgorOption IndependentModuleDev=1
 		"Reset and store current DA_EPHYS panel"   , /Q, DAP_EphysPanelStartUpSettings()
 		"Reset and store current DataBrowser panel", /Q, DB_ResetAndStoreCurrentDBPanel()
@@ -162,6 +162,16 @@ Function ButtonProc_AboutMIESCopy(ba) : ButtonControl
 	endswitch
 
 	return 0
+End
+
+Function OpenBackgroundWatcherPanel()
+
+	if(!QuerySetIgorOption("BACKGROUND_TASK_DEBUGGING", globalSymbol = 1))
+		Execute/P/Q "SetIgorOption poundDefine=BACKGROUND_TASK_DEBUGGING"
+		Execute/P/Q "COMPILEPROCEDURES "
+	endif
+
+	Execute/P/Q "BkgWatcher#BW_StartPanel()"
 End
 
 /// @brief Custom notebook action for the "About MIES" dialog

--- a/Packages/MIES_Include.ipf
+++ b/Packages/MIES_Include.ipf
@@ -158,7 +158,11 @@ End
 #include "MIES_Async"
 #include "MIES_Blowout"
 #include "MIES_BrowserSettingsPanel"
+
+#if defined(BACKGROUND_TASK_DEBUGGING)
 #include "MIES_BackgroundWatchdog"
+#endif
+
 #include "MIES_Cache"
 #include "MIES_CheckInstallation"
 #include "MIES_Configuration"

--- a/tools/unit-testing/check_mies_compilation.sh
+++ b/tools/unit-testing/check_mies_compilation.sh
@@ -19,6 +19,7 @@ fi
 
 echo DEBUGGING_ENABLED >> define.txt
 echo EVIL_KITTEN_EATING_MODE >> define.txt
+echo BACKGROUND_TASK_DEBUGGING >> define.txt
 
 ./autorun-test.sh $@
 


### PR DESCRIPTION
The background watcher panel is a debugging tool for background tasks.
And therefore by the average user not used at all.

And as it is living in an independent module there is always the chance
that you edit the wrong include file when developing.

So let's not include it by default but only on request.

This also makes compilation faster.