### PR TITLE
NWB: Ensure that sweep-by-sweep export is finished when required

### DIFF
--- a/Packages/MIES/MIES_Async.ipf
+++ b/Packages/MIES/MIES_Async.ipf
@@ -271,7 +271,7 @@ Function ASYNC_IsWorkloadClassDone(string workloadClass, [variable removeClass])
 
 	removeClass = ParamIsDefault(removeClass) ? 0 : !!removeClass
 
-	done = track[%$workloadClass][%INPUTCOUNT] - track[%$workloadClass][%OUTPUTCOUNT] == 0
+	done = (track[%$workloadClass][%INPUTCOUNT] - track[%$workloadClass][%OUTPUTCOUNT]) == 0
 
 	if(removeClass && done)
 		DeleteWavePoint(track, ROWS, index)

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -5010,6 +5010,8 @@ static Function DAP_UnlockDevice(panelTitle)
 	DQ_StopDAQ(panelTitle, DQ_STOP_REASON_UNLOCKED_DEVICE)
 	TP_StopTestPulse(panelTitle)
 	ASSERT(!ASYNC_WaitForWLCToFinishAndRemove(WORKLOADCLASS_TP + panelTitle, DAP_WAITFORTPANALYSIS_TIMEOUT), "TP analysis did not finish within timeout")
+	NWB_ASYNC_FinishWriting(panelTitle)
+
 	PGC_SetAndActivateControl(panelTitle, "check_Settings_TPAfterDAQ", val = state)
 
 	DAP_SerializeCommentNotebook(panelTitle)

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -5307,9 +5307,14 @@ End
 ///
 /// We have only one NWB file open for all running devices
 Function CloseNWBFile()
+	string lockedDevices
+
 	NVAR fileID = $GetNWBFileIDExport()
 
 	if(IsFinite(fileID))
+		lockedDevices = GetListOfLockedDevices()
+		CallFunctionForEachListItem(NWB_ASYNC_FinishWriting, lockedDevices)
+
 		HDF5CloseFile/Z fileID
 		DEBUGPRINT("Trying to close the NWB file using HDF5CloseFile returned: ", var=V_flag)
 		if(!V_flag) // success


### PR DESCRIPTION
Since fbbb2f6a (Use ASYNC framework to write sweep-by-sweep NWB files, 2021-05-11) we write the data in sweep-by-sweep export mode via the ASYNC framework.

But the author of this commit forgot to add a synchronization point,
when closing the NWB file and/or unlocking the device.

This is now done.
