### PR TITLE
P_RecordUserPressure: Make read errors fatal

### DIFF
--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -1403,3 +1403,12 @@ Constant MAX_DOUBLE_PRECISION = 15
 StrConstant PACKAGE_MIES = "MIES"
 
 StrConstant LOGFILE_NWB_MARKER = "### LOGFILE:JSONL ###"
+
+/// @name National Instruments input configuration
+/// @anchor NIAnalogInputConfigs
+/// @{
+Constant HW_NI_CONFIG_RSE                 = 1 //< RSE terminal configuration
+Constant HW_NI_CONFIG_NRSE                = 2 //< NRSE terminal configuration
+Constant HW_NI_CONFIG_DIFFERENTIAL        = 4 //< Differential terminal configuration
+Constant HW_NI_CONFIG_PSEUDO_DIFFERENTIAL = 8 //< Pseudodifferential terminal configuration
+/// @}

--- a/Packages/MIES/MIES_DAC-Hardware.ipf
+++ b/Packages/MIES/MIES_DAC-Hardware.ipf
@@ -474,13 +474,8 @@ End
 /// @brief Update the device info wave
 ///
 /// Query the data via GetDeviceInfoWave().
-Function HW_WriteDeviceInfo(hardwareType, deviceID, deviceInfo)
-	variable hardwareType, deviceID
-	WAVE deviceInfo
+Function HW_WriteDeviceInfo(variable hardwareType, WAVE deviceInfo, WAVE devInfoHW)
 
-	HW_AssertOnInvalid(hardwareType, deviceID)
-
-	WAVE devInfoHW = HW_GetDeviceInfo(hardwareType, deviceID, flags = HARDWARE_ABORT_ON_ERROR)
 	deviceInfo[%HardwareType] = hardwareType
 
 	switch(hardwareType)

--- a/Packages/MIES/MIES_DAC-Hardware.ipf
+++ b/Packages/MIES/MIES_DAC-Hardware.ipf
@@ -939,8 +939,6 @@ Function HW_ITC_OpenDevice(deviceType, deviceNumber, [flags])
 	HW_ITC_HandleReturnValues(flags, V_ITCError, V_ITCXOPError)
 	deviceID = V_Value
 
-	printf "ITC Device opened, returned deviceID is %d.\r", deviceID
-
 	return deviceID
 End
 

--- a/Packages/MIES/MIES_DAC-Hardware.ipf
+++ b/Packages/MIES/MIES_DAC-Hardware.ipf
@@ -458,8 +458,8 @@ Function HW_WriteDeviceInfo(hardwareType, deviceID, deviceInfo)
 		case HARDWARE_ITC_DAC:
 			deviceInfo[%AD]   = devInfoHW[%ADCCount]
 			deviceInfo[%DA]   = devInfoHW[%DACCount]
-			deviceInfo[%TTL]  = min(devInfoHW[%DOCount], devInfoHW[%DICount])
-			deviceInfo[%Rack] = ceil(deviceInfo[%TTL] / 3)
+			deviceInfo[%TTL]  = devInfoHW[%DOCount] * 8
+			deviceInfo[%Rack] = ceil(min(devInfoHW[%DOCount], devInfoHW[%DICount]) / 3)
 			break
 		case HARDWARE_NI_DAC:
 			WAVE/T devInfoHWText = devInfoHW

--- a/Packages/MIES/MIES_DAC-Hardware.ipf
+++ b/Packages/MIES/MIES_DAC-Hardware.ipf
@@ -442,6 +442,35 @@ Function/WAVE HW_GetDeviceInfo(hardwareType, deviceID, [flags])
 	endswitch
 End
 
+/// @brief Return hardware specific information from the device
+///
+/// This function does not require the device to be registered compared to HW_GetDeviceInfo().
+///
+/// @param device name of the device
+/// @param flags  [optional, default none] One or multiple flags from @ref HardwareInteractionFlags
+Function/WAVE HW_GetDeviceInfoUnregistered(string device, [variable flags])
+
+	variable hardwareType, deviceID
+
+	deviceID = HW_OpenDevice(device, hardwareType, flags = flags)
+
+	switch(hardwareType)
+		case HARDWARE_ITC_DAC:
+			WAVE devInfo = HW_ITC_GetDeviceInfo(deviceID, flags = flags)
+			HW_CloseDevice(hardwareType, deviceID)
+			break
+		case HARDWARE_NI_DAC:
+			HW_NI_AssertOnInvalid(device)
+			WAVE devInfo = HW_NI_GetDeviceInfo(device, flags = flags)
+			// nothing to do for NI
+			break
+		default:
+			ASSERT(0, "Unsupported hardware")
+	endswitch
+
+	return devInfo
+End
+
 /// @brief Update the device info wave
 ///
 /// Query the data via GetDeviceInfoWave().

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -4833,8 +4833,108 @@ Function DAP_LockDevice(string win)
 	endif
 
 	DAP_UpdateSweepLimitsAndDisplay(panelTitleLocked, initial = 1)
