### PR TITLE
Fix package folder location on disk

### DIFF
--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -1432,3 +1432,7 @@ Constant HW_NI_CONFIG_NRSE                = 2 //< NRSE terminal configuration
 Constant HW_NI_CONFIG_DIFFERENTIAL        = 4 //< Differential terminal configuration
 Constant HW_NI_CONFIG_PSEUDO_DIFFERENTIAL = 8 //< Pseudodifferential terminal configuration
 /// @}
+
+StrConstant PACKAGE_SETTINGS_JSON = "Settings.json"
+
+StrConstant LOGFILE_NAME = "Log.jsonl"

--- a/Packages/MIES/MIES_IgorHooks.ipf
+++ b/Packages/MIES/MIES_IgorHooks.ipf
@@ -245,6 +245,8 @@ static Function IgorStartOrNewHook(igorApplicationNameStr)
 
 	string miesVersion
 
+	PS_FixPackageLocation(PACKAGE_MIES)
+
 	LOG_MarkSessionStart(PACKAGE_MIES)
 
 	miesVersion = ROStr(GetMiesVersion())

--- a/Packages/MIES/MIES_Logging.ipf
+++ b/Packages/MIES/MIES_Logging.ipf
@@ -19,7 +19,7 @@ threadsafe Function/S LOG_GetFile(string package)
 
 	folder = PS_GetSettingsFolder_TS(package)
 
-	return folder + ":Log.jsonl"
+	return folder + "Log.jsonl"
 End
 
 /// @brief Check that the given JSON document has the required top level keys

--- a/Packages/MIES/MIES_Logging.ipf
+++ b/Packages/MIES/MIES_Logging.ipf
@@ -19,7 +19,7 @@ threadsafe Function/S LOG_GetFile(string package)
 
 	folder = PS_GetSettingsFolder_TS(package)
 
-	return folder + "Log.jsonl"
+	return folder + LOGFILE_NAME
 End
 
 /// @brief Check that the given JSON document has the required top level keys

--- a/Packages/MIES/MIES_PackageSettings.ipf
+++ b/Packages/MIES/MIES_PackageSettings.ipf
@@ -69,6 +69,8 @@ End
 ///
 ///        Threadsafe variant which requires the symbolic path `PackageFolder` created by
 ///        PS_Initialize() to exist.
+///
+///        The returned folder location includes a trailing colon (":")
 threadsafe Function/S PS_GetSettingsFolder_TS(package)
 	string package
 
@@ -80,6 +82,8 @@ End
 
 /// @brief Return the absolute path to the settings folder for `package`
 ///        creating it when necessary.
+///
+///        The returned folder location includes a trailing colon (":")
 Function/S PS_GetSettingsFolder(package)
 	string package
 
@@ -103,7 +107,7 @@ static Function/S PS_GetSettingsFile(package)
 
 	folder = PS_GetSettingsFolder(package)
 
-	return folder + ":Settings.json"
+	return folder + "Settings.json"
 End
 
 /// @brief Move the window to the stored location

--- a/Packages/MIES/MIES_PackageSettings.ipf
+++ b/Packages/MIES/MIES_PackageSettings.ipf
@@ -107,7 +107,7 @@ static Function/S PS_GetSettingsFile(package)
 
 	folder = PS_GetSettingsFolder(package)
 
-	return folder + "Settings.json"
+	return folder + PACKAGE_SETTINGS_JSON
 End
 
 /// @brief Move the window to the stored location


### PR DESCRIPTION
Since c87daee1 (MIES_PackageSettings.ipf: Extract settings folder
creation into separate function, 2021-03-09) we created the log file and
the JSON settings file in the folder

C:\Users\$user\AppData\Roaming\WaveMetrics\Igor Pro 8\Packages

instead of

C:\Users\$user\AppData\Roaming\WaveMetrics\Igor Pro 8\Packages\MIES

.

The reason is that the path contained an additional colon (":") which in
IP lingua means "go down one folder". But that was only the case in IP8,
IP9 has a bug where this was is not done.

Remove the additional colon so that it works with all IP versions.

@timjarsky I don't have a automatic fix, which means that we move the files from the wrong location to the right location, included. Should I?