### PR TITLE
GetSweepsWithSetting: Don't treat textwaves like numeric waves

### DIFF
--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -1569,7 +1569,12 @@ Function/WAVE GetSweepsWithSetting(labnotebookValues, setting)
 
 	sweepCol = GetSweepColumn(labnotebookValues)
 
-	Make/FREE/N=(DimSize(indizes, ROWS)) sweeps = labnotebookValues[indizes[p]][sweepCol][0]
+	if(IsTextWave(labnotebookValues))
+		WAVE/T labnotebookValuesText = labnotebookValues
+		Make/FREE/N=(DimSize(indizes, ROWS)) sweeps = str2num(labnotebookValuesText[indizes[p]][sweepCol][0])
+	else
+		Make/FREE/N=(DimSize(indizes, ROWS)) sweeps = labnotebookValues[indizes[p]][sweepCol][0]
+	endif
 
 	return DeleteDuplicates(sweeps)
 End


### PR DESCRIPTION
This is flagged with IP9 r36973 and later. And it is totally correct
that we have to pass convert the sweep numbers when extracting them from
the textual labnotebook.

The bug resulted in the wrong sweep numbers being reported in case these
were not purely ascending starting from 0.