+	DAP_AdaptPanelForDeviceSpecifics(panelTitleLocked)
 
 	LOG_AddEntry(PACKAGE_MIES, "locking", keys = {"device"}, values = {panelTitleLocked})
+End
+
+static Function DAP_AdaptPanelForDeviceSpecifics(string panelTitle)
+
+	variable i
+	string controls
+
+	WAVE deviceInfo = GetDeviceInfoWave(panelTitle)
+
+	for(i = 0; i < NUM_DA_TTL_CHANNELS; i += 1)
+
+		controls = DAP_GetControlsForChannelIndex(i, CHANNEL_TYPE_DAC)
+
+		if(i < deviceInfo[%DA])
+			EnableControls(panelTitle, controls)
+		else
+#ifndef EVIL_KITTEN_EATING_MODE
+			DisableControls(panelTitle, controls)
+#endif
+		endif
+	endfor
+
+	for(i = 0; i < NUM_AD_CHANNELS; i += 1)
+
+		controls = DAP_GetControlsForChannelIndex(i, CHANNEL_TYPE_ADC)
+
+		if(i < deviceInfo[%AD])
+			EnableControls(panelTitle, controls)
+		else
+#ifndef EVIL_KITTEN_EATING_MODE
+			DisableControls(panelTitle, controls)
+#endif
+		endif
+	endfor
+
+	for(i = 0; i < NUM_DA_TTL_CHANNELS; i += 1)
+
+		controls = DAP_GetControlsForChannelIndex(i, CHANNEL_TYPE_TTL)
+
+		if(i < deviceInfo[%TTL])
+			EnableControls(panelTitle, controls)
+		else
+#ifndef EVIL_KITTEN_EATING_MODE
+			DisableControls(panelTitle, controls)
+#endif
+		endif
+	endfor
+
+	for(i = 0; i < NUM_DA_TTL_CHANNELS; i += 1)
+
+		controls = DAP_GetControlsForChannelIndex(i, CHANNEL_TYPE_ASYNC)
+
+		if(i < deviceInfo[%TTL])
+			EnableControls(panelTitle, controls)
+		else
+#ifndef EVIL_KITTEN_EATING_MODE
+			DisableControls(panelTitle, controls)
+#endif
+		endif
+	endfor
+End
+
+static Function/S DAP_GetControlsForChannelIndex(variable channelIndex, variable channelType)
+
+	string controls = ""
+
+	switch(channelType)
+		case CHANNEL_TYPE_DAC:
+			controls = AddListItem(GetPanelControl(channelIndex, channelType, CHANNEL_CONTROL_CHECK), controls, ";", Inf)
+			controls = AddListItem(GetPanelControl(channelIndex, channelType, CHANNEL_CONTROL_GAIN), controls, ";", Inf)
+			controls = AddListItem(GetPanelControl(channelIndex, channelType, CHANNEL_CONTROL_UNIT), controls, ";", Inf)
+			controls = AddListItem(GetPanelControl(channelIndex, channelType, CHANNEL_CONTROL_WAVE), controls, ";", Inf)
+			controls = AddListItem(GetPanelControl(channelIndex, channelType, CHANNEL_CONTROL_SEARCH), controls, ";", Inf)
+			controls = AddListItem(GetPanelControl(channelIndex, channelType, CHANNEL_CONTROL_SCALE), controls, ";", Inf)
+			controls = AddListItem(GetPanelControl(channelIndex, channelType, CHANNEL_CONTROL_INDEX_END), controls, ";", Inf)
+			break
+		case CHANNEL_TYPE_ADC:
+			controls = AddListItem(GetPanelControl(channelIndex, channelType, CHANNEL_CONTROL_CHECK), controls, ";", Inf)
+			controls = AddListItem(GetPanelControl(channelIndex, channelType, CHANNEL_CONTROL_GAIN), controls, ";", Inf)
+			controls = AddListItem(GetPanelControl(channelIndex, channelType, CHANNEL_CONTROL_UNIT), controls, ";", Inf)
+			break
+		case CHANNEL_TYPE_TTL:
+			controls = AddListItem(GetPanelControl(channelIndex, channelType, CHANNEL_CONTROL_CHECK), controls, ";", Inf)
+			controls = AddListItem(GetPanelControl(channelIndex, channelType, CHANNEL_CONTROL_WAVE), controls, ";", Inf)
+			controls = AddListItem(GetPanelControl(channelIndex, channelType, CHANNEL_CONTROL_SEARCH), controls, ";", Inf)
+			controls = AddListItem(GetPanelControl(channelIndex, channelType, CHANNEL_CONTROL_INDEX_END), controls, ";", Inf)
+			break
+		case CHANNEL_TYPE_ASYNC:
+			controls = AddListItem(GetPanelControl(channelIndex, channelType, CHANNEL_CONTROL_TITLE), controls, ";", Inf)
+			controls = AddListItem(GetPanelControl(channelIndex, channelType, CHANNEL_CONTROL_CHECK), controls, ";", Inf)
+			controls = AddListItem(GetPanelControl(channelIndex, channelType, CHANNEL_CONTROL_GAIN), controls, ";", Inf)
+			controls = AddListItem(GetPanelControl(channelIndex, channelType, CHANNEL_CONTROL_UNIT), controls, ";", Inf)
+			controls = AddListItem(GetPanelControl(channelIndex, CHANNEL_TYPE_ALARM, CHANNEL_CONTROL_CHECK), controls, ";", Inf)
+			controls = AddListItem(GetPanelControl(channelIndex, channelType, CHANNEL_CONTROL_ALARM_MIN), controls, ";", Inf)
+			controls = AddListItem(GetPanelControl(channelIndex, channelType, CHANNEL_CONTROL_ALARM_MAX), controls, ";", Inf)
+			break
+	endswitch
+
+	return controls
 End
 
 static Function DAP_LoadBuiltinStimsets()

