### PR TITLE
NWB_CheckForMissingSweeps: Handle no sweeps gracefully

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,12 @@
 [submodule "Packages/unit-testing"]
-	fetchRecurseSubmodules = false
 	path = Packages/unit-testing
 	shallow = true
 	url = https://github.com/byte-physics/igor-unit-testing-framework
 [submodule "Packages/IPNWB"]
-	fetchRecurseSubmodules = true
 	path = Packages/IPNWB
 	shallow = true
 	url = https://github.com/AllenInstitute/IPNWB
 [submodule "Packages/doc/doxygen-filter-ipf"]
-	fetchRecurseSubmodules = false
 	path = Packages/doc/doxygen-filter-ipf
 	shallow = true
 	url = https://github.com/byte-physics/doxygen-filter-ipf

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -2548,7 +2548,7 @@ Function DAP_CheckSettings(panelTitle, mode)
 	endif
 
 	if(DAG_GetNumericalValue(panelTitle, "Check_Settings_NwbExport"))
-		NWB_PrepareExport(DAG_GetNumericalValue(panelTitle, "Popup_Settings_NwbVersion"))
+		NWB_PrepareExport(str2num(DAG_GetTextualValue(panelTitle, "Popup_Settings_NwbVersion")))
 	endif
 
 	return 0

--- a/Packages/MIES/MIES_DAEphys_GuiState.ipf
+++ b/Packages/MIES/MIES_DAEphys_GuiState.ipf
@@ -167,6 +167,8 @@ End
 
 /// @brief Query a control value from the numerical gui state wave
 ///
+/// This does return the zero-based *index* for PopupMenues.
+///
 /// Convienience wrapper to make the call sites nicer.
 ///
 /// @param panelTitle device

--- a/Packages/MIES/MIES_Debugging.ipf
+++ b/Packages/MIES/MIES_Debugging.ipf
@@ -315,8 +315,12 @@ Function DEBUGPRINTSTACKINFO()
 
 	print GetStackTrace(prefix = "\tDEBUG ")
 
+	if(!cmpstr(GetExperimentName(), UNTITLED_EXPERIMENT))
+		// do nothing
+		return NaN
+	endif
+
 	if(!windowExists("HistoryCarbonCopy"))
-		ASSERT(cmpstr(GetExperimentName(), UNTITLED_EXPERIMENT), "Untitled experiments do not work")
 		CreateHistoryLog()
 	endif
 
@@ -343,6 +347,8 @@ static Function SaveHistoryLog()
 		ControlWindowToFront()
 		return NaN
 	endif
+
+	ASSERT(cmpstr(GetExperimentName(), UNTITLED_EXPERIMENT), "Untitled experiments do not work")
 
 	SaveNoteBook/O/S=3/P=home HistoryCarbonCopy as historyLog
 End

