### PR TITLE
MIES_Include.ipf: Raise required IP8 version

### DIFF
--- a/Packages/MIES_Include.ipf
+++ b/Packages/MIES_Include.ipf
@@ -15,7 +15,7 @@
 // These are sphinx substitutions destined for Packages/doc/installation_subst.txt.
 // They are defined here so that we can parse them from within IP.
 //
-// .. |IgorPro8Nightly| replace:: `Igor Pro 8 <https://www.byte-physics.de/Downloads/WinIgor8_06MAY2020.zip>`__
+// .. |IgorPro8Nightly| replace:: `Igor Pro 8 <https://www.byte-physics.de/Downloads/WinIgor8_28APR2021.zip>`__
 // .. |IgorPro9Nightly| replace:: `Igor Pro 9 <https://www.byte-physics.de/Downloads/WinIgor9_02FEB2021.zip>`__
 
 #pragma IgorVersion=8.04
@@ -25,7 +25,7 @@
 #define TOO_OLD_IGOR
 #endif
 #else
-#if (NumberByKey("BUILD", IgorInfo(0)) < 35712)
+#if (NumberByKey("BUILD", IgorInfo(0)) < 37395)
 #define TOO_OLD_IGOR
 #endif
 #endif


### PR DESCRIPTION
This resolves the slow compilation issues with the navigation bar
enabled and might also avoid the minute long lockup then NewExperiment
is called.

Close #912.

We nearly had for one year the same IP8 nightly. Glad I "fixed" that.