--- a/Packages/MIES/MIES_PressureControl.ipf
+++ b/Packages/MIES/MIES_PressureControl.ipf
@@ -510,10 +510,7 @@ static Function P_PrepareITCWaves(mainDevice, pressureDevice, deviceID)
 
 		ITCConfig[3][0]  = XOP_CHANNEL_TYPE_TTL
 
-		Duplicate GetDeviceInfoWave(mainDevice), deviceInfo
-		deviceInfo[] = NaN
-
-		HW_WriteDeviceInfo(HARDWARE_ITC_DAC, deviceID, deviceInfo)
+		WAVE deviceInfo = GetDeviceInfoWave(pressureDevice)
 		ASSERT(deviceInfo[%Rack] == 2, "Pressure with ITC1600 requires two racks")
 		ITCConfig[3][1]  = HW_ITC_GetITCXOPChannelForRack(pressureDevice, RACK_ONE)
 	else // one rack

--- a/Packages/MIES/MIES_PressureControl.ipf
+++ b/Packages/MIES/MIES_PressureControl.ipf
@@ -142,7 +142,7 @@ static Function P_RecordUserPressure(panelTitle)
 			continue
 		endif
 
-		TPStorage[count][i][%UserPressure]             = HW_ReadADC(hwType, deviceID, ADC)
+		TPStorage[count][i][%UserPressure]             = HW_ReadADC(hwType, deviceID, ADC, flags = HARDWARE_ABORT_ON_ERROR)
 		TPStorage[count][i][%UserPressureTimeStampUTC] = DateTimeInUTC()
 	endfor
 End

--- a/Packages/MIES/MIES_PressureControl.ipf
+++ b/Packages/MIES/MIES_PressureControl.ipf
@@ -1947,6 +1947,58 @@ Function P_PressureDisplayHighlite(panelTitle, hilite)
 	//ValDisplay $controlNamevalueColor=(65535,65535,65535)
 End
 
