### PR TITLE
Document daq stopping reason

### DIFF
--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -629,7 +629,7 @@ Constant WAVEBUILDER_PANEL_VERSION         = 9
 /// - Changed names of entries
 /// - Changed units or meaning of entries
 /// - New/Changed layers of entries
-Constant LABNOTEBOOK_VERSION = 44
+Constant LABNOTEBOOK_VERSION = 45
 
 /// Version of the stimset wave note
 Constant STIMSET_NOTE_VERSION = 7

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -629,7 +629,7 @@ Constant WAVEBUILDER_PANEL_VERSION         = 9
 /// - Changed names of entries
 /// - Changed units or meaning of entries
 /// - New/Changed layers of entries
-Constant LABNOTEBOOK_VERSION = 45
+Constant LABNOTEBOOK_VERSION = 46
 
 /// Version of the stimset wave note
 Constant STIMSET_NOTE_VERSION = 7
@@ -1489,3 +1489,19 @@ StrConstant IVS_PUB_FILTER = "ivscc"
 Constant PSQ_CR_SPIKE_CHECK_DEFAULT = 1
 
 StrConstant NOT_AVAILABLE = "n/a"
+
+/// @name Flags for stopping DAQ
+/// @anchor DAQStoppingFlags
+///
+/// @{
+Constant DQ_STOP_REASON_DAQ_BUTTON        = 0x001
+Constant DQ_STOP_REASON_CONFIG_FAILED     = 0x002
+Constant DQ_STOP_REASON_FINISHED          = 0x004
+Constant DQ_STOP_REASON_UNCOMPILED        = 0x008
+Constant DQ_STOP_REASON_HW_ERROR          = 0x010
+Constant DQ_STOP_REASON_ESCAPE_KEY        = 0x020
+Constant DQ_STOP_REASON_TP_STARTED        = 0x040
+Constant DQ_STOP_REASON_STIMSET_SELECTION = 0x080
+Constant DQ_STOP_REASON_UNLOCKED_DEVICE   = 0x100
+Constant DQ_STOP_REASON_OUT_OF_MEMORY     = 0x200
+/// @}

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -1344,10 +1344,7 @@ End
 /// @param panelTitle      device
 /// @param forcedStop      [optional, defaults to false] if DAQ was aborted (true) or stopped by itself (false)
 /// @param startTPAfterDAQ [optional, defaults to true]  start "TP after DAQ" if enabled at the end
-Function DAP_OneTimeCallAfterDAQ(panelTitle, [forcedStop, startTPAfterDAQ])
-	string panelTitle
-	variable forcedStop, startTPAfterDAQ
-
+Function DAP_OneTimeCallAfterDAQ(string panelTitle, [variable forcedStop, variable startTPAfterDAQ])
 	variable hardwareType
 
 	forcedStop      = ParamIsDefault(forcedStop)      ? 0 : !!forcedStop

--- a/Packages/MIES/MIES_DataAcquisition.ipf
+++ b/Packages/MIES/MIES_DataAcquisition.ipf
@@ -40,9 +40,7 @@ End
 ///
 /// @param panelTitle      device
 /// @param startTPAfterDAQ [optional, defaults to true]  start "TP after DAQ" if enabled
-Function DQ_StopOngoingDAQ(panelTitle, [startTPAfterDAQ])
-	string panelTitle
-	variable startTPAfterDAQ
+Function DQ_StopOngoingDAQ(string panelTitle, [variable startTPAfterDAQ])
 
 	startTPAfterDAQ = ParamIsDefault(startTPAfterDAQ) ? 1 : !!startTPAfterDAQ
 
@@ -68,10 +66,7 @@ static Function DQ_StopOngoingDAQHelperNoTPA(panelTitle)
 End
 
 /// @brief Stop the testpulse and data acquisition
-static Function DQ_StopOngoingDAQHelper(panelTitle, [startTPAfterDAQ])
-	string panelTitle
-	variable startTPAfterDAQ
-
+static Function DQ_StopOngoingDAQHelper(string panelTitle, [variable startTPAfterDAQ])
 	variable needsOTCAfterDAQ = 0
 	variable discardData      = 0
 	variable stopDeviceTimer  = 0
@@ -206,10 +201,7 @@ End
 ///
 /// Assumes that single device and multi device do not run at the same time.
 /// @return One of @ref DAQRunModes
-Function DQ_StopDAQ(panelTitle, [startTPAfterDAQ])
-	string panelTitle
-	variable startTPAfterDAQ
-
+Function DQ_StopDAQ(string panelTitle, [variable startTPAfterDAQ])
 	variable runMode
 
 	startTPAfterDAQ = ParamIsDefault(startTPAfterDAQ) ? 1 : !!startTPAfterDAQ

--- a/Packages/MIES/MIES_DataAcquisition.ipf
+++ b/Packages/MIES/MIES_DataAcquisition.ipf
@@ -197,11 +197,9 @@ Function DQ_StopDAQ(string panelTitle, [variable startTPAfterDAQ])
 
 	startTPAfterDAQ = ParamIsDefault(startTPAfterDAQ) ? 1 : !!startTPAfterDAQ
 
-	NVAR dataAcqRunMode = $GetDataAcqRunMode(panelTitle)
-
-	// create copy as the implicitly called DAP_OneTimeCallAfterDAQ()
+	// create readonly copy as the implicitly called DAP_OneTimeCallAfterDAQ()
 	// will change it
-	runMode = dataAcqRunMode
+	runMode = ROVar(GetDataAcqRunMode(panelTitle))
 
 	switch(runMode)
 		case DAQ_FG_SINGLE_DEVICE:

--- a/Packages/MIES/MIES_DataAcquisition.ipf
+++ b/Packages/MIES/MIES_DataAcquisition.ipf
@@ -10,7 +10,7 @@
 /// @brief __DQ__ Routines for Data acquisition
 
 /// @brief Stop DAQ and TP on all locked devices
-Function DQ_StopOngoingDAQAllLocked()
+Function DQ_StopOngoingDAQAllLocked(variable stopReason)
 	string panelTitle
 
 	variable i, numDev, err
@@ -21,7 +21,7 @@ Function DQ_StopOngoingDAQAllLocked()
 	for(i = 0; i < numDev; i += 1)
 		device = StringFromList(i, devices)
 
