### PR TITLE
Allow resaving NWBv1 files into NWBv2 files

### DIFF
--- a/Packages/Conversion/MIES_MassExperimentProcessing.ipf
+++ b/Packages/Conversion/MIES_MassExperimentProcessing.ipf
@@ -135,11 +135,6 @@ static Function PerformMiesTasks(outputFilePath)
 
 	printf "Free Memory: %g GB\r", GetFreeMemory()
 
-	if(FileExists(outputFilePath))
-		print "Output file already exists, skipping!"
-		return 0
-	endif
-
 	folder = GetFolder(outputFilePath)
 
 	if(!FolderExists(folder))

--- a/Packages/MIES/MIES_AnalysisBrowser.ipf
+++ b/Packages/MIES/MIES_AnalysisBrowser.ipf
@@ -199,7 +199,7 @@ static Function AB_AddFile(baseFolder, discLocation)
 	AB_LoadFile(discLocation)
 	lastMapped = GetNumberFromWaveNote(list, NOTE_INDEX) - 1
 
-	if(lastMapped > firstMapped)
+	if(lastMapped >= firstMapped)
 		list[firstMapped, lastMapped][%experiment][1] = num2str(mapIndex)
 	else // experiment could not be loaded
 		AB_RemoveMapEntry(mapIndex)

--- a/Packages/MIES/MIES_AnalysisBrowser.ipf
+++ b/Packages/MIES/MIES_AnalysisBrowser.ipf
@@ -2623,9 +2623,9 @@ static Function BeforeFileOpenHook(refNum, file, pathName, type, creator, kind)
 	return 1
 End
 
-Function/S AB_GetAllDevicesForExperiment(string experiment)
+Function/S AB_GetAllDevicesForExperiment(string dataFolder)
 
-	DFREF expFolder = GetAnalysisExpFolder(experiment)
+	DFREF dfr = GetAnalysisExpFolder(dataFolder)
 
-	return GetListOfDataFolders(expFolder)
+	return GetListOfDataFolders(dfr)
 End

--- a/Packages/MIES/MIES_AnalysisBrowser.ipf
+++ b/Packages/MIES/MIES_AnalysisBrowser.ipf
@@ -237,7 +237,7 @@ static Function AB_LoadFile(discLocation)
 			case ANALYSISBROWSER_FILE_TYPE_NWB:
 				AB_LoadSweepsFromNWB(map[%DiscLocation], map[%DataFolder], device)
 				AB_LoadTPStorageFromNWB(map[%DiscLocation], map[%DataFolder], device)
-				AB_LoadUserCommentFromNWB(map[%DiscLocation], map[%DataFolder], device)
+				AB_LoadUserCommentAndHistoryFromNWB(map[%DiscLocation], map[%DataFolder], device)
 				break
 			default:
 				ASSERT(0, "invalid file type")
@@ -723,11 +723,11 @@ static Function AB_LoadUserCommentFromFile(expFilePath, expFolder, device)
 	return numStringsLoaded
 End
 
-static Function AB_LoadUserCommentFromNWB(nwbFilePath, expFolder, device)
+static Function AB_LoadUserCommentAndHistoryFromNWB(nwbFilePath, expFolder, device)
 	string nwbFilePath, expFolder, device
 
-	string groupName, comment
-	variable h5_fileID, commentGroup
+	string groupName, comment, datasetName, history
+	variable h5_fileID, commentGroup, version
 
 	DFREF targetDFR = GetAnalysisDeviceFolder(expFolder, device)
 	h5_fileID = H5_OpenFile(nwbFilePath)
@@ -737,9 +737,16 @@ static Function AB_LoadUserCommentFromNWB(nwbFilePath, expFolder, device)
 
 	comment = ReadTextDataSetAsString(commentGroup, "userComment")
 	HDF5CloseGroup/Z commentGroup
+
+	version = GetNWBMajorVersion(ReadNWBVersion(h5_fileID))
+
+	datasetName = "/general/" + GetHistoryAndLogFileDatasetName(version)
+	history = ReadTextDataSetAsString(h5_fileID, datasetName)
+
 	H5_CloseFile(h5_fileID)
 
 	string/G targetDFR:userComment = comment