+static Function [variable result, string msg] P_CheckDeviceAndChannelSelection(string panelTitle)
+	string pressureDevice, userPressureDevice
+	variable DAC, ADC, TTLA, TTLB
+
+	pressureDevice = GetPopupMenuString(panelTitle, "popup_Settings_Pressure_dev")
+
+	if(cmpstr(pressureDevice, NONE))
+
+		WAVE deviceInfo = GetDeviceInfoWave(pressureDevice)
+
+		ADC  = str2num(GetPopupMenuString(panelTitle, "Popup_Settings_Pressure_AD"))
+		DAC  = str2num(GetPopupMenuString(panelTitle, "Popup_Settings_Pressure_DA"))
+		TTLA = str2numSafe(GetPopupMenuString(panelTitle, "Popup_Settings_Pressure_TTLA"))
+		TTLB = str2numSafe(GetPopupMenuString(panelTitle, "Popup_Settings_Pressure_TTLB"))
+
+		if(ADC >= deviceInfo[%AD])
+			sprintf msg, "The AD channel %d is not available on the pressure device %s.", ADC, pressureDevice
+			return [1, msg]
+		endif
+
+		if(DAC >= deviceInfo[%DA])
+			sprintf msg, "The DA channel %d is not available on the pressure device %s.", DAC, pressureDevice
+			return [1, msg]
+		endif
+
+		if(IsFinite(TTLA) && TTLA >= deviceInfo[%TTL])
+			sprintf msg, "The TTL channel %d is not available on the pressure device %s.", TTLA, pressureDevice
+			return [1, msg]
+		endif
+
+		if(IsFinite(TTLB) && TTLB >= deviceInfo[%TTL])
+			sprintf msg, "The TTL channel %d is not available on the pressure device %s.", TTLB, pressureDevice
+			return [1, msg]
+		endif
+	endif
+
+	userPressureDevice = GetPopupMenuString(panelTitle, "popup_Settings_UserPressure")
+
+	if(cmpstr(userPressureDevice, NONE))
+		WAVE deviceInfo = GetDeviceInfoWave(userPressureDevice)
+
+		ADC = str2num(GetPopupMenuString(panelTitle, "Popup_Settings_UserPressure_ADC"))
+
+		if(ADC >= deviceInfo[%AD])
+			sprintf msg, "The AD channel %d is not available on the user pressure device %s.", ADC, userPressureDevice
+			return [1, msg]
+		endif
+	endif
+
+	return [0, ""]
+End
+
 /// @brief Enables devices for all locked DA_Ephys panels. Sets the correct pressure button state for all locked DA_Ephys panels.
 static Function P_Enable()
 	variable i, j, headstage, numPressureDevices
@@ -2260,12 +2312,23 @@ End
 Function P_ButtonProc_Enable(ba) : ButtonControl
 	STRUCT WMButtonAction &ba
 
-	string panelTitle
+	string panelTitle, msg
+	variable result
 
 	switch(ba.eventCode)
 		case 2: // mouse up
 			panelTitle = ba.win
 			DAP_AbortIfUnlocked(panelTitle)
+
+			[result, msg] = P_CheckDeviceAndChannelSelection(panelTitle)
+
+			if(result)
+				print "Can not enable the pressure device due to:"
+				print msg
+				ControlWindowToFront()
+				break
+			endif
+
 			P_Enable()
 			P_UpdatePressureDataStorageWv(panelTitle)
 			break
@@ -2346,8 +2409,8 @@ End
 Function P_ButtonProc_UserPressure(ba) : ButtonControl
 	STRUCT WMButtonAction &ba
 
-	string userPressureDevice, panelTitle
-	variable hardwareType, deviceID, ADC, flags
+	string userPressureDevice, panelTitle, msg
+	variable hardwareType, deviceID, ADC, flags, result
 
 	switch(ba.eventCode)
 		case 2: // mouse up
@@ -2361,6 +2424,15 @@ Function P_ButtonProc_UserPressure(ba) : ButtonControl
 			if(!cmpstr(ba.ctrlName, "button_Hardware_PUser_Enable"))
 
 				if(!cmpstr(userPressureDevice, NONE))
+					break
+				endif
+
+				[result, msg] = P_CheckDeviceAndChannelSelection(panelTitle)
+
+				if(result)
+					print "Can not enable the user pressure device due to:"
+					print msg
+					ControlWindowToFront()
 					break
 				endif
 

--- a/Packages/MIES/MIES_PressureControl.ipf
+++ b/Packages/MIES/MIES_PressureControl.ipf
@@ -512,7 +512,7 @@ static Function P_PrepareITCWaves(mainDevice, pressureDevice, deviceID)
 
 		WAVE deviceInfo = GetDeviceInfoWave(pressureDevice)
 		ASSERT(deviceInfo[%Rack] == 2, "Pressure with ITC1600 requires two racks")