-		DQ_StopOngoingDAQ(device, startTPAfterDAQ = 0); err = GetRTError(1)
+		DQ_StopOngoingDAQ(device, stopReason, startTPAfterDAQ = 0); err = GetRTError(1)
 	endfor
 End
 
@@ -30,8 +30,9 @@ End
 /// Works with single/multi device mode and on yoked devices simultaneously.
 ///
 /// @param panelTitle      device
+/// @param stopReason      One of @ref DAQStoppingFlags
 /// @param startTPAfterDAQ [optional, defaults to true]  start "TP after DAQ" if enabled
-Function DQ_StopOngoingDAQ(string panelTitle, [variable startTPAfterDAQ])
+Function DQ_StopOngoingDAQ(string panelTitle, variable stopReason, [variable startTPAfterDAQ])
 	variable i, numEntries
 	string list, device
 
@@ -42,12 +43,12 @@ Function DQ_StopOngoingDAQ(string panelTitle, [variable startTPAfterDAQ])
 
 	for(i = 0; i < numEntries; i += 1)
 		device = StringFromList(i, list)
-		DQ_StopOngoingDAQHelper(device, startTPAfterDAQ)
+		DQ_StopOngoingDAQHelper(device, stopReason, startTPAfterDAQ)
 	endfor
 End
 
 /// @brief Stop the testpulse and data acquisition
-static Function DQ_StopOngoingDAQHelper(string panelTitle, variable startTPAfterDAQ)
+static Function DQ_StopOngoingDAQHelper(string panelTitle, variable stopReason, variable startTPAfterDAQ)
 	variable needsOTCAfterDAQ = 0
 	variable discardData      = 0
 	variable stopDeviceTimer  = 0