--- a/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
+++ b/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
@@ -302,16 +302,12 @@ static Function NWB_AddDeviceSpecificData(locationID, panelTitle, nwbVersion, [c
 		IPNWB#WriteNeuroDataType(locationID, path, "LabNotebookDevice")
 	endif
 
-	WAVE/Z numericalValuesTrimmed = RemoveUnusedRows(numericalValues)
-	if(WaveExists(numericalValuesTrimmed))
-		IPNWB#H5_WriteDataset(groupID, "numericalValues", wv=numericalValuesTrimmed, writeIgorAttr=1, overwrite=1, compressionMode = compressionMode)
-	endif
+	WAVE numericalValuesTrimmed = RemoveUnusedRows(numericalValues)
+	IPNWB#H5_WriteDataset(groupID, "numericalValues", wv=numericalValuesTrimmed, writeIgorAttr=1, overwrite=1, compressionMode = compressionMode)
 	IPNWB#H5_WriteTextDataset(groupID, "numericalKeys", wvText=numericalKeys, writeIgorAttr=1, overwrite=1, compressionMode = compressionMode)
 
-	WAVE/Z textualValuesTrimmed = RemoveUnusedRows(textualValues)
-	if(WaveExists(textualValuesTrimmed))
-		IPNWB#H5_WriteTextDataset(groupID, "textualValues", wvText=textualValuesTrimmed, writeIgorAttr=1, overwrite=1, compressionMode = compressionMode)
-	endif
+	WAVE textualValuesTrimmed = RemoveUnusedRows(textualValues)
+	IPNWB#H5_WriteTextDataset(groupID, "textualValues", wvText=textualValuesTrimmed, writeIgorAttr=1, overwrite=1, compressionMode = compressionMode)
 
 	IPNWB#H5_WriteTextDataset(groupID, "textualKeys", wvText=textualKeys, writeIgorAttr=1, overwrite=1, compressionMode = compressionMode)
 
@@ -369,13 +365,11 @@ static Function NWB_AddDeviceSpecificData(locationID, panelTitle, nwbVersion, [c
 		name = StringFromList(i, list)
 		WAVE/SDFR=dfr wv = $name
 
-		WAVE/Z wvTrimmed = RemoveUnusedRows(wv)
-		if(WaveExists(wvTrimmed))
-			IPNWB#H5_WriteDataset(groupID, name, wv=wvTrimmed, writeIgorAttr=1, overwrite=1, compressionMode = compressionMode)
+		WAVE wvTrimmed = RemoveUnusedRows(wv)
+		IPNWB#H5_WriteDataset(groupID, name, wv=wvTrimmed, writeIgorAttr=1, overwrite=1, compressionMode = compressionMode)
 
-			if(nwbVersion == 2)
-				IPNWB#WriteNeuroDataType(groupID, name, "TestpulseMetadata")
-			endif
+		if(nwbVersion == 2)
+			IPNWB#WriteNeuroDataType(groupID, name, "TestpulseMetadata")
 		endif
 	endfor
 

--- a/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
+++ b/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
@@ -501,9 +501,17 @@ End
 Function NWB_CheckForMissingSweeps(string panelTitle, WAVE/T sweepNames)
 	WAVE numericalValues = GetLBNumericalValues(panelTitle)
 
-	WAVE sweepsFromLBN = GetSweepsWithSetting(numericalValues, "SweepNum")
+	WAVE/Z sweepsFromLBN = GetSweepsWithSetting(numericalValues, "SweepNum")
 
-	Make/FREE/N=(DimSize(sweepNames, ROWS)) sweepsFromDFR = ExtractSweepNumber(sweepNames[p])
+	if(!WaveExists(sweepsFromLBN))
+		Make/FREE/N=(0) sweepsFromLBN
+	endif
+
+	if(DimSize(sweepNames, ROWS) == 0)
+		Make/FREE/N=(0) sweepsFromDFR
+	else
+		Make/FREE/N=(DimSize(sweepNames, ROWS)) sweepsFromDFR = ExtractSweepNumber(sweepNames[p])
+	endif
 
 	if(EqualWaves(sweepsfromLBN, sweepsFromDFR, 1) == 1)
 		return 0

--- a/Packages/MIES/MIES_SweepSaving.ipf
+++ b/Packages/MIES/MIES_SweepSaving.ipf
@@ -55,7 +55,7 @@ Function SWS_SaveAcquiredData(panelTitle, [forcedStop])
 	ED_createWaveNoteTags(panelTitle, sweepNo)
 
 	if(DAG_GetNumericalValue(panelTitle, "Check_Settings_NwbExport"))
-		NWB_AppendSweep(panelTitle, sweepWave, configWave, sweepNo, DAG_GetNumericalValue(panelTitle, "Popup_Settings_NwbVersion"))
+		NWB_AppendSweep(panelTitle, sweepWave, configWave, sweepNo, str2num(DAG_GetTextualValue(panelTitle, "Popup_Settings_NwbVersion")))
 	endif
 
 	SWS_AfterSweepDataChangeHook(panelTitle)

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -5504,6 +5504,11 @@ End
 
 /// @brief Remove unused rows from the passed wave and return a copy of it.
 ///
+/// If the wave is empty with index being zero, we return a wave with one point
+/// so that we:
+/// - can store something non-empty
+/// - preserve the dimension labels (this can get lost for empty waves when duplication/saving)
+///
 /// @see EnsureLargeEnoughWave()
 Function/WAVE RemoveUnusedRows(WAVE wv)
 
@@ -5513,13 +5518,11 @@ Function/WAVE RemoveUnusedRows(WAVE wv)
 
 	if(IsNaN(index))
 		return wv
-	elseif(index == 0)
-		return $""
 	endif
 
-	ASSERT(IsInteger(index) && index > 0, "Expected strictly positive and integer NOTE_INDEX")
+	ASSERT(IsInteger(index) && index >= 0, "Expected non-negative and integer NOTE_INDEX")
 
-	Duplicate/FREE/RMD=[0, index - 1] wv, dup
+	Duplicate/FREE/RMD=[0, max(0, index - 1)] wv, dup
 
 	return dup
 End

--- a/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
+++ b/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
@@ -4676,3 +4676,53 @@ Function ExportStimsetsAndRoundtripThem([variable var])
 		CHECK_EQUAL_WAVES(oldWave, newWave)
 	endfor
 End
+
+/// UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
+Function ExportIntoNWB([str])
+	string str
+
+	string filePathExport, experimentName
+
+	STRUCT DAQSettings s
+	InitDAQSettingsFromString(s, "MD1_RA0_I0_L0_BKG_1")
+
+	CloseNwBFile()
+	PathInfo home
+	CHECK(V_Flag)
+
+	experimentName = GetExperimentName()
+	CHECK(cmpstr(experimentName, UNTITLED_EXPERIMENT))
+
+	DeleteFile/Z S_path + experimentName + ".nwb"
+
+	AcquireData(s, str, startTPInstead = 1)
+
+	CtrlNamedBackGround StopTPAfterFiveSeconds, start=(ticks + TP_DURATION_S * 60), period=1, proc=StopTPAfterFiveSeconds_IGNORE
+End
+
+Function ExportIntoNWB_REENTRY([str])
+	string str
+	variable sweepNo
+
+	CHECK_EQUAL_VAR(GetSetVariable(str, "SetVar_Sweep"), 0)
+
+	sweepNo = AFH_GetLastSweepAcquired(str)
+	CHECK_EQUAL_VAR(sweepNo, NaN)
+
+	RegisterReentryFunction(GetRTStackInfo(1))
+
+	PGC_SetAndActivateControl(str, "Check_Settings_NwbExport", val = CHECKBOX_SELECTED)
+	PGC_SetAndActivateControl(str, "StartTestPulseButton")
+
+	CtrlNamedBackGround StopTPAfterFiveSeconds, start=(ticks + TP_DURATION_S * 60), period=1, proc=StopTPAfterFiveSeconds_IGNORE
+End
+
+Function ExportIntoNWB_REENTRY_REENTRY([str])
+	string str
+	variable sweepNo
+
+	CHECK_EQUAL_VAR(GetSetVariable(str, "SetVar_Sweep"), 0)
+
+	sweepNo = AFH_GetLastSweepAcquired(str)
+	CHECK_EQUAL_VAR(sweepNo, NaN)
+End

--- a/Packages/Testing-MIES/UTF_HelperFunctions.ipf
+++ b/Packages/Testing-MIES/UTF_HelperFunctions.ipf
@@ -38,6 +38,9 @@ Function AdditionalExperimentCleanup()
 	name = GetDataFolder(0, dfr)
 	MoveDataFolder/O=1 dfr, root:
 
+	CloseNWBFile()
+	HDF5CloseFile/A/Z 0
+
 	KillOrMoveToTrash(dfr=root:MIES)
 
 	NewDataFolder root:MIES

--- a/Packages/Testing-MIES/UTF_Utils.ipf
+++ b/Packages/Testing-MIES/UTF_Utils.ipf
@@ -694,13 +694,13 @@ Function RUR_ChecksNote2()
 	endtry
 End
 
-Function RUR_ReturnsInvalidWaveRef()
+Function RUR_ReturnsAlwaysAWave()
 
 	Make/FREE wv
 	SetNumberInWaveNote(wv, NOTE_INDEX, 0)
 
-	WAVE/Z dup = RemoveUnusedRows(wv)
-	CHECK_WAVE(dup, NULL_WAVE)
+	WAVE dup = RemoveUnusedRows(wv)
+	CHECK_EQUAL_WAVES(dup, {0}, mode = WAVE_DATA | WAVE_DATA_TYPE | DIMENSION_SIZES)
 End
 
 Function RUR_Works()


### PR DESCRIPTION
Calling NWB_ExportAllData where at least one device has content but no
sweeps currently leads to NWB_CheckForMissingSweeps bugging out as
GetSweepsWithSetting returns a null wave.

Bug introduced in 6a432cb7 (Add code to allow recovering deleted sweeps,
2021-04-19).

- [x] Add test
- [x] Think about fix again