-		ITCConfig[3][1]  = HW_ITC_GetITCXOPChannelForRack(pressureDevice, RACK_ONE)
+		ITCConfig[3][1] = HW_ITC_GetITCXOPChannelForRack(pressureDevice, RACK_ONE)
 	else // one rack
 		Redimension/N=(-1, 3) ITCData
 		Redimension/N=(3, -1) ITCConfig

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -604,6 +604,18 @@ threadsafe Function/DF GetDevicePath(panelTitle)
 	return createDFWithAllParents(GetDevicePathAsString(panelTitle))
 End
 
+/// @brief Return the path to the device info folder, e.g. root:mies:HardwareDevices:DeviceInfo
+threadsafe Function/S GetDeviceInfoPathAsString()
+
+	return GetDAQDevicesFolderAsString() + ":DeviceInfo"
+End
+
+/// @brief Return a datafolder reference to the device info folder
+threadsafe Function/DF GetDeviceInfoPath()
+
+	return createDFWithAllParents(GetDeviceInfoPathAsString())
+End
+
 /// @brief Return the path to the device folder, e.g. root:mies:HardwareDevices:ITC1600:Device0
 threadsafe Function/S GetDevicePathAsString(panelTitle)
 	string panelTitle
@@ -6288,15 +6300,15 @@ Function/WAVE GetDeviceInfoWave(panelTitle)
 
 	variable versionOfNewWave = 1
 
-	DFREF dfr = GetDevicePath(panelTitle)
-	WAVE/D/Z/SDFR=dfr wv = deviceInfo
+	DFREF dfr = GetDeviceInfoPath()
+	WAVE/D/Z/SDFR=dfr wv = $panelTitle
 
 	if(ExistsWithCorrectLayoutVersion(wv, versionOfNewWave))
 		return wv
 	elseif(WaveExists(wv))
 		// handle upgrade
 	else
-		Make/D/N=(5) dfr:deviceInfo/Wave=wv
+		Make/D/N=(5) dfr:$panelTitle/Wave=wv
 	endif
 
 	SetDimLabel ROWS, 0, AD, wv

--- a/Packages/Testing-MIES/UTF_HardwareMain.ipf
+++ b/Packages/Testing-MIES/UTF_HardwareMain.ipf
@@ -190,6 +190,12 @@ Function TEST_BEGIN_OVERRIDE(name)
 	string/G root:ITCDeviceList = DAP_GetITCDeviceList()
 	string/G root:NIDeviceList = DAP_GetNIDeviceList()
 
+	// cache device info waves
+	DFREF dfr = GetDeviceInfoPath()
+	DFREF dest = root:
+	DuplicateDataFolder/Z/O=1 dfr, dest
+	CHECK_EQUAL_VAR(V_flag, 0)
+
 	NWB_LoadAllStimsets(filename = GetFolder(FunctionPath("")) + "_2017_09_01_192934-compressed.nwb", overwrite = 1)
 	KillDataFolder/Z root:WaveBuilder
 	DuplicateDataFolder	root:MIES:WaveBuilder, root:WaveBuilder
@@ -226,6 +232,11 @@ Function TEST_CASE_BEGIN_OVERRIDE(name)
 
 	SVAR NIDeviceList = root:NIDeviceList
 	string/G $(GetDAQDevicesFolderAsString() + ":NIDeviceList") = NIDeviceList
+
+	DFREF dest = GetDAQDevicesFolder()
+	DFREF source = root:DeviceInfo
+	DuplicateDataFolder/O=1/Z source, dest
+	CHECK_EQUAL_VAR(V_flag, 0)
 
 #ifndef TESTS_WITH_NI_HARDWARE
 	HW_ITC_CloseAllDevices()


### PR DESCRIPTION
- [x]  Check that reading works on pressure device locking, don't lock if it does not work.
- [x] Limit available AD channels to the existing ones, see https://ai-mies.slack.com/archives/D1P2AN29F/p1614621507030100?thread_ts=1614544686.028000&cid=D1P2AN29F
- [x] Existing framework P_ValidatePressureSetHeadstage
- [x] Don't gray out controls in evil mode
- [x] Finish
- [x] Good commits
- [x] Update NIDAQ hashes for check installation when new installer is available
- [x] Install new NIDAQmx version on CI machine

Close #849
Close #842
Close #131
Close #880