### PR TITLE
tools/nextFreePRNumber.sh: Make it work with discussions

### DIFF
--- a/tools/nextFreePRNumber.sh
+++ b/tools/nextFreePRNumber.sh
@@ -10,9 +10,21 @@ nextPR=$(curl -X GET -sL -H "Accept: application/vnd.github.v3+json" \
 https://api.github.com/repos/AllenInstitute/MIES/pulls?state=all       \
 | jq '[.[] | .number] | max + 1')
 
-if [[  $nextIssue -gt $nextPR ]]
-then
-  echo $nextIssue
-else
-  echo $nextPR
-fi
+nextFree=$(($nextIssue > $nextPR ? $nextIssue : $nextPR))
+
+# now search the first discussion ID which gives a http 404
+# the discussions API is graphQL only and needs authentication
+while [ true ]
+do
+  statusCode=$(curl -o /dev/null -I -L -s -w "%{http_code}" https://github.com/AllenInstitute/MIES/discussions/$nextFree)
+
+  if [ $statusCode -eq 200 ]
+  then
+    nextFree=$((nextFree + 1))
+    continue
+  fi
+
+  break
+done
+
+echo $nextFree


### PR DESCRIPTION
Discussion on github share the same number space as issues and PRs.
Unfortunately we can not just query the list of discussions using the
REST API as there only exists a GraphQL API and that needs always
authentication.

So let's just use dump curl to find the first discussion ID which return
a HTTP status code different than 200.

Thanks for opening a PR in MIES :sparkles:!

- Code can only be merged if the continous integration tests pass
- [ ] Please ensure that the branch is named correctly. See
  [here](https://alleninstitute.github.io/MIES/developers.html#branch-naming-scheme) for all detailed explanation. In
  short: Branches targeting the release branch should have a `-backport` suffix, others targeting main must not have
  this suffix. This is done so that the correct CI plan is executed.