+	string/G targetDFR:historyAndLogFile = history
 End
 
 static Function/S AB_LoadLabNotebook(discLocation)

--- a/Packages/MIES/MIES_AnalysisBrowser.ipf
+++ b/Packages/MIES/MIES_AnalysisBrowser.ipf
@@ -2227,12 +2227,16 @@ static Function AB_ScanFolder(win)
 	WAVE expBrowserList = GetExperimentBrowserGUIList()
 	numEntries = GetNumberFromWaveNote(expBrowserList, NOTE_INDEX)
 	AB_ResetListBoxWaves(numEntries)
+End
 
+Function/S AB_GetPanelName()
+
+	return "AnalysisBrowser"
 End
 
 Function/S AB_OpenAnalysisBrowser()
 
-	string panel = "AnalysisBrowser"
+	string panel = AB_GetPanelName()
 	string directory
 
 	if(windowExists(panel))

--- a/Packages/MIES/MIES_AnalysisBrowser.ipf
+++ b/Packages/MIES/MIES_AnalysisBrowser.ipf
@@ -1502,10 +1502,12 @@ static Function AB_LoadSweepFromFile(discLocation, dataFolder, fileType, device,
 
 	// sweep already loaded
 	if(DataFolderExists(sweepFolder))
-		if(overwrite)
-			/// @todo check complete sweep overwrite and *_LoadSweep functions
+		if(!overwrite)
+			return 0
 		endif
-		return 0
+
+		KillOrMoveToTrash(dfr = $sweepFolder)
+		KillOrMoveToTrash(wv = GetAnalysisConfigWave(dataFolder, device, sweep))
 	endif
 
 	DFREF sweepDFR = createDFWithAllParents(sweepFolder)

--- a/Packages/MIES/MIES_AnalysisBrowser.ipf
+++ b/Packages/MIES/MIES_AnalysisBrowser.ipf
@@ -2579,11 +2579,10 @@ End
 static Function BeforeFileOpenHook(refNum, file, pathName, type, creator, kind)
 	variable refNum, kind
 	string file, pathName, type, creator
+	string baseFolder, fileSuffix
 	variable numEntries
 
 	LOG_AddEntry(PACKAGE_MIES, "start")
-
-	string baseFolder, fileSuffix
 
 	fileSuffix = GetFileSuffix(file)
 	if(cmpstr(fileSuffix, "nwb"))

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -620,7 +620,8 @@ Constant HARDWARE_DAC_EXTERNAL_TRIGGER = 0x1
 /// Used to upgrade the GuiStateWave as well as the DA Ephys panel
 Constant DA_EPHYS_PANEL_VERSION           = 52
 Constant DATA_SWEEP_BROWSER_PANEL_VERSION = 28
-Constant WAVEBUILDER_PANEL_VERSION         = 9
+Constant WAVEBUILDER_PANEL_VERSION        =  9
+Constant ANALYSISBROWSER_PANEL_VERSION    =  1
 
 /// Version of the labnotebooks (numerical and textual)
 ///

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -723,9 +723,11 @@ Constant ZEROMQ_BIND_REP_PORT = 5670
 Constant ZEROMQ_BIND_PUB_PORT = 5770
 
 /// @name Constants for AnalysisBrowserMap (Text Wave)
+/// @anchor AnalysisBrowserFileTypes
 /// @{
-StrConstant ANALYSISBROWSER_FILE_TYPE_IGOR = "I"
-StrConstant ANALYSISBROWSER_FILE_TYPE_NWB  = "N"
+StrConstant ANALYSISBROWSER_FILE_TYPE_IGOR  = "Igor"
+StrConstant ANALYSISBROWSER_FILE_TYPE_NWBv1 = "NWBv1"
+StrConstant ANALYSISBROWSER_FILE_TYPE_NWBV2 = "NWBv2"
 /// @}
 
 /// Convenience definition for functions interacting with threads

--- a/Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf
+++ b/Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf
@@ -690,3 +690,10 @@ End
 Function/S GetBugCount()
 	return GetNVARAsString(GetMiesPath(), "bugCount", initialValue = 0)
 End
+
+/// @brief Temporary storage for IP history and logfile
+///
+/// Used for reexporting from NWBv1 into NWBv2, see AB_ReExport()
+Function/S GetNWBOverrideHistoryAndLogFile()
+	return GetSVARAsString(GetNwBFolder(), "overrideHistoryAndLogFile")
+End

--- a/Packages/MIES/MIES_IVSCC.ipf
+++ b/Packages/MIES/MIES_IVSCC.ipf
@@ -475,12 +475,9 @@ End
 Function IVS_ExportAllData(filePath)
 	string filePath
 
-	CloseNWBFile()
-	DeleteFile/Z filePath
-
 	printf "Saving experiment data in NWB format to %s\r", filePath
 
-	NWB_ExportAllData(IVS_DEFAULT_NWBVERSION, overrideFilePath = filePath)
+	NWB_ExportAllData(IVS_DEFAULT_NWBVERSION, overrideFilePath = filePath, overwrite = 1)
 End
 
 Function/S IVS_ReturnNWBFileLocation()

--- a/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
+++ b/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
@@ -1811,12 +1811,10 @@ static Function NWB_AppendIgorHistoryAndLogFile(nwbVersion, locationID)
 	EnsureValidNWBVersion(nwbVersion)
 	ASSERT(GetNWBMajorVersion(ReadNWBVersion(locationID)) == nwbVersion, "NWB version of the selected file differs.")
 
-	history = GetHistoryNotebookText()
+	history = ROStr(GetNWBOverrideHistoryAndLogFile())
 
-	if(nwbVersion == 1)
-		name = "history"
-	elseif(nwbVersion == 2)
-		name = "data_collection"
+	if(IsEmpty(history))
+		history = GetHistoryNotebookText()
 	endif
 
 	groupID = H5_OpenGroup(locationID, "/general")
@@ -1831,6 +1829,8 @@ static Function NWB_AppendIgorHistoryAndLogFile(nwbVersion, locationID)
 		// someone might have edited the log file by hand
 		entry += "\n" + LOGFILE_NWB_MARKER + "\n" + NormalizeToEOL(data, "\n")
 	endif
+
+	name = GetHistoryAndLogFileDatasetName(nwbVersion)
 
 	H5_WriteTextDataset(groupID, name, str=entry, compressionMode = GetChunkedCompression(), overwrite=1, writeIgorAttr=0)
 

--- a/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
+++ b/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
@@ -477,6 +477,8 @@ End
 /// @param keepFileOpen          [optional, defaults to false] keep the NWB file open after return, or close it
 /// @param overwrite             [optional, defaults to false] overwrite any existing NWB file with the same name, only
 ///                              used when overrideFilePath is passed
+///
+/// @return 0 on success, non-zero on failure
 Function NWB_ExportAllData(nwbVersion, [overrideFilePath, writeStoredTestPulses, writeIgorHistory, compressionMode, keepFileOpen, overwrite])
 	variable nwbVersion
 	string overrideFilePath
@@ -525,7 +527,7 @@ Function NWB_ExportAllData(nwbVersion, [overrideFilePath, writeStoredTestPulses,
 		ControlWindowToFront()
 
 		LOG_AddEntry(PACKAGE_MIES, "end")
-		return NaN
+		return 1
 	endif
 
 	if(!ParamIsDefault(overrideFilePath))
@@ -537,7 +539,7 @@ Function NWB_ExportAllData(nwbVersion, [overrideFilePath, writeStoredTestPulses,
 			else
 				printf "The given path %s for the NWB export points to an existing file and overwrite is disabled.\r", overrideFilePath
 				ControlWindowToFront()
-				return NaN
+				return 1
 			endif
 		endif
 
@@ -548,7 +550,7 @@ Function NWB_ExportAllData(nwbVersion, [overrideFilePath, writeStoredTestPulses,
 
 	if(!IsFinite(locationID))
 		LOG_AddEntry(PACKAGE_MIES, "end")
-		return NaN
+		return 1
 	endif
 
 	print "Please be patient while we export all existing acquired content of all devices to NWB"
@@ -618,6 +620,8 @@ Function NWB_ExportAllData(nwbVersion, [overrideFilePath, writeStoredTestPulses,
 	endif
 
 	LOG_AddEntry(PACKAGE_MIES, "end", keys = {"size [MiB]"}, values = {num2str(NWB_GetExportedFileSize())})
+
+	return 0
 End
 
 /// @brief Wait for ASYNC nwb writing to finish

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -5803,3 +5803,24 @@ end
 threadsafe Function/S GetIgorInstanceID()
 	return Hash(IgorInfo(-102), 1)
 End
+
+/// @brief Rename the given datafolder path to a unique name
+///
+/// With path `root:a:b:c` and suffix `_old` the datafolder is renamed to `root:a:b:c_old` or if that exists
+/// `root:a:b:c_old_1` and so on.
+Function RenameDataFolderToUniqueName(string path, string suffix)
+
+	string name, folder
+
+	if(!DataFolderExists(path))
+		return NaN
+	endif
+
+	DFREF dfr = $path
+	name = GetFile(path)
+	folder = UniqueDataFolderName($path + "::", name + suffix)
+	name = GetFile(folder)
+	RenameDataFolder $path, $name
+	ASSERT_TS(!DataFolderExists(path), "Could not move it of the way.")
+	ASSERT_TS(DataFolderExists(folder), "Could not create it in the correct place.")
+End

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -1575,9 +1575,6 @@ End
 
 /// @brief Return an absolute unique data folder name which does not exist in dfr
 ///
-/// If you want to have the datafolder created for you and don't need a
-/// threadsafe function, use UniqueDataFolder() instead.
-///
 /// @param dfr      datafolder to search
 /// @param baseName first part of the datafolder, must be a *valid* Igor Pro object name
 threadsafe Function/S UniqueDataFolderName(dfr, baseName)

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -4697,7 +4697,7 @@ Function/Wave GetAnalysisConfigWave(dataFolder, device, sweep)
 	variable sweep
 
 	DFREF dfr = GetAnalysisDeviceConfigFolder(dataFolder, device)
-	string configSweep  = "Config_Sweep_" + num2str(sweep)
+	string configSweep = GetConfigWaveName(sweep)
 
 	Wave/I/Z/SDFR=dfr wv = $configSweep
 

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -4480,7 +4480,7 @@ Function/S GetAnalysisSweepDataPathAS(expFolder, device, sweep)
 	string expFolder, device
 	variable sweep
 
-	ASSERT(IsFinite(sweep), "Expected finite sweep number")
+	ASSERT(IsValidSweepNumber(sweep), "Expected finite sweep number")
 	return GetSingleSweepFolderAsString(GetAnalysisSweepPath(expFolder, device), sweep)
 End
 

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -4599,6 +4599,22 @@ Function/Wave GetAnalysisDeviceWave(dataFolder)
 	return wv
 End
 
+/// @brief Return wave with all stored test pulses
+Function/Wave GetAnalysisStoredTestPulses(string dataFolder, string device)
+
+	DFREF dfr = GetAnalysisDeviceTestpulse(dataFolder, device)
+
+	Wave/Z/SDFR=dfr/WAVE wv = StoredTestPulses
+
+	if(WaveExists(wv))
+		return wv
+	endif
+
+	Make/N=(0)/WAVE dfr:StoredTestPulses/Wave=wv
+
+	return wv
+End
+
 /// @brief Return AnalysisBrowser indexing storage wave
 ///
 /// Rows:

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -15,7 +15,8 @@
 ///   The latter ones are only useful if you need to know if the folder exists.
 /// - Modifying wave getter functions might require to introduce wave versioning, see @ref WaveVersioningSupport
 
-static Constant NUM_COLUMNS_LIST_WAVE   = 11
+static Constant ANALYSIS_BROWSER_LISTBOX_WAVE_VERSION = 1
+static Constant NUM_COLUMNS_LIST_WAVE   = 12
 static StrConstant WAVE_NOTE_LAYOUT_KEY = "WAVE_LAYOUT_VERSION"
 
 static Constant WAVE_TYPE_NUMERICAL = 0x1
@@ -4607,10 +4608,10 @@ End
 /// - 0: %DiscLocation:  Path to Experiment on Disc
 /// - 1: %FileName:      Name of File in experiment column in ExperimentBrowser
 /// - 2: %DataFolder     Data folder inside current Igor experiment
-/// - 3: %FileType       File Type identifier for routing to loader functions
+/// - 3: %FileType       File Type identifier for routing to loader functions, one of @ref AnalysisBrowserFileTypes
 Function/Wave GetAnalysisBrowserMap()
 	DFREF dfr = GetAnalysisFolder()
-	variable versionOfWave = 2
+	variable versionOfWave = 3
 
 	STRUCT WaveLocationMod p
 	p.dfr     = dfr
@@ -4624,6 +4625,9 @@ Function/Wave GetAnalysisBrowserMap()
 		return wv
 	elseif(ExistsWithCorrectLayoutVersion(wv, 1))
 		// update dimension labels
+	elseif(ExistsWithCorrectLayoutVersion(wv, 2))
+		// clear file type as this now holds nwb version as well
+		wv[][%FileType] = ""
 	elseif(WaveExists(wv))
 		Redimension/N=(-1, 4) wv
 		wv[][3] = ANALYSISBROWSER_FILE_TYPE_IGOR
@@ -4648,28 +4652,34 @@ End
 Function/Wave GetExperimentBrowserGUIList()
 
 	DFREF dfr = GetAnalysisFolder()
+	variable versionOfWave = ANALYSIS_BROWSER_LISTBOX_WAVE_VERSION
 
 	Wave/Z/SDFR=dfr/T wv = expBrowserList
 
-	if(WaveExists(wv))
+	if(ExistsWithCorrectLayoutVersion(wv, versionOfWave))
 		return wv
+	elseif(WaveExists(wv))
+		Redimension/N=(-1, NUM_COLUMNS_LIST_WAVE, -1) wv
+		wv = ""
+	else
+		Make/N=(MINIMUM_WAVE_SIZE, NUM_COLUMNS_LIST_WAVE, 2)/T dfr:expBrowserList/Wave=wv
 	endif
 
-	Make/N=(MINIMUM_WAVE_SIZE, NUM_COLUMNS_LIST_WAVE, 2)/T dfr:expBrowserList/Wave=wv
-
 	SetDimLabel COLS, 0 , $""          , wv
-	SetDimLabel COLS, 1 , experiment   , wv
-	SetDimLabel COLS, 2 , $""          , wv
-	SetDimLabel COLS, 3 , device       , wv
-	SetDimLabel COLS, 4 , '#sweeps'    , wv
-	SetDimLabel COLS, 5 , sweep        , wv
-	SetDimLabel COLS, 6 , '#headstages', wv
-	SetDimLabel COLS, 7 , 'stim sets'  , wv
-	SetDimLabel COLS, 8 , 'set count'  , wv
-	SetDimLabel COLS, 9 , '#DAC'       , wv
-	SetDimLabel COLS, 10, '#ADC'       , wv
+	SetDimLabel COLS, 1 , file         , wv
+	SetDimLabel COLS, 2 , type         , wv
+	SetDimLabel COLS, 3 , $""          , wv
+	SetDimLabel COLS, 4 , device       , wv
+	SetDimLabel COLS, 5 , '#sweeps'    , wv
+	SetDimLabel COLS, 6 , sweep        , wv
+	SetDimLabel COLS, 7 , '#headstages', wv
+	SetDimLabel COLS, 8 , 'stim sets'  , wv
+	SetDimLabel COLS, 9 , 'set count'  , wv
+	SetDimLabel COLS, 10, '#DAC'       , wv
+	SetDimLabel COLS, 11, '#ADC'       , wv
 
 	SetNumberInWaveNote(wv, NOTE_INDEX, 0)
+	SetWaveVersion(wv, versionOfWave)
 
 	return wv
 End
@@ -4679,14 +4689,20 @@ End
 Function/Wave GetExperimentBrowserGUISel()
 
 	DFREF dfr = GetAnalysisFolder()
+	variable versionOfWave = ANALYSIS_BROWSER_LISTBOX_WAVE_VERSION
 
 	Wave/Z/SDFR=dfr wv = expBrowserSel
 
-	if(WaveExists(wv))
+	if(ExistsWithCorrectLayoutVersion(wv, versionOfWave))
 		return wv
+	elseif(WaveExists(wv))
+		Redimension/N=(-1, NUM_COLUMNS_LIST_WAVE, -1) wv
+		wv = 0
+	else
+		Make/R/N=(MINIMUM_WAVE_SIZE, NUM_COLUMNS_LIST_WAVE) dfr:expBrowserSel/Wave=wv
 	endif
 
-	Make/R/N=(MINIMUM_WAVE_SIZE, NUM_COLUMNS_LIST_WAVE) dfr:expBrowserSel/Wave=wv
+	SetWaveVersion(wv, versionOfWave)
 
 	return wv
 End

--- a/Packages/Testing-MIES/UTF_TestNWBExportV1.ipf
+++ b/Packages/Testing-MIES/UTF_TestNWBExportV1.ipf
@@ -566,11 +566,9 @@ static Function/S TestFileExport()
 	nwbFile = GetExperimentName() + "-V1.nwb"
 	discLocation = baseFolder + nwbFile
 
-	HDF5CloseFile/Z/A 0
-	DeleteFile/Z/P=home nwbFile
 	KillOrMoveToTrash(dfr = GetAnalysisFolder())
 
-	NWB_ExportAllData(NWB_VERSION, compressionMode = GetNoCompression(), writeStoredTestPulses = 1, overrideFilePath=discLocation)
+	NWB_ExportAllData(NWB_VERSION, compressionMode = GetNoCompression(), writeStoredTestPulses = 1, overrideFilePath=discLocation, overwrite = 1)
 
 	GetFileFolderInfo/P=home/Q/Z nwbFile
 	CHECK(V_IsFile)

--- a/Packages/Testing-MIES/UTF_TestNWBExportV2.ipf
+++ b/Packages/Testing-MIES/UTF_TestNWBExportV2.ipf
@@ -568,10 +568,9 @@ static Function/S TestFileExport()
 	[baseFolder, nwbFile] = GetUniqueNWBFileForExport(NWB_VERSION)
 	discLocation = baseFolder + nwbFile
 
-	HDF5CloseFile/Z/A 0
 	KillOrMoveToTrash(dfr = GetAnalysisFolder())
 
-	NWB_ExportAllData(NWB_VERSION, compressionMode = GetNoCompression(), writeStoredTestPulses = 1, overrideFilePath=discLocation)
+	NWB_ExportAllData(NWB_VERSION, compressionMode = GetNoCompression(), writeStoredTestPulses = 1, overrideFilePath=discLocation, overwrite = 1)
 
 	GetFileFolderInfo/Q/Z discLocation
 	REQUIRE(V_IsFile)

--- a/Packages/Testing-MIES/UTF_Utils.ipf
+++ b/Packages/Testing-MIES/UTF_Utils.ipf
@@ -5027,3 +5027,29 @@ Function GLS_Checks()
 End
 
 /// @}
+
+// RenameDataFolderToUniqueName
+/// @{
+
+Function RDFU_Works()
+	string name, suffix, path
+
+	name = "I_DONT_EXIST"
+	suffix = "DONT_CARE"
+
+	CHECK(!DataFolderExists(name))
+	RenameDataFolderToUniqueName(name, suffix)
+	CHECK(!DataFolderExists(name))
+
+	name = "folder"
+	suffix = "_old"
+
+	NewDataFolder $name
+	path = GetDataFolder(1) + name
+	CHECK(DataFolderExists(path))
+	RenameDataFolderToUniqueName(path, suffix)
+	CHECK(!DataFolderExists(path))
+	CHECK(DataFolderExists(path + suffix))
+End
+
+/// @}


### PR DESCRIPTION
- [x] Code cleanup
- [x] Proper commits
- [x] Move marked code into IPNWB once #918 and #954 is done
- [x] Collapsed experiment names don't work
- [x] Only load the stored TPs for reexport
- [x] ~~Do we need to load the stored TPs from pxp as well~~ No
- [x] Reuse overwrite checkbox to avoid asking the user
- [x] Add NWB version/PXP to the analyisbrowser list box

Close https://github.com/AllenInstitute/MIES/issues/911