### PR TITLE
.gitattributes: Fix linguist overrides

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -58,8 +58,8 @@ tools/unit-testing/*.pxp filter=compress
 *.nwb filter=compress
 
 # github specialities, see https://github.com/github/linguist
-Packages/doc/* linguist-documentation
+Packages/doc/** linguist-documentation
 
-tools/installer/nsis/* linguist-vendored
-tools/installer/Shelllink/* linguist-vendored
-tools/installer/AccessControl/* linguist-vendored
+tools/installer/nsis/** linguist-vendored
+tools/installer/Shelllink/** linguist-vendored
+tools/installer/AccessControl/** linguist-vendored


### PR DESCRIPTION
We actually need to use ** as only that recurses into subdirectories.

Not properly done in 86575bf7 (.gitattributes: Mark more paths as non
source code for github, 2021-01-27).