### PR TITLE
Feature/957 make stimset only nwb files validate

### DIFF
--- a/Packages/Testing-MIES/UTF_HardwareMain.ipf
+++ b/Packages/Testing-MIES/UTF_HardwareMain.ipf
@@ -973,3 +973,19 @@ static Function TestSweepReconstruction_IGNORE(string panelTitle)
 		CHECK_EQUAL_WAVES(wvReconstructed, wvOriginal)
 	endfor
 End
+
+Function [string baseFolder, string nwbFile] GetUniqueNWBFileForExport(variable nwbVersion)
+	string suffix
+
+	ASSERT(IPNWB#EnsureValidNWBVersion(nwbVersion), "Invalid nwb version")
+
+	PathInfo home
+	REQUIRE(V_flag)
+	baseFolder = S_path
+
+	sprintf suffix, "-V%d.nwb", nwbVersion
+
+	nwbFile = UniqueFileOrFolder("home", GetExperimentName(), suffix = suffix)
+
+	return [baseFolder, nwbFile]
+End

--- a/Packages/Testing-MIES/UTF_HardwareMain.ipf
+++ b/Packages/Testing-MIES/UTF_HardwareMain.ipf
@@ -989,3 +989,12 @@ Function [string baseFolder, string nwbFile] GetUniqueNWBFileForExport(variable 
 
 	return [baseFolder, nwbFile]
 End
+
+Function/WAVE MajorNWBVersions()
+
+	Make/FREE wv = {1, 2}
+
+	SetDimensionLabels(wv, "v1;v2", ROWS)
+
+	return wv
+End

--- a/Packages/Testing-MIES/UTF_TestNWBExportV2.ipf
+++ b/Packages/Testing-MIES/UTF_TestNWBExportV2.ipf
@@ -564,13 +564,9 @@ End
 
 static Function/S TestFileExport()
 
-	string nwbFile, discLocation, baseFolder
+	string baseFolder, nwbFile, discLocation
 
-	PathInfo home
-	REQUIRE(V_flag)
-	baseFolder = S_path
-
-	nwbFile = UniqueFileOrFolder("home", GetExperimentName(), suffix = "-V2.nwb")
+	[baseFolder, nwbFile] = GetUniqueNWBFileForExport(NWB_VERSION)
 	discLocation = baseFolder + nwbFile
 
 	HDF5CloseFile/Z/A 0
@@ -578,7 +574,7 @@ static Function/S TestFileExport()
 
 	NWB_ExportAllData(NWB_VERSION, compressionMode = IPNWB#GetNoCompression(), writeStoredTestPulses = 1, overrideFilePath=discLocation)
 
-	GetFileFolderInfo/P=home/Q/Z nwbFile
+	GetFileFolderInfo/Q/Z discLocation
 	REQUIRE(V_IsFile)
 
 	CHECK_EQUAL_VAR(MIES_AB#AB_AddFile(baseFolder, discLocation), 0)


### PR DESCRIPTION
Thanks for opening a PR in MIES :sparkles:!

- Code can only be merged if the continous integration tests pass
- [x] Please ensure that the branch is named correctly. See
  [here](https://alleninstitute.github.io/MIES/developers.html#branch-naming-scheme) for all detailed explanation. In
  short: Branches targeting the release branch should have a `-backport` suffix, others targeting main must not have
  this suffix. This is done so that the correct CI plan is executed.