@@ -120,7 +121,7 @@ static Function DQ_StopOngoingDAQHelper(string panelTitle, variable startTPAfter
 	endif
 
 	if(needsOTCAfterDAQ)
-		DAP_OneTimeCallAfterDAQ(panelTitle, forcedStop = 1, startTPAfterDAQ = startTPAfterDAQ)
+		DAP_OneTimeCallAfterDAQ(panelTitle, stopReason, forcedStop = 1, startTPAfterDAQ = startTPAfterDAQ)
 	endif
 End
 
@@ -180,7 +181,7 @@ End
 ///
 /// Assumes that single device and multi device do not run at the same time.
 /// @return One of @ref DAQRunModes
-Function DQ_StopDAQ(string panelTitle, [variable startTPAfterDAQ])
+Function DQ_StopDAQ(string panelTitle, variable stopReason, [variable startTPAfterDAQ])
 	variable runMode
 
 	startTPAfterDAQ = ParamIsDefault(startTPAfterDAQ) ? 1 : !!startTPAfterDAQ
@@ -195,7 +196,7 @@ Function DQ_StopDAQ(string panelTitle, [variable startTPAfterDAQ])
 			return runMode
 		case DAQ_BG_SINGLE_DEVICE:
 		case DAQ_BG_MULTI_DEVICE:
-			DQ_StopOngoingDAQ(panelTitle, startTPAfterDAQ = startTPAfterDAQ)
+			DQ_StopOngoingDAQ(panelTitle, stopReason, startTPAfterDAQ = startTPAfterDAQ)
 			return runMode
 	endswitch
 

--- a/Packages/MIES/MIES_DataAcquisition.ipf
+++ b/Packages/MIES/MIES_DataAcquisition.ipf
@@ -32,37 +32,25 @@ End
 /// @param panelTitle      device
 /// @param startTPAfterDAQ [optional, defaults to true]  start "TP after DAQ" if enabled
 Function DQ_StopOngoingDAQ(string panelTitle, [variable startTPAfterDAQ])
+	variable i, numEntries
+	string list, device
 
 	startTPAfterDAQ = ParamIsDefault(startTPAfterDAQ) ? 1 : !!startTPAfterDAQ
 
-	if(startTPAfterDAQ)
-		DQM_CallFuncForDevicesYoked(panelTitle, DQ_StopOngoingDAQHelperWithTPA)
-	else
-		DQM_CallFuncForDevicesYoked(panelTitle, DQ_StopOngoingDAQHelperNoTPA)
-	endif
-End
+	list = GetListofLeaderAndPossFollower(panelTitle)
+	numEntries = ItemsInList(list)
 
-/// @brief Helper function for DQ_StopOngoingDAQHelper() with CallFunctionForEachListItem() compatible signature
-static Function DQ_StopOngoingDAQHelperWithTPA(panelTitle)
-	string panelTitle
-
-	DQ_StopOngoingDAQHelper(panelTitle, startTPAfterDAQ = 1)
-End
-
-/// @brief Helper function for DQ_StopOngoingDAQHelper() with CallFunctionForEachListItem() compatible signature
-static Function DQ_StopOngoingDAQHelperNoTPA(panelTitle)
-	string panelTitle
-
-	DQ_StopOngoingDAQHelper(panelTitle, startTPAfterDAQ = 0)
+	for(i = 0; i < numEntries; i += 1)
+		device = StringFromList(i, list)
+		DQ_StopOngoingDAQHelper(device, startTPAfterDAQ)
+	endfor
 End
 
 /// @brief Stop the testpulse and data acquisition
-static Function DQ_StopOngoingDAQHelper(string panelTitle, [variable startTPAfterDAQ])
+static Function DQ_StopOngoingDAQHelper(string panelTitle, variable startTPAfterDAQ)
 	variable needsOTCAfterDAQ = 0
 	variable discardData      = 0
 	variable stopDeviceTimer  = 0
-
-	startTPAfterDAQ = ParamIsDefault(startTPAfterDAQ) ? 1 : !!startTPAfterDAQ
 
 	if(IsDeviceActiveWithBGTask(panelTitle, TASKNAME_TP))
 		TPS_StopTestPulseSingleDevice(panelTitle)

--- a/Packages/MIES/MIES_DataAcquisition.ipf
+++ b/Packages/MIES/MIES_DataAcquisition.ipf
@@ -13,25 +13,16 @@
 Function DQ_StopOngoingDAQAllLocked()
 	string panelTitle
 
-	variable i, numDev, debuggerState
+	variable i, numDev, err
 	string device
-
-	debuggerState = DisableDebugger()
 
 	SVAR devices = $GetDevicePanelTitleList()
 	numDev = ItemsInList(devices)
 	for(i = 0; i < numDev; i += 1)
 		device = StringFromList(i, devices)
 
-		try
-			ClearRTError()
-			DQ_StopOngoingDAQ(device, startTPAfterDAQ = 0); AbortOnRTE
-		catch
-			ClearRTError()
-		endtry
+		DQ_StopOngoingDAQ(device, startTPAfterDAQ = 0); err = GetRTError(1)
 	endfor
-
-	ResetDebuggerState(debuggerState)
 End
 
 /// @brief Stop the DAQ and testpulse

--- a/Packages/MIES/MIES_DataAcquisition_Multi.ipf
+++ b/Packages/MIES/MIES_DataAcquisition_Multi.ipf
@@ -63,7 +63,7 @@ Function DQM_FIFOMonitor(s)
 					errMsg = GetRTErrMessage()
 					err = ClearRTError()
 					LOG_AddEntry(PACKAGE_MIES, "hardware error")
-					DQ_StopOngoingDAQ(panelTitle, startTPAfterDAQ = 0)
+					DQ_StopOngoingDAQ(panelTitle, DQ_STOP_REASON_HW_ERROR, startTPAfterDAQ = 0)
 					if(err == 18)
 						ASSERT(0, "Acquisition FIFO overflow, data lost. This may happen if the computer is too slow.")
 					else
@@ -110,7 +110,7 @@ Function DQM_FIFOMonitor(s)
 		endif
 
 		if(GetKeyState(0) & ESCAPE_KEY)
-			DQ_StopOngoingDAQ(panelTitle, startTPAfterDAQ = 0)
+			DQ_StopOngoingDAQ(panelTitle, DQ_STOP_REASON_ESCAPE_KEY, startTPAfterDAQ = 0)
 			return 1
 		endif
 	endfor
@@ -179,7 +179,7 @@ Function DQM_StartDAQMultiDevice(panelTitle, [initialSetupReq])
 		NVAR maxITI = $GetMaxIntertrialInterval(panelTitle)
 	catch
 		if(initialSetupReq)
-			DAP_OneTimeCallAfterDAQ(panelTitle, forcedStop = 1)
+			DAP_OneTimeCallAfterDAQ(panelTitle, DQ_STOP_REASON_CONFIG_FAILED, forcedStop = 1)
 		else // required for RA for the lead device only
 			DQ_StopDAQDeviceTimer(panelTitle)
 		endif
@@ -219,10 +219,10 @@ Function DQM_StartDAQMultiDevice(panelTitle, [initialSetupReq])
 		if(initialSetupReq)
 			for(i = 0; i < numFollower; i += 1)
 				followerPanelTitle = StringFromList(i, listOfFollowerDevices)
-				DAP_OneTimeCallAfterDAQ(followerPanelTitle, forcedStop = 1)
+				DAP_OneTimeCallAfterDAQ(followerPanelTitle, DQ_STOP_REASON_CONFIG_FAILED, forcedStop = 1)
 			endfor
 
-			DAP_OneTimeCallAfterDAQ(panelTitle, forcedStop = 1)
+			DAP_OneTimeCallAfterDAQ(panelTitle, DQ_STOP_REASON_CONFIG_FAILED, forcedStop = 1)
 		else // required for RA for the lead device only
 			DQ_StopDAQDeviceTimer(panelTitle)
 		endif

--- a/Packages/MIES/MIES_DataAcquisition_Multi.ipf
+++ b/Packages/MIES/MIES_DataAcquisition_Multi.ipf
@@ -62,6 +62,7 @@ Function DQM_FIFOMonitor(s)
 				catch
 					errMsg = GetRTErrMessage()
 					err = ClearRTError()
+					LOG_AddEntry(PACKAGE_MIES, "hardware error")
 					DQ_StopOngoingDAQ(panelTitle, startTPAfterDAQ = 0)
 					if(err == 18)
 						ASSERT(0, "Acquisition FIFO overflow, data lost. This may happen if the computer is too slow.")

--- a/Packages/MIES/MIES_DataAcquisition_Single.ipf
+++ b/Packages/MIES/MIES_DataAcquisition_Single.ipf
@@ -35,7 +35,7 @@ Function DQS_StartDAQSingleDevice(panelTitle, [useBackground])
 		DC_Configure(panelTitle, DATA_ACQUISITION_MODE)
 	catch
 		// we need to undo the earlier one time call only
-		DAP_OneTimeCallAfterDAQ(panelTitle, forcedStop = 1)
+		DAP_OneTimeCallAfterDAQ(panelTitle, DQ_STOP_REASON_CONFIG_FAILED, forcedStop = 1)
 		return NaN
 	endtry
 
@@ -77,12 +77,12 @@ Function DQS_DataAcq(panelTitle)
 
 		DoUpdate/W=$oscilloscopeSubwindow
 		if(GetKeyState(0) & ESCAPE_KEY)
-			DQS_StopDataAcq(panelTitle, forcedStop = 1)
+			DQS_StopDataAcq(panelTitle, DQ_STOP_REASON_ESCAPE_KEY, forcedStop = 1)
 			return NaN
 		endif
 	while(moreData)
 
-	DQS_StopDataAcq(panelTitle)
+	DQS_StopDataAcq(panelTitle, DQ_STOP_REASON_FINISHED)
 End
 
 /// @brief Fifo monitor for DAQ Single Device
@@ -105,7 +105,7 @@ Function DQS_BkrdDataAcq(panelTitle)
 End
 
 /// @brief Stop single device data acquisition
-static Function DQS_StopDataAcq(string panelTitle, [variable forcedStop])
+static Function DQS_StopDataAcq(string panelTitle, variable stopReason, [variable forcedStop])
 	if(ParamIsDefault(forcedStop))
 		forcedStop = 0
 	else
@@ -117,7 +117,7 @@ static Function DQS_StopDataAcq(string panelTitle, [variable forcedStop])
 	SWS_SaveAcquiredData(panelTitle, forcedStop = forcedStop)
 
 	if(forcedStop)
-		DQ_StopOngoingDAQ(panelTitle)
+		DQ_StopOngoingDAQ(panelTitle, stopReason)
 	else
 		RA_ContinueOrStop(panelTitle, multiDevice=0)
 	endif
@@ -155,12 +155,12 @@ Function DQS_FIFOMonitor(s)
 
 	if(!moreData)
 		DQS_STOPBackgroundFifoMonitor()
-		DQS_StopDataAcq(panelTitleG)
+		DQS_StopDataAcq(panelTitleG, DQ_STOP_REASON_FINISHED)
 		return 1
 	endif
 
 	if(GetKeyState(0) & ESCAPE_KEY)
-		DQ_StopOngoingDAQ(panelTitleG, startTPAfterDAQ = 0)
+		DQ_StopOngoingDAQ(panelTitleG, DQ_STOP_REASON_ESCAPE_KEY, startTPAfterDAQ = 0)
 		return 1
 	endif
 

--- a/Packages/MIES/MIES_DataAcquisition_Single.ipf
+++ b/Packages/MIES/MIES_DataAcquisition_Single.ipf
@@ -105,10 +105,7 @@ Function DQS_BkrdDataAcq(panelTitle)
 End
 
 /// @brief Stop single device data acquisition
-static Function DQS_StopDataAcq(panelTitle, [forcedStop])
-	string panelTitle
-	variable forcedStop
-
+static Function DQS_StopDataAcq(string panelTitle, [variable forcedStop])
 	if(ParamIsDefault(forcedStop))
 		forcedStop = 0
 	else

--- a/Packages/MIES/MIES_DataConfigurator.ipf
+++ b/Packages/MIES/MIES_DataConfigurator.ipf
@@ -1374,6 +1374,7 @@ static Function DC_PlaceDataInDAQDataWave(panelTitle, numActiveChannels, dataAcq
 	DC_DocumentChannelProperty(panelTitle, "JSON config file: path", INDEP_HEADSTAGE, NaN, NaN, str=GetUserData(panelTitle, "", EXPCONFIG_UDATA_SOURCEFILE_PATH))
 	DC_DocumentChannelProperty(panelTitle, "JSON config file: SHA-256 hash", INDEP_HEADSTAGE, NaN, NaN, str=GetUserData(panelTitle, "", EXPCONFIG_UDATA_SOURCEFILE_HASH))
 	DC_DocumentChannelProperty(panelTitle, "JSON config file: stimset nwb file path", INDEP_HEADSTAGE, NaN, NaN, str=GetUserData(panelTitle, "", EXPCONFIG_UDATA_STIMSET_NWB_PATH))
+	DC_DocumentChannelProperty(panelTitle, "TP after DAQ", INDEP_HEADSTAGE, NaN, NaN, var=DAG_GetNumericalValue(panelTitle, "check_Settings_TPAfterDAQ"))
 
 	for(i = 0; i < NUM_HEADSTAGES; i += 1)
 

--- a/Packages/MIES/MIES_ExperimentDocumentation.ipf
+++ b/Packages/MIES/MIES_ExperimentDocumentation.ipf
@@ -546,15 +546,13 @@ Function ED_WriteUserCommentToLabNB(panelTitle, comment, sweepNo)
 	variable sweepNo
 
 	Make/FREE/N=(3, 1)/T keys
-	keys = ""
 
 	keys[0][0] =  "User comment"
 	keys[1][0] =  ""
 	keys[2][0] =  LABNOTEBOOK_NO_TOLERANCE
 
-
 	Make/FREE/T/N=(1, 1, LABNOTEBOOK_LAYER_COUNT) values
-	values[][][8] = comment
+	values[][][INDEP_HEADSTAGE] = comment
 
 	ED_AddEntriesToLabnotebook(values, keys, sweepNo, panelTitle, UNKNOWN_MODE)
 End

--- a/Packages/MIES/MIES_IgorHooks.ipf
+++ b/Packages/MIES/MIES_IgorHooks.ipf
@@ -271,7 +271,7 @@ static Function BeforeUncompiledHook(changeCode, procedureWindowTitleStr, textCh
 
 	LOG_AddEntry(PACKAGE_MIES, "start")
 
-	DQ_StopOngoingDAQAllLocked()
+	DQ_StopOngoingDAQAllLocked(DQ_STOP_REASON_UNCOMPILED)
 
 	ASYNC_Stop(timeout=5)
 

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -384,7 +384,7 @@ End
 /// @param[in]  entrySourceType   type of the labnotebook entry, one of @ref DataAcqModes
 /// @param[out] first             point index of the beginning of the range
 /// @param[out] last              point index of the end of the range
-Function FindRange(wv, col, val, forwardORBackward, entrySourceType, first, last)
+static Function FindRange(wv, col, val, forwardORBackward, entrySourceType, first, last)
 	WAVE wv
 	variable col, val, forwardORBackward, entrySourceType
 	variable &first, &last

--- a/Packages/MIES/MIES_RepeatedAcquisition.ipf
+++ b/Packages/MIES/MIES_RepeatedAcquisition.ipf
@@ -266,7 +266,7 @@ static Function RA_FinishAcquisition(panelTitle)
 
 	numEntries = ItemsInList(list)
 	for(i = 0; i < numEntries; i += 1)
-		DAP_OneTimeCallAfterDAQ(StringFromList(i, list))
+		DAP_OneTimeCallAfterDAQ(StringFromList(i, list), DQ_STOP_REASON_FINISHED)
 	endfor
 End
 
@@ -629,7 +629,7 @@ Function RA_ContinueOrStop(panelTitle, [multiDevice])
 				RA_Start(panelTitle)
 			endif
 		else
-			DAP_OneTimeCallAfterDAQ(panelTitle)
+			DAP_OneTimeCallAfterDAQ(panelTitle, DQ_STOP_REASON_FINISHED)
 		endif
 	else
 		if(multiDevice)

--- a/Packages/MIES/MIES_TestPulse.ipf
+++ b/Packages/MIES/MIES_TestPulse.ipf
@@ -442,7 +442,7 @@ static Function TP_RecordTP(panelTitle, BaselineSSAvg, InstResistance, SSResista
 		printf "The amount of free memory is too low to increase TPStorage, please create a new experiment.\r"
 		ControlWindowToFront()
 		LOG_AddEntry(PACKAGE_MIES, "out of memory")
-		DQ_StopDAQ(panelTitle, startTPAfterDAQ = 0)
+		DQ_StopDAQ(panelTitle, DQ_STOP_REASON_OUT_OF_MEMORY, startTPAfterDAQ = 0)
 		TP_StopTestPulse(panelTitle)
 		return NaN
 	endif

--- a/Packages/MIES/MIES_TestPulse.ipf
+++ b/Packages/MIES/MIES_TestPulse.ipf
@@ -441,6 +441,7 @@ static Function TP_RecordTP(panelTitle, BaselineSSAvg, InstResistance, SSResista
 	if(ret) // running out of memory
 		printf "The amount of free memory is too low to increase TPStorage, please create a new experiment.\r"
 		ControlWindowToFront()
+		LOG_AddEntry(PACKAGE_MIES, "out of memory")
 		DQ_StopDAQ(panelTitle, startTPAfterDAQ = 0)
 		TP_StopTestPulse(panelTitle)
 		return NaN

--- a/Packages/MIES/MIES_TestPulse_Multi.ipf
+++ b/Packages/MIES/MIES_TestPulse_Multi.ipf
@@ -234,6 +234,7 @@ Function TPM_BkrdTPFuncMD(s)
 						catch
 							errMsg = GetRTErrMessage()
 							err = ClearRTError()
+							LOG_AddEntry(PACKAGE_MIES, "hardware error")
 							DQ_StopOngoingDAQ(panelTitle)
 							if(err == 18)
 								ASSERT(0, "Acquisition FIFO overflow, data lost. This may happen if the computer is too slow.")

--- a/Packages/MIES/MIES_TestPulse_Multi.ipf
+++ b/Packages/MIES/MIES_TestPulse_Multi.ipf
@@ -109,7 +109,7 @@ Function TPM_StartTestPulseMultiDevice(panelTitle, [fast])
 
 	AbortOnValue DAP_CheckSettings(panelTitle, TEST_PULSE_MODE),1
 
-	DQ_StopOngoingDAQ(panelTitle)
+	DQ_StopOngoingDAQ(panelTitle, DQ_STOP_REASON_TP_STARTED)
 
 	// stop early as "TP after DAQ" might be already running
 	if(TP_CheckIfTestpulseIsRunning(panelTitle))
@@ -235,7 +235,7 @@ Function TPM_BkrdTPFuncMD(s)
 							errMsg = GetRTErrMessage()
 							err = ClearRTError()
 							LOG_AddEntry(PACKAGE_MIES, "hardware error")
-							DQ_StopOngoingDAQ(panelTitle)
+							DQ_StopOngoingDAQ(panelTitle, DQ_STOP_REASON_HW_ERROR)
 							if(err == 18)
 								ASSERT(0, "Acquisition FIFO overflow, data lost. This may happen if the computer is too slow.")
 							else
@@ -314,7 +314,7 @@ Function TPM_BkrdTPFuncMD(s)
 		SCOPE_UpdateGraph(panelTitle, TEST_PULSE_MODE)
 
 		if(GetKeyState(0) & ESCAPE_KEY)
-			DQ_StopOngoingDAQ(panelTitle)
+			DQ_StopOngoingDAQ(panelTitle, DQ_STOP_REASON_ESCAPE_KEY)
 		endif
 	endfor
 

--- a/Packages/MIES/MIES_TestPulse_Single.ipf
+++ b/Packages/MIES/MIES_TestPulse_Single.ipf
@@ -63,7 +63,7 @@ Function TPS_TestPulseFunc(s)
 	SCOPE_UpdateGraph(panelTitle, TEST_PULSE_MODE)
 
 	if(GetKeyState(0) & ESCAPE_KEY)
-		DQ_StopOngoingDAQ(panelTitle)
+		DQ_StopOngoingDAQ(panelTitle, DQ_STOP_REASON_ESCAPE_KEY)
 		return 1
 	endif
 
@@ -104,7 +104,7 @@ Function TPS_StartTestPulseSingleDevice(panelTitle, [fast])
 
 	AbortOnValue DAP_CheckSettings(panelTitle, TEST_PULSE_MODE),1
 
-	DQ_StopOngoingDAQ(panelTitle)
+	DQ_StopOngoingDAQ(panelTitle, DQ_STOP_REASON_TP_STARTED)
 
 	// stop early as "TP after DAQ" might be already running
 	if(TP_CheckIfTestpulseIsRunning(panelTitle))

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -2657,6 +2657,13 @@ Function QuerySetIgorOption(name, [globalSymbol])
 	return result
 End
 
+/// @brief Force recompilation of all procedure files
+///
+/// Uses the "Operation Queue".
+Function ForceRecompile()
+	Execute/P/Q/Z "Silent 100"
+End
+
 /// @brief Parse a ISO8601 timestamp, e.g. created by GetISO8601TimeStamp(), and returns the number
 /// of seconds, including fractional parts, since Igor Pro epoch (1/1/1904) in UTC time zone
 ///

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -1730,7 +1730,7 @@ Function/WAVE GetLBNidCache(numericalValues)
 	return wv
 End
 
-static Constant SWEEP_SETTINGS_WAVE_VERSION = 29
+static Constant SWEEP_SETTINGS_WAVE_VERSION = 30
 
 /// @brief Uses the parameter names from the `sourceKey` columns and
 ///        write them as dimension into the columns of dest.
@@ -1871,6 +1871,7 @@ End
 /// - 51: oodDAQ member, true if headstage takes part in oodDAQ mode, false otherwise
 /// - 52: Autobias % (DAEphys->Settings->Amplifier)
 /// - 53: Autobias Interval (DAEphys->Settings->Amplifier)
+/// - 54: TP after DAQ
 Function/Wave GetSweepSettingsKeyWave(panelTitle)
 	string panelTitle
 
@@ -1889,9 +1890,9 @@ Function/Wave GetSweepSettingsKeyWave(panelTitle)
 	if(ExistsWithCorrectLayoutVersion(wv, versionOfNewWave))
 		return wv
 	elseif(WaveExists(wv))
-		Redimension/N=(-1, 54) wv
+		Redimension/N=(-1, 55) wv
 	else
-		Make/T/N=(3, 54) newDFR:$newName/Wave=wv
+		Make/T/N=(3, 55) newDFR:$newName/Wave=wv
 	endif
 
 	wv = ""
@@ -2115,6 +2116,10 @@ Function/Wave GetSweepSettingsKeyWave(panelTitle)
 	wv[%Parameter][53] = "Autobias Interval"
 	wv[%Units][53]     = "s"
 	wv[%Tolerance][53] = "0.1"
+
+	wv[%Parameter][54] = "TP after DAQ"
+	wv[%Units][54]     = LABNOTEBOOK_BINARY_UNIT
+	wv[%Tolerance][54] = LABNOTEBOOK_NO_TOLERANCE
 
 	SetSweepSettingsDimLabels(wv, wv)
 	SetWaveVersion(wv, versionOfNewWave)

--- a/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
+++ b/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
@@ -1945,6 +1945,16 @@ static Function CheckLastLBNEntryFromTP_IGNORE(device)
 	CHECK_EQUAL_VAR(numericalValues[index - 1][%EntrySourceType], TEST_PULSE_MODE)
 End
 
+static Function CheckThatTestpulseRan_IGNORE(device)
+	string device
+	variable sweepNo
+
+	WAVE numericalValues = GetLBNumericalValues(device)
+	sweepNo = AFH_GetLastSweepAcquired(device)
+	WAVE/Z settings = GetLastSetting(numericalValues, sweepNo, "ADC", TEST_PULSE_MODE)
+	CHECK_WAVE(settings, NUMERIC_WAVE)
+End
+
 // UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD0
 Function Abort_ITI_TP_SD([str])
 	string str
@@ -2166,8 +2176,7 @@ Function Abort_ITI_PressAcq_SD_REENTRY([str])
 	NVAR runModeTP = $GetTestpulseRunMode(str)
 	CHECK_EQUAL_VAR(runModeTP, TEST_PULSE_NOT_RUNNING)
 
-	// check that TP after DAQ really ran
-	CheckLastLBNEntryFromTP_IGNORE(str)
+	CheckThatTestpulseRan_IGNORE(str)
 End
 
 // UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
@@ -2194,8 +2203,7 @@ Function Abort_ITI_PressAcq_MD_REENTRY([str])
 	NVAR runModeTP = $GetTestpulseRunMode(str)
 	CHECK_EQUAL_VAR(runModeTP, TEST_PULSE_NOT_RUNNING)
 
-	// check that TP after DAQ really ran
-	CheckLastLBNEntryFromTP_IGNORE(str)
+	CheckThatTestpulseRan_IGNORE(str)
 End
 
 // UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD0

--- a/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
+++ b/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
@@ -2236,7 +2236,7 @@ Function Abort_ITI_TP_A_PressAcq_SD_REENTRY([str])
 End
 
 // UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
-Function Abort_ITI_TP_A_Acq_MD([str])
+Function Abort_ITI_TP_A_PressAcq_MD([str])
 	string str
 
 	STRUCT DAQSettings s
@@ -2251,7 +2251,7 @@ Function Abort_ITI_TP_A_Acq_MD([str])
 	PGC_SetAndActivateControl(str, "check_Settings_TPAfterDAQ", val = 1)
 End
 
-Function Abort_ITI_TP_A_Acq_MD_REENTRY([str])
+Function Abort_ITI_TP_A_PressAcq_MD_REENTRY([str])
 	string str
 
 	NVAR runModeDAQ = $GetDataAcqRunMode(str)

--- a/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
+++ b/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
@@ -2040,6 +2040,35 @@ Function Abort_ITI_TP_A_TP_SD_REENTRY([str])
 	CheckLastLBNEntryFromTP_IGNORE(str)
 End
 
+// UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
+Function Abort_ITI_TP_A_TP_MD([str])
+	string str
+
+	STRUCT DAQSettings s
+	InitDAQSettingsFromString(s, "MD1_RA1_I0_L0_BKG_1_RES_5")
+	AcquireData(s, str)
+
+	CtrlNamedBackGround StopTPAfterSomeTime, start=(ticks + 420), period=60, proc=StopTP_IGNORE
+	CtrlNamedBackGround Abort_ITI_TP, start, period=30, proc=StartTPDuringITI_IGNORE
+
+	PGC_SetAndActivateControl(str, "Check_DataAcq_Get_Set_ITI", val = 0)
+	PGC_SetAndActivateControl(str, "SetVar_DataAcq_ITI", val = 5)
+	PGC_SetAndActivateControl(str, "check_Settings_TPAfterDAQ", val = 1)
+End
+
+Function Abort_ITI_TP_A_TP_MD_REENTRY([str])
+	string str
+
+	NVAR runModeDAQ = $GetDataAcqRunMode(str)
+	CHECK_EQUAL_VAR(runModeDAQ, DAQ_NOT_RUNNING)
+
+	NVAR runModeTP = $GetTestpulseRunMode(str)
+	CHECK_EQUAL_VAR(runModeTP, TEST_PULSE_NOT_RUNNING)
+
+	// check that TP after DAQ really ran
+	CheckLastLBNEntryFromTP_IGNORE(str)
+End
+
 Function StartDAQDuringTP_IGNORE(device)
 	string device
 
@@ -2121,35 +2150,6 @@ Function StartDAQDuringTP_REENTRY([str])
 	CHECK_EQUAL_WAVES(settings, {0, 1, 2, 3, 4, 5, 6, 7, NaN}, mode = WAVE_DATA)
 
 	// ascending sweep numbers are checked in TEST_CASE_BEGIN_OVERRIDE()
-End
-
-// UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
-Function Abort_ITI_TP_A_TP_MD([str])
-	string str
-
-	STRUCT DAQSettings s
-	InitDAQSettingsFromString(s, "MD1_RA1_I0_L0_BKG_1_RES_5")
-	AcquireData(s, str)
-
-	CtrlNamedBackGround StopTPAfterSomeTime, start=(ticks + 420), period=60, proc=StopTP_IGNORE
-	CtrlNamedBackGround Abort_ITI_TP, start, period=30, proc=StartTPDuringITI_IGNORE
-
-	PGC_SetAndActivateControl(str, "Check_DataAcq_Get_Set_ITI", val = 0)
-	PGC_SetAndActivateControl(str, "SetVar_DataAcq_ITI", val = 5)
-	PGC_SetAndActivateControl(str, "check_Settings_TPAfterDAQ", val = 1)
-End
-
-Function Abort_ITI_TP_A_TP_MD_REENTRY([str])
-	string str
-
-	NVAR runModeDAQ = $GetDataAcqRunMode(str)
-	CHECK_EQUAL_VAR(runModeDAQ, DAQ_NOT_RUNNING)
-
-	NVAR runModeTP = $GetTestpulseRunMode(str)
-	CHECK_EQUAL_VAR(runModeTP, TEST_PULSE_NOT_RUNNING)
-
-	// check that TP after DAQ really ran
-	CheckLastLBNEntryFromTP_IGNORE(str)
 End
 
 // UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD0

--- a/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
+++ b/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
@@ -5,6 +5,40 @@
 
 /// @file UTF_BasicHardWareTests.ipf Implement some basic tests using the DAQ hardware.
 
+/// Test matrix for DQ_STOP_REASON_XXX
+///
+/// DQ_STOP_REASON_DAQ_BUTTON
+/// - Abort_ITI_TP_A_PressAcq_MD
+/// - Abort_ITI_TP_A_PressAcq_SD
+/// - Abort_ITI_PressAcq_MD
+/// - Abort_ITI_PressAcq_SD
+///
+/// DQ_STOP_REASON_CONFIG_FAILED
+/// - ConfigureFails
+///
+/// DQ_STOP_REASON_FINISHED
+/// - AllTests(...)
+///
+/// DQ_STOP_REASON_UNCOMPILED
+/// - StopDAQDueToUncompiled
+///
+/// DQ_STOP_REASON_TP_STARTED
+/// - Abort_ITI_TP_A_TP_MD
+/// - Abort_ITI_TP_A_TP_SD
+/// - Abort_ITI_TP_MD
+/// - Abort_ITI_TP_SD
+///
+/// DQ_STOP_REASON_STIMSET_SELECTION
+/// - ChangeStimSetDuringDAQ
+///
+/// DQ_STOP_REASON_UNLOCKED_DEVICE
+/// - StopDAQDueToUnlocking
+///
+/// DQ_STOP_REASON_OUT_OF_MEMORY
+/// DQ_STOP_REASON_HW_ERROR
+/// DQ_STOP_REASON_ESCAPE_KEY
+/// - not tested
+
 static StrConstant REF_DAEPHYS_CONFIG_FILE = "DA_Ephys.json"
 static StrConstant REF_TMP1_CONFIG_FILE = "UserConfigTemplate_Temp1.txt"
 
@@ -295,6 +329,8 @@ static Function AllTests(t, devices)
 			CHECK_EQUAL_TEXTWAVES(indexEndStimsetsGUI, indexEndStimsetsLBN)
 		endfor
 	endfor
+
+	CheckDAQStopReason(device, DQ_STOP_REASON_FINISHED)
 
 	TestNwbExportV1()
 	TestNwbExportV2()
@@ -1955,6 +1991,23 @@ static Function CheckThatTestpulseRan_IGNORE(device)
 	CHECK_WAVE(settings, NUMERIC_WAVE)
 End
 
+static Function CheckDAQStopReason(string device, variable stopReason)
+	string key
+	variable sweepNo
+
+	key = "DAQ stop reason"
+
+	WAVE numericalValues = GetLBNumericalValues(device)
+	WAVE/Z sweeps = GetSweepsWithSetting(numericalValues, key)
+	CHECK_WAVE(sweeps, NUMERIC_WAVE)
+	CHECK(DimSize(sweeps, ROWS) >= 1)
+
+	sweepNo = sweeps[0]
+	WAVE/Z settings = GetLastSetting(numericalValues, sweepNo, key, UNKNOWN_MODE)
+	CHECK_WAVE(settings, NUMERIC_WAVE)
+	CHECK_EQUAL_VAR(settings[INDEP_HEADSTAGE], stopReason)
+End
+
 // UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD0
 Function Abort_ITI_TP_SD([str])
 	string str
@@ -1981,6 +2034,8 @@ Function Abort_ITI_TP_SD_REENTRY([str])
 
 	// check that TP after DAQ really ran
 	CheckLastLBNEntryFromTP_IGNORE(str)
+
+	CheckDAQStopReason(str, DQ_STOP_REASON_TP_STARTED)
 End
 
 // UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
@@ -2009,6 +2064,8 @@ Function Abort_ITI_TP_MD_REENTRY([str])
 
 	// check that TP after DAQ really ran
 	CheckLastLBNEntryFromTP_IGNORE(str)
+
+	CheckDAQStopReason(str, DQ_STOP_REASON_TP_STARTED)
 End
 
 // UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD0
@@ -2038,6 +2095,8 @@ Function Abort_ITI_TP_A_TP_SD_REENTRY([str])
 
 	// check that TP after DAQ really ran
 	CheckLastLBNEntryFromTP_IGNORE(str)
+
+	CheckDAQStopReason(str, DQ_STOP_REASON_TP_STARTED)
 End
 
 // UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
@@ -2067,6 +2126,8 @@ Function Abort_ITI_TP_A_TP_MD_REENTRY([str])
 
 	// check that TP after DAQ really ran
 	CheckLastLBNEntryFromTP_IGNORE(str)
+
+	CheckDAQStopReason(str, DQ_STOP_REASON_TP_STARTED)
 End
 
 Function StartDAQDuringTP_IGNORE(device)
@@ -2177,6 +2238,8 @@ Function Abort_ITI_PressAcq_SD_REENTRY([str])
 	CHECK_EQUAL_VAR(runModeTP, TEST_PULSE_NOT_RUNNING)
 
 	CheckThatTestpulseRan_IGNORE(str)
+
+	CheckDAQStopReason(str, DQ_STOP_REASON_DAQ_BUTTON)
 End
 
 // UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
@@ -2204,6 +2267,8 @@ Function Abort_ITI_PressAcq_MD_REENTRY([str])
 	CHECK_EQUAL_VAR(runModeTP, TEST_PULSE_NOT_RUNNING)
 
 	CheckThatTestpulseRan_IGNORE(str)
+
+	CheckDAQStopReason(str, DQ_STOP_REASON_DAQ_BUTTON)
 End
 
 // UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD0
@@ -2262,6 +2327,8 @@ Function Abort_ITI_TP_A_PressAcq_MD_REENTRY([str])
 
 	// check that TP after DAQ really ran
 	CheckLastLBNEntryFromTP_IGNORE(str)
+
+	CheckDAQStopReason(str, DQ_STOP_REASON_DAQ_BUTTON)
 End
 
 static Function SetSingleDeviceDAQ_IGNORE(device)
@@ -2358,6 +2425,8 @@ Function ChangeStimSetDuringDAQ_REENTRY([str])
 		NVAR runModeTP = $GetTestpulseRunMode(device)
 		CHECK_EQUAL_VAR(runModeTP, TEST_PULSE_NOT_RUNNING)
 	endfor
+
+	CheckDAQStopReason(str, DQ_STOP_REASON_STIMSET_SELECTION)
 End
 
 Function EnableUnassocChannels_IGNORE(device)
@@ -4472,4 +4541,94 @@ Function CheckAcquisitionStates(string str)
 				FAIL()
 		endswitch
 	endfor
+End
+
+Function ConfigureFails_IGNORE(string device)
+
+	string ctrl
+
+	ctrl = GetPanelControl(0, CHANNEL_TYPE_DAC, CHANNEL_CONTROL_SCALE)
+	PGC_SetAndActivateControl(device, ctrl, val = 10000)
+End
+
+/// UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
+Function ConfigureFails([str])
+	string str
+
+	STRUCT DAQSettings s
+	InitDAQSettingsFromString(s, "MD1_RA0_I0_L0_BKG_1")
+
+	try
+		AcquireData(s, str, preAcquireFunc = ConfigureFails_IGNORE)
+	catch
+		// do nothing
+	endtry
+End
+
+Function ConfigureFails_REENTRY([str])
+	string str
+	variable sweepNo
+
+	CHECK_EQUAL_VAR(GetSetVariable(str, "SetVar_Sweep"), 0)
+
+	sweepNo = AFH_GetLastSweepAcquired(str)
+	CHECK_EQUAL_VAR(sweepNo, NaN)
+
+	CheckDAQStopReason(str, DQ_STOP_REASON_CONFIG_FAILED)
+End
+
+// UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
+Function StopDAQDueToUnlocking([str])
+	string str
+
+	STRUCT DAQSettings s
+	InitDAQSettingsFromString(s, "MD1_RA1_I0_L0_BKG_1_RES_5")
+	AcquireData(s, str)
+
+	CtrlNamedBackGround UnlockDevice, start, period=30, proc=StopAcqByUnlocking_IGNORE
+
+	PGC_SetAndActivateControl(str, "Check_DataAcq_Get_Set_ITI", val = 0)
+	PGC_SetAndActivateControl(str, "SetVar_DataAcq_ITI", val = 5)
+End
+
+Function StopDAQDueToUnlocking_REENTRY([str])
+	string str
+
+	NVAR runModeDAQ = $GetDataAcqRunMode(str)
+	CHECK_EQUAL_VAR(runModeDAQ, DAQ_NOT_RUNNING)
+
+	NVAR runModeTP = $GetTestpulseRunMode(str)
+	CHECK_EQUAL_VAR(runModeTP, TEST_PULSE_NOT_RUNNING)
+
+	CheckThatTestpulseRan_IGNORE(str)
+
+	CheckDAQStopReason(str, DQ_STOP_REASON_UNLOCKED_DEVICE)
+End
+
+// UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
+Function StopDAQDueToUncompiled([str])
+	string str
+
+	STRUCT DAQSettings s
+	InitDAQSettingsFromString(s, "MD1_RA1_I0_L0_BKG_1_RES_5")
+	AcquireData(s, str)
+
+	CtrlNamedBackGround UncompileProcedures, start, period=30, proc=StopAcqByUncompiled_IGNORE
+
+	PGC_SetAndActivateControl(str, "Check_DataAcq_Get_Set_ITI", val = 0)
+	PGC_SetAndActivateControl(str, "SetVar_DataAcq_ITI", val = 5)
+End
+
+Function StopDAQDueToUncompiled_REENTRY([str])
+	string str
+
+	NVAR runModeDAQ = $GetDataAcqRunMode(str)
+	CHECK_EQUAL_VAR(runModeDAQ, DAQ_NOT_RUNNING)
+
+	NVAR runModeTP = $GetTestpulseRunMode(str)
+	CHECK_EQUAL_VAR(runModeTP, TEST_PULSE_NOT_RUNNING)
+
+	CheckThatTestpulseRan_IGNORE(str)
+
+	CheckDAQStopReason(str, DQ_STOP_REASON_UNCOMPILED)
 End

--- a/Packages/Testing-MIES/UTF_HardwareMain.ipf
+++ b/Packages/Testing-MIES/UTF_HardwareMain.ipf
@@ -451,6 +451,38 @@ Function StopAcqDuringITI_IGNORE(s)
 	return 0
 End
 
+Function StopAcqByUnlocking_IGNORE(s)
+	STRUCT WMBackgroundStruct &s
+
+	SVAR devices = $GetDevicePanelTitleList()
+	string device = StringFromList(0, devices)
+
+	NVAR runMode = $GetTestpulseRunMode(device)
+
+	if(runMode & TEST_PULSE_DURING_RA_MOD)
+		PGC_SetAndActivateControl(device, "button_SettingsPlus_unLockDevic")
+		return 1
+	endif
+
+	return 0
+End
+
+Function StopAcqByUncompiled_IGNORE(s)
+	STRUCT WMBackgroundStruct &s
+
+	SVAR devices = $GetDevicePanelTitleList()
+	string device = StringFromList(0, devices)
+
+	NVAR runMode = $GetTestpulseRunMode(device)
+
+	if(runMode & TEST_PULSE_DURING_RA_MOD)
+		ForceRecompile()
+		return 1
+	endif
+
+	return 0
+End
+
 Function StartTPDuringITI_IGNORE(s)
 	STRUCT WMBackgroundStruct &s
 


### PR DESCRIPTION
- [x] Should be merged after #941
- [x] Add tests
- [x]  Add log message for reasons like HW_ERROR, OUT_OF_MEMORY, etc.
- [x] `DQ_STOP_REASON_STIMSET_CHANGED` -> `DQ_STOP_REASON_STIMSET_SELECTION` 
       `DQ_STOP_REASON_BUTTON` -> `DQ_STOP_REASON_DAQ_BUTTON`

This fixes point 2 of #798.