### PR TITLE
Fix autopipette offset taking apply on mode switch into account

### DIFF
--- a/Packages/MIES/MIES_AmplifierInteraction.ipf
+++ b/Packages/MIES/MIES_AmplifierInteraction.ipf
@@ -208,7 +208,7 @@ Function AI_UpdateAmpModel(panelTitle, ctrl, headStage, [value, sendToAll, check
 	string ctrl
 	variable headStage, value, sendToAll, checkBeforeWrite, selectAmp
 
-	variable i, diff, selectedHeadstage, clampMode, oppositeMode
+	variable i, diff, selectedHeadstage, clampMode, oppositeMode, oldTab
 	variable runMode = TEST_PULSE_NOT_RUNNING
 	string str, rowLabel, rowLabelOpposite, ctrlToCall, ctrlToCallOpposite
 
@@ -378,12 +378,21 @@ Function AI_UpdateAmpModel(panelTitle, ctrl, headStage, [value, sendToAll, check
 				AI_UpdateAmpView(panelTitle, i, ctrl=ctrlToCall)
 				// the pipette offset for the opposite mode has also changed, fetch that too
 				try
+					oldTab = GetTabID(panelTitle, "ADC")
+					if(oldTab != 0)
+						PGC_SetAndActivateControl(panelTitle, "ADC", val=0)
+					endif
+
 					DAP_ChangeHeadStageMode(panelTitle, oppositeMode, i, SKIP_MCC_MIES_SYNCING)
 					// selecting amplifier here, as the clamp mode is now different
 					value = AI_SendToAmp(panelTitle, i, oppositeMode, MCC_GETPIPETTEOFFSET_FUNC, NaN, checkBeforeWrite=checkBeforeWrite, selectAmp = 1)
 					AmpStorageWave[%$rowLabelOpposite][0][i] = value
 					AI_UpdateAmpView(panelTitle, i, ctrl=ctrlToCallOpposite)
 					DAP_ChangeHeadStageMode(panelTitle, clampMode, i, SKIP_MCC_MIES_SYNCING)
+
+					if(oldTab != 0)
+						PGC_SetAndActivateControl(panelTitle, "ADC", val=oldTab)
+					endif
 				catch
 					if(DAG_GetNumericalValue(panelTitle, "check_Settings_SyncMiesToMCC"))
 						printf "(%s) The pipette offset for %s of headstage %d is invalid.\r", panelTitle, ConvertAmplifierModeToString(oppositeMode), i

--- a/Packages/MIES/MIES_AmplifierInteraction.ipf
+++ b/Packages/MIES/MIES_AmplifierInteraction.ipf
@@ -383,12 +383,12 @@ Function AI_UpdateAmpModel(panelTitle, ctrl, headStage, [value, sendToAll, check
 						PGC_SetAndActivateControl(panelTitle, "ADC", val=0)
 					endif
 
-					DAP_ChangeHeadStageMode(panelTitle, oppositeMode, i, SKIP_MCC_MIES_SYNCING)
+					DAP_ChangeHeadStageMode(panelTitle, oppositeMode, i, MCC_SKIP_UPDATES)
 					// selecting amplifier here, as the clamp mode is now different
 					value = AI_SendToAmp(panelTitle, i, oppositeMode, MCC_GETPIPETTEOFFSET_FUNC, NaN, checkBeforeWrite=checkBeforeWrite, selectAmp = 1)
 					AmpStorageWave[%$rowLabelOpposite][0][i] = value
 					AI_UpdateAmpView(panelTitle, i, ctrl=ctrlToCallOpposite)
-					DAP_ChangeHeadStageMode(panelTitle, clampMode, i, SKIP_MCC_MIES_SYNCING)
+					DAP_ChangeHeadStageMode(panelTitle, clampMode, i, MCC_SKIP_UPDATES)
 
 					if(oldTab != 0)
 						PGC_SetAndActivateControl(panelTitle, "ADC", val=oldTab)

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -673,12 +673,14 @@ Constant AMPLIFIER_CONNECTION_MCC_FAILED = 2 ///< calling MCC_SelectMultiClamp70
 StrConstant NWB_SOURCE_TTL_BIT = "TTLBit"
 StrConstant IPNWB_PLACEHOLDER = "PLACEHOLDER"
 
-/// @name Convenience constants for DAP_UpdateClampmodeTabs() and DAP_ChangeHeadStageMode()
-/// @anchor MCCSyncOverrides
+/// @name Constants for the options parameter of DAP_ChangeHeadStageMode()
+/// @anchor ClampModeChangeOptions
 /// @{
-Constant DO_MCC_MIES_SYNCING   = 0x0
-Constant SKIP_MCC_MIES_SYNCING = 0x1
-Constant NO_SLIDER_MOVEMENT    = 0x2
+Constant DO_MCC_MIES_SYNCING   = 0x0 ///< Default mode with all bells and whistles
+Constant NO_SLIDER_MOVEMENT    = 0x2 ///< Does not move the headstage slider
+Constant MCC_SKIP_UPDATES      = 0x4 ///< Skips all unnecessary updates. Intereseting for temporarily switching the clamp mode,
+                                     ///< e.g. for an auto MCC amplifier function.
+                                     ///< Using that option requires to switch the clamp mode back to its original value.
 /// @}
 
 /// Number of trials to find a suitable port for binding a ZeroMQ service

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -3233,8 +3233,7 @@ End
 /// @param panelTitle Device
 /// @param clampMode  Clamp mode to activate
 /// @param headstage  Headstage [0, 8[ or use one of @ref AllHeadstageModeConstants
-/// @param options    One of @ref MCCSyncOverrides. #SKIP_MCC_MIES_SYNCING is interesting for callers which
-///                   are doing a auto MCC function and need to change the clamp mode temporarily.
+/// @param options    One of @ref ClampModeChangeOptions
 Function DAP_ChangeHeadStageMode(panelTitle, clampMode, headstage, options)
 	string panelTitle
 	variable headstage, clampMode, options
@@ -3245,11 +3244,13 @@ Function DAP_ChangeHeadStageMode(panelTitle, clampMode, headstage, options)
 	AI_AssertOnInvalidClampMode(clampMode)
 	DAP_AbortIfUnlocked(panelTitle)
 
-	// explicitly switch to the data acquistion tab to avoid having
-	// the control layout messed up
-	oldTab = GetTabID(panelTitle, "ADC")
-	if(oldTab != 0)
-		PGC_SetAndActivateControl(panelTitle, "ADC", val=0)
+	if(options != MCC_SKIP_UPDATES)
+		// explicitly switch to the data acquistion tab to avoid having
+		// the control layout messed up
+		oldTab = GetTabID(panelTitle, "ADC")
+		if(oldTab != 0)
+			PGC_SetAndActivateControl(panelTitle, "ADC", val=0)
+		endif
 	endif
 
 	WAVE ChanAmpAssign = GetChanAmpAssign(panelTitle)
@@ -3266,8 +3267,10 @@ Function DAP_ChangeHeadStageMode(panelTitle, clampMode, headstage, options)
 		newSliderPos = headstage
 	endif
 
-	if(activeHS || headstage < 0)
-		testPulseMode = TP_StopTestPulse(panelTitle)
+	if(options != MCC_SKIP_UPDATES)
+		if(activeHS || headstage < 0)
+			testPulseMode = TP_StopTestPulse(panelTitle)
+		endif
 	endif
 
 	for(i = 0; i < NUM_HEADSTAGES ; i +=1)
@@ -3290,26 +3293,23 @@ Function DAP_ChangeHeadStageMode(panelTitle, clampMode, headstage, options)
 
 		GuiState[i][%HSmode] = clampMode
 
-		DAP_SetAmpModeControls(panelTitle, i, clampMode)
-		DAP_SetHeadstageChanControls(panelTitle, i, clampMode, delayed = IsFinite(GuiState[i][%HSmode_delayed]))
+		if(options != MCC_SKIP_UPDATES)
+			DAP_SetAmpModeControls(panelTitle, i, clampMode)
+			DAP_SetHeadstageChanControls(panelTitle, i, clampMode, delayed = IsFinite(GuiState[i][%HSmode_delayed]))
+		endif
+
 		AI_SetClampMode(panelTitle, i, clampMode, zeroStep = DAG_GetNumericalValue(panelTitle, "check_Settings_AmpIEQZstep"))
 	endfor
 
-	if(options == SKIP_MCC_MIES_SYNCING)
-		// turn off miesToMCC syncing before moving the slider as we don't want to sync implicitly
-		// as the control procedure of the headstage slider does
-		oldState = DAG_GetNumericalValue(panelTitle, "check_Settings_SyncMiesToMCC")
-		DAG_Update(panelTitle, "check_Settings_SyncMiesToMCC", val = CHECKBOX_UNSELECTED)
-
-		PGC_SetAndActivateControl(panelTitle, "slider_DataAcq_ActiveHeadstage", val = newSliderPos)
-
-		DAG_Update(panelTitle, "check_Settings_SyncMiesToMCC", val = oldState)
+	if(options == MCC_SKIP_UPDATES)
+		// we are done
+		return NaN
 	elseif(options == DO_MCC_MIES_SYNCING)
 		PGC_SetAndActivateControl(panelTitle, "slider_DataAcq_ActiveHeadstage", val = newSliderPos)
 	elseif(options == NO_SLIDER_MOVEMENT)
 		// do nothing
 	else
-		ASSERT(0, "Unsupported mcc mies syncing mode")
+		ASSERT(0, "Unsupported option: " + num2str(options))
 	endif
 
 	DAP_UpdateDAQControls(panelTitle, REASON_HEADSTAGE_CHANGE)

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -3384,10 +3384,9 @@ static Function DAP_SetHeadstageChanControls(panelTitle, headstage, clampMode, [
 	DAP_AllChanDASettings(panelTitle, headStage, delayed = delayed)
 End
 
-/// See @ref MCCSyncOverrides for allowed values of `mccMiesSyncOverride`
-static Function DAP_UpdateClampmodeTabs(panelTitle, headStage, clampMode, mccMiesSyncOverride)
+static Function DAP_UpdateClampmodeTabs(panelTitle, headStage, clampMode)
 	string panelTitle
-	variable headStage, clampMode, mccMiesSyncOverride
+	variable headStage, clampMode
 
 	string highlightSpec = "\\f01\\Z11"
 
@@ -3396,7 +3395,7 @@ static Function DAP_UpdateClampmodeTabs(panelTitle, headStage, clampMode, mccMie
 	AI_SyncAmpStorageToGUI(panelTitle, headStage)
 	PGC_SetAndActivateControl(panelTitle, "tab_DataAcq_Amp", val = clampMode)
 
-	if(DAG_GetNumericalValue(panelTitle, "check_Settings_SyncMiesToMCC") && mccMiesSyncOverride == DO_MCC_MIES_SYNCING)
+	if(DAG_GetNumericalValue(panelTitle, "check_Settings_SyncMiesToMCC"))
 		AI_SyncGUIToAmpStorageAndMCCApp(panelTitle, headStage, clampMode)
 	endif
 
@@ -3781,7 +3780,7 @@ Function DAP_SliderProc_MIESHeadStage(sc) : SliderControl
 		P_UpdatePressureType(panelTitle)
 		P_LoadPressureButtonState(panelTitle)
 		P_UpdatePressureModeTabs(panelTitle, headStage)
-		DAP_UpdateClampmodeTabs(panelTitle, headStage, mode, DO_MCC_MIES_SYNCING)
+		DAP_UpdateClampmodeTabs(panelTitle, headStage, mode)
 		SCOPE_SetADAxisLabel(panelTitle, UNKNOWN_MODE, HeadStage)
 		P_RunP_ControlIfTPOFF(panelTitle)
 	endif

--- a/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
+++ b/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
@@ -3022,6 +3022,44 @@ Function TPDuringDAQOnlyTP_IGNORE(device)
 End
 
 // UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
+Function AutoPipetteOffsetIgnoresApplyOnModeSwitch([str])
+	string str
+
+	string ctrl
+
+	STRUCT DAQSettings s
+	InitDAQSettingsFromString(s, "MD1_RA1_I0_L0_BKG_1_RES_1")
+	AcquireData(s, str, preAcquireFunc=EnableApplyOnModeSwitch_IGNORE, startTPInstead = 1)
+
+	CtrlNamedBackGround DelayReentry, start=(ticks + 300), period=60, proc=AutoPipetteOffsetAndStopTP_IGNORE
+	RegisterUTFMonitor("DelayReentry", BACKGROUNDMONMODE_AND, "AutoPipetteOffsetIgnoresApplyOnModeSwitch_REENTRY", timeout = 600, failOnTimeout = 1)
+End
+
+Function AutoPipetteOffsetIgnoresApplyOnModeSwitch_REENTRY([str])
+	string str
+
+	variable sweepNo
+	string ctrl, stimset, expected
+
+	CHECK_EQUAL_VAR(GetSetVariable(str, "SetVar_Sweep"), 0)
+
+	sweepNo = AFH_GetLastSweepAcquired(str)
+	CHECK_EQUAL_VAR(sweepNo, NaN)
+
+	CHECK_EQUAL_VAR(GetCheckBoxState(str, "check_DA_applyOnModeSwitch"), 1)
+
+	ctrl = GetPanelControl(0, CHANNEL_TYPE_DAC, CHANNEL_CONTROL_WAVE)
+	stimset = GetPopupMenuString(str, ctrl)
+	expected = "StimulusSetA_DA_0"
+	CHECK_EQUAL_STR(stimset, expected)
+
+	ctrl = GetPanelControl(1, CHANNEL_TYPE_DAC, CHANNEL_CONTROL_WAVE)
+	stimset = GetPopupMenuString(str, ctrl)
+	expected = "StimulusSetC_DA_0"
+	CHECK_EQUAL_STR(stimset, expected)
+End
+
+// UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
 Function TPDuringDAQOnlyTP([str])
 	string str
 

--- a/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
+++ b/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
@@ -2783,10 +2783,16 @@ Function EnableApplyOnModeSwitch_IGNORE(device)
 	string ctrl
 
 	ctrl = GetPanelControl(CHANNEL_INDEX_ALL_I_CLAMP, CHANNEL_TYPE_DAC, CHANNEL_CONTROL_WAVE)
-	PGC_SetAndActivateControl(device, ctrl, str = "StimulusSetA_DA_0")
+	PGC_SetAndActivateControl(device, ctrl, str = "StimulusSetE_DA_0")
 
 	ctrl = GetPanelControl(CHANNEL_INDEX_ALL_V_CLAMP, CHANNEL_TYPE_DAC, CHANNEL_CONTROL_WAVE)
+	PGC_SetAndActivateControl(device, ctrl, str = "StimulusSetF_DA_0")
+
+	ctrl = GetPanelControl(0, CHANNEL_TYPE_DAC, CHANNEL_CONTROL_WAVE)
 	PGC_SetAndActivateControl(device, ctrl, str = "StimulusSetA_DA_0")
+
+	ctrl = GetPanelControl(1, CHANNEL_TYPE_DAC, CHANNEL_CONTROL_WAVE)
+	PGC_SetAndActivateControl(device, ctrl, str = "StimulusSetC_DA_0")
 
 	PGC_SetAndActivateControl(device, "check_DA_applyOnModeSwitch", val=1)
 End
@@ -2837,6 +2843,18 @@ Function ChangeCMDuringSweepWMS_REENTRY([str])
 
 	WAVE clampMode = GetLastSetting(numericalValues, 2, "Clamp Mode", DATA_ACQUISITION_MODE)
 	CHECK_EQUAL_WAVES(clampMode, {V_CLAMP_MODE, I_CLAMP_MODE, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode=1)
+
+	WAVE/T textualValues   = GetLBTextualValues(str)
+	WAVE   numericalValues = GetLBNumericalValues(str)
+
+	// the stimsets are not changed as this is delayed clamp mode change in action
+	WAVE/T/Z foundStimSets = GetLastSettingTextEachRAC(numericalValues, textualValues, sweepNo, STIM_WAVE_NAME_KEY, 0, DATA_ACQUISITION_MODE)
+	REQUIRE_WAVE(foundStimSets, TEXT_WAVE)
+	CHECK_EQUAL_TEXTWAVES(foundStimSets, {"StimulusSetA_DA_0", "StimulusSetA_DA_0", "StimulusSetA_DA_0"})
+
+	WAVE/T/Z foundStimSets = GetLastSettingTextEachRAC(numericalValues, textualValues, sweepNo, STIM_WAVE_NAME_KEY, 1, DATA_ACQUISITION_MODE)
+	REQUIRE_WAVE(foundStimSets, TEXT_WAVE)
+	CHECK_EQUAL_TEXTWAVES(foundStimSets, {"StimulusSetC_DA_0", "StimulusSetC_DA_0", "StimulusSetC_DA_0"})
 End
 
 // UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1

--- a/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
+++ b/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
@@ -2768,13 +2768,13 @@ Function ChangeCMDuringSweep_REENTRY([str])
 	WAVE numericalValues = GetLBNumericalValues(str)
 
 	WAVE clampMode = GetLastSetting(numericalValues, 0, "Clamp Mode", DATA_ACQUISITION_MODE)
-	CHECK_EQUAL_WAVES(clampMode, {V_CLAMP_MODE, V_CLAMP_MODE, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode=1)
+	CHECK_EQUAL_WAVES(clampMode, {V_CLAMP_MODE, V_CLAMP_MODE, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode = WAVE_DATA)
 
 	WAVE clampMode = GetLastSetting(numericalValues, 1, "Clamp Mode", DATA_ACQUISITION_MODE)
-	CHECK_EQUAL_WAVES(clampMode, {V_CLAMP_MODE, I_CLAMP_MODE, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode=1)
+	CHECK_EQUAL_WAVES(clampMode, {V_CLAMP_MODE, I_CLAMP_MODE, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode = WAVE_DATA)
 
 	WAVE clampMode = GetLastSetting(numericalValues, 2, "Clamp Mode", DATA_ACQUISITION_MODE)
-	CHECK_EQUAL_WAVES(clampMode, {V_CLAMP_MODE, I_CLAMP_MODE, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode=1)
+	CHECK_EQUAL_WAVES(clampMode, {V_CLAMP_MODE, I_CLAMP_MODE, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode = WAVE_DATA)
 End
 
 Function EnableApplyOnModeSwitch_IGNORE(device)
@@ -2836,13 +2836,13 @@ Function ChangeCMDuringSweepWMS_REENTRY([str])
 	WAVE numericalValues = GetLBNumericalValues(str)
 
 	WAVE clampMode = GetLastSetting(numericalValues, 0, "Clamp Mode", DATA_ACQUISITION_MODE)
-	CHECK_EQUAL_WAVES(clampMode, {V_CLAMP_MODE, V_CLAMP_MODE, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode=1)
+	CHECK_EQUAL_WAVES(clampMode, {V_CLAMP_MODE, V_CLAMP_MODE, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode= WAVE_DATA)
 
 	WAVE clampMode = GetLastSetting(numericalValues, 1, "Clamp Mode", DATA_ACQUISITION_MODE)
-	CHECK_EQUAL_WAVES(clampMode, {V_CLAMP_MODE, I_CLAMP_MODE, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode=1)
+	CHECK_EQUAL_WAVES(clampMode, {V_CLAMP_MODE, I_CLAMP_MODE, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode = WAVE_DATA)
 
 	WAVE clampMode = GetLastSetting(numericalValues, 2, "Clamp Mode", DATA_ACQUISITION_MODE)
-	CHECK_EQUAL_WAVES(clampMode, {V_CLAMP_MODE, I_CLAMP_MODE, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode=1)
+	CHECK_EQUAL_WAVES(clampMode, {V_CLAMP_MODE, I_CLAMP_MODE, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode = WAVE_DATA)
 
 	WAVE/T textualValues   = GetLBTextualValues(str)
 	WAVE   numericalValues = GetLBNumericalValues(str)
@@ -2896,7 +2896,7 @@ Function ChangeCMDuringSweepNoRA_REENTRY([str])
 	WAVE numericalValues = GetLBNumericalValues(str)
 
 	WAVE clampMode = GetLastSetting(numericalValues, 0, "Clamp Mode", DATA_ACQUISITION_MODE)
-	CHECK_EQUAL_WAVES(clampMode, {V_CLAMP_MODE, V_CLAMP_MODE, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode=1)
+	CHECK_EQUAL_WAVES(clampMode, {V_CLAMP_MODE, V_CLAMP_MODE, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode = WAVE_DATA)
 End
 
 Function ITISetupNoTP_IGNORE(device)
@@ -2946,13 +2946,13 @@ Function ChangeCMDuringITI_REENTRY([str])
 	WAVE numericalValues = GetLBNumericalValues(str)
 
 	WAVE clampMode = GetLastSetting(numericalValues, 0, "Clamp Mode", DATA_ACQUISITION_MODE)
-	CHECK_EQUAL_WAVES(clampMode, {V_CLAMP_MODE, V_CLAMP_MODE, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode=1)
+	CHECK_EQUAL_WAVES(clampMode, {V_CLAMP_MODE, V_CLAMP_MODE, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode = WAVE_DATA)
 
 	WAVE clampMode = GetLastSetting(numericalValues, 1, "Clamp Mode", DATA_ACQUISITION_MODE)
-	CHECK_EQUAL_WAVES(clampMode, {V_CLAMP_MODE, I_CLAMP_MODE, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode=1)
+	CHECK_EQUAL_WAVES(clampMode, {V_CLAMP_MODE, I_CLAMP_MODE, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode = WAVE_DATA)
 
 	WAVE clampMode = GetLastSetting(numericalValues, 2, "Clamp Mode", DATA_ACQUISITION_MODE)
-	CHECK_EQUAL_WAVES(clampMode, {V_CLAMP_MODE, I_CLAMP_MODE, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode=1)
+	CHECK_EQUAL_WAVES(clampMode, {V_CLAMP_MODE, I_CLAMP_MODE, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode = WAVE_DATA)
 End
 
 Function ITISetupWithTP_IGNORE(device)
@@ -3005,13 +3005,13 @@ Function ChangeCMDuringITIWithTP_REENTRY([str])
 	WAVE numericalValues = GetLBNumericalValues(str)
 
 	WAVE clampMode = GetLastSetting(numericalValues, 0, "Clamp Mode", DATA_ACQUISITION_MODE)
-	CHECK_EQUAL_WAVES(clampMode, {V_CLAMP_MODE, V_CLAMP_MODE, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode=1)
+	CHECK_EQUAL_WAVES(clampMode, {V_CLAMP_MODE, V_CLAMP_MODE, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode = WAVE_DATA)
 
 	WAVE clampMode = GetLastSetting(numericalValues, 1, "Clamp Mode", DATA_ACQUISITION_MODE)
-	CHECK_EQUAL_WAVES(clampMode, {V_CLAMP_MODE, I_CLAMP_MODE, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode=1)
+	CHECK_EQUAL_WAVES(clampMode, {V_CLAMP_MODE, I_CLAMP_MODE, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode = WAVE_DATA)
 
 	WAVE clampMode = GetLastSetting(numericalValues, 2, "Clamp Mode", DATA_ACQUISITION_MODE)
-	CHECK_EQUAL_WAVES(clampMode, {V_CLAMP_MODE, I_CLAMP_MODE, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode=1)
+	CHECK_EQUAL_WAVES(clampMode, {V_CLAMP_MODE, I_CLAMP_MODE, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode = WAVE_DATA)
 End
 
 Function TPDuringDAQOnlyTP_IGNORE(device)

--- a/Packages/Testing-MIES/UTF_HardwareMain.ipf
+++ b/Packages/Testing-MIES/UTF_HardwareMain.ipf
@@ -492,6 +492,18 @@ Function JustDelay_IGNORE(s)
 	return 1
 End
 
+Function AutoPipetteOffsetAndStopTP_IGNORE(s)
+	STRUCT WMBackgroundStruct &s
+
+	SVAR devices = $GetDevicePanelTitleList()
+	string device = StringFromList(0, devices)
+
+	PGC_SetAndActivateControl(device, "button_DataAcq_AutoPipOffset_VC")
+	PGC_SetAndActivateControl(device, "StartTestPulseButton")
+
+	return 1
+End
+
 Function StopTP_IGNORE(s)
 	STRUCT WMBackgroundStruct &s
 


### PR DESCRIPTION
Close #860.
Close #850.

We still respect "Mode switch via I=0" when changing clamp mode for the auto pipette offset function. Is that correct?
