### PR TITLE
Databrowser set sweep count selection

### DIFF
--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -1588,3 +1588,11 @@ StrConstant EPOCH_SHORTNAME_USER_PREFIX = "U_"
 Constant SF_DM_NORMAL = 1
 Constant SF_DM_SUBWINDOWS = 2
 /// @}
+
+/// @name Parameters for GetTTLLabnotebookEntry()
+/// @anchor LabnotebookTTLNames
+///
+/// @{
+StrConstant LABNOTEBOOK_TTL_STIMSETS       = "stim sets"
+StrConstant LABNOTEBOOK_TTL_SETSWEEPCOUNTS = "set sweep counts"
+/// @}

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -635,7 +635,7 @@ Constant ANALYSISBROWSER_PANEL_VERSION    =  1
 /// - Changed names of entries
 /// - Changed units or meaning of entries
 /// - New/Changed layers of entries
-Constant LABNOTEBOOK_VERSION = 49
+Constant LABNOTEBOOK_VERSION = 50
 
 /// Version of the stimset wave note
 Constant STIMSET_NOTE_VERSION = 7
@@ -1595,4 +1595,5 @@ Constant SF_DM_SUBWINDOWS = 2
 /// @{
 StrConstant LABNOTEBOOK_TTL_STIMSETS       = "stim sets"
 StrConstant LABNOTEBOOK_TTL_SETSWEEPCOUNTS = "set sweep counts"
+StrConstant LABNOTEBOOK_TTL_SETCYCLECOUNTS = "set cycle counts"
 /// @}

--- a/Packages/MIES/MIES_Epochs.ipf
+++ b/Packages/MIES/MIES_Epochs.ipf
@@ -449,8 +449,7 @@ static Function EP_SortEpochs(panelTitle)
 		// remove epochs marked for removal
 		// first column needs to be StartTime
 		ASSERT(EPOCH_COL_STARTTIME == 0, "First column changed")
-		for(;!RemoveTextWaveEntry1D(epochChannel, "NaN");)
-		endfor
+		RemoveTextWaveEntry1D(epochChannel, "NaN", all = 1)
 
 		epochCnt = DimSize(epochChannel, ROWS)
 

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -4781,16 +4781,12 @@ End
 /// The indexing here is **hardware independent**.
 /// For ITC hardware the assertion "log(ttlBit)/log(2) == DAEphys TTL channel" holds.
 ///
-/// @param numericalValues Numerical labnotebook values
 /// @param textualValues   Text labnotebook values
 /// @param sweep           Sweep number
-threadsafe Function/WAVE GetTTLStimSets(numericalValues, textualValues, sweep)
-	WAVE numericalValues, textualValues
-	variable sweep
-
+threadsafe Function/WAVE GetTTLStimSets(WAVE/T textualValues, variable sweep)
 	variable index
 
-	index = GetIndexForHeadstageIndepData(numericalValues)
+	index = GetIndexForHeadstageIndepData(textualValues)
 
 	WAVE/T/Z ttlStimsets = GetLastSetting(textualValues, sweep, "TTL stim sets", DATA_ACQUISITION_MODE)
 	WAVE/T/Z ttlStimsetsRackZero = GetLastSetting(textualValues, sweep, "TTL rack zero stim sets", DATA_ACQUISITION_MODE)

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -6393,7 +6393,8 @@ End
 ///
 /// Allows to search only the specified column for a value
 /// and returns all matching row indizes in a wave. By defaults only looks into the first layer
-/// for backward compatibility reasons.
+/// for backward compatibility reasons. When multiple layers are searched `startLayer`/`endLayer` the
+/// result contains matches from all layers, and this also means the resulting wave is still 1D.
 ///
 /// Exactly one of `var`/`str`/`prop` has to be given except for
 /// `prop == PROP_MATCHES_VAR_BIT_MASK` and `prop == PROP_NOT_MATCHES_VAR_BIT_MASK`

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -4782,28 +4782,29 @@ End
 /// For ITC hardware the assertion "log(ttlBit)/log(2) == DAEphys TTL channel" holds.
 ///
 /// @param textualValues   Text labnotebook values
+/// @param name            One of @ref LabnotebookTTLNames
 /// @param sweep           Sweep number
-threadsafe Function/WAVE GetTTLStimSets(WAVE/T textualValues, variable sweep)
+threadsafe Function/WAVE GetTTLLabnotebookEntry(WAVE/T textualValues, string name, variable sweep)
 	variable index
 
 	index = GetIndexForHeadstageIndepData(textualValues)
 
-	WAVE/T/Z ttlStimsets = GetLastSetting(textualValues, sweep, "TTL stim sets", DATA_ACQUISITION_MODE)
-	WAVE/T/Z ttlStimsetsRackZero = GetLastSetting(textualValues, sweep, "TTL rack zero stim sets", DATA_ACQUISITION_MODE)
-	WAVE/T/Z ttlStimsetsRackOne = GetLastSetting(textualValues, sweep, "TTL rack one stim sets", DATA_ACQUISITION_MODE)
+	WAVE/T/Z ttlEntry = GetLastSetting(textualValues, sweep, "TTL " + name, DATA_ACQUISITION_MODE)
+	WAVE/T/Z ttlEntryRackZero = GetLastSetting(textualValues, sweep, "TTL rack zero " + name, DATA_ACQUISITION_MODE)
+	WAVE/T/Z ttlEntryRackOne = GetLastSetting(textualValues, sweep, "TTL rack one " + name, DATA_ACQUISITION_MODE)
 
-	if(WaveExists(ttlStimsets))
+	if(WaveExists(ttlEntry))
 		// NI hardware
-		return ListToTextWave(ttlStimsets[index], ";")
-	elseif(WaveExists(ttlStimsetsRackZero) || WaveExists(ttlStimsetsRackOne))
+		return ListToTextWave(ttlEntry[index], ";")
+	elseif(WaveExists(ttlEntryRackZero) || WaveExists(ttlEntryRackOne))
 		// ITC hardware
 		Make/FREE/T/N=(NUM_DA_TTL_CHANNELS) entries
-		if(WaveExists(ttlStimsetsRackZero))
-			entries += StringFromList(p, ttlStimsetsRackZero[index])
+		if(WaveExists(ttlEntryRackZero))
+			entries += StringFromList(p, ttlEntryRackZero[index])
 		endif
 
-		if(WaveExists(ttlStimsetsRackOne))
-			entries += StringFromList(p, ttlStimsetsRackOne[index])
+		if(WaveExists(ttlEntryRackOne))
+			entries += StringFromList(p, ttlEntryRackOne[index])
 		endif
 
 		return entries

--- a/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
+++ b/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
@@ -986,7 +986,7 @@ static Function/S NWB_GetStimsetFromSweepGeneric(sweep, numericalValues, textual
 		stimsetList = AddListItem(name, stimsetList)
 	endfor
 
-	WAVE/Z/T ttlStimSets = GetTTLstimSets(textualValues, sweep)
+	WAVE/Z/T ttlStimSets = GetTTLLabnotebookEntry(textualValues, LABNOTEBOOK_TTL_STIMSETS, sweep)
 
 	// handle TTL channels
 	for(i = 0; i < NUM_DA_TTL_CHANNELS; i += 1)
@@ -1170,7 +1170,7 @@ threadsafe static Function NWB_AppendSweepLowLevel(STRUCT NWBAsyncParameters &s)
 	// introduced in db531d20 (DC_PlaceDataInITCDataWave: Document the digitizer hardware type, 2018-07-30)
 	// before that we only had ITC hardware
 	hardwareType = GetLastSettingIndep(s.numericalValues, s.sweep, "Digitizer Hardware Type", DATA_ACQUISITION_MODE, defValue = HARDWARE_ITC_DAC)
-	WAVE/Z/T ttlStimsets = GetTTLStimSets(s.textualValues, s.sweep)
+	WAVE/Z/T ttlStimsets = GetTTLLabnotebookEntry(s.textualValues, LABNOTEBOOK_TTL_STIMSETS, s.sweep)
 
 	// i has the following meaning:
 	// - ITC hardware: hardware channel

--- a/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
+++ b/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
@@ -986,7 +986,7 @@ static Function/S NWB_GetStimsetFromSweepGeneric(sweep, numericalValues, textual
 		stimsetList = AddListItem(name, stimsetList)
 	endfor
 
-	WAVE/Z/T ttlStimSets = GetTTLstimSets(numericalValues, textualValues, sweep)
+	WAVE/Z/T ttlStimSets = GetTTLstimSets(textualValues, sweep)
 
 	// handle TTL channels
 	for(i = 0; i < NUM_DA_TTL_CHANNELS; i += 1)
@@ -1170,7 +1170,7 @@ threadsafe static Function NWB_AppendSweepLowLevel(STRUCT NWBAsyncParameters &s)
 	// introduced in db531d20 (DC_PlaceDataInITCDataWave: Document the digitizer hardware type, 2018-07-30)
 	// before that we only had ITC hardware
 	hardwareType = GetLastSettingIndep(s.numericalValues, s.sweep, "Digitizer Hardware Type", DATA_ACQUISITION_MODE, defValue = HARDWARE_ITC_DAC)
-	WAVE/Z/T ttlStimsets = GetTTLStimSets(s.numericalValues, s.textualValues, s.sweep)
+	WAVE/Z/T ttlStimsets = GetTTLStimSets(s.textualValues, s.sweep)
 
 	// i has the following meaning:
 	// - ITC hardware: hardware channel

--- a/Packages/MIES/MIES_OverlaySweeps.ipf
+++ b/Packages/MIES/MIES_OverlaySweeps.ipf
@@ -232,7 +232,7 @@ Function OVS_UpdateSweepSelectionChoices(string win, WAVE/T sweepSelectionChoice
 	for(i = 0; i < numEntries; i += 1)
 		WAVE/T stimsets = GetLastSetting(allTextualValues[i], sweeps[i], STIM_WAVE_NAME_KEY, DATA_ACQUISITION_MODE)
 		sweepSelectionChoices[i][][%Stimset] = stimsets[q]
-		WAVE/T/Z TTLStimSets = GetTTLstimSets(allTextualValues[i], sweeps[i])
+		WAVE/T/Z TTLStimSets = GetTTLLabnotebookEntry(allTextualValues[i], LABNOTEBOOK_TTL_STIMSETS, sweeps[i])
 		if(WaveExists(TTLStimSets))
 			sweepSelectionChoices[i][][%TTLStimSet] = TTLStimSets[q]
 		else

--- a/Packages/MIES/MIES_OverlaySweeps.ipf
+++ b/Packages/MIES/MIES_OverlaySweeps.ipf
@@ -232,7 +232,7 @@ Function OVS_UpdateSweepSelectionChoices(string win, WAVE/T sweepSelectionChoice
 	for(i = 0; i < numEntries; i += 1)
 		WAVE/T stimsets = GetLastSetting(allTextualValues[i], sweeps[i], STIM_WAVE_NAME_KEY, DATA_ACQUISITION_MODE)
 		sweepSelectionChoices[i][][%Stimset] = stimsets[q]
-		WAVE/T/Z TTLStimSets = GetTTLstimSets(allNumericalValues[i], allTextualValues[i], sweeps[i])
+		WAVE/T/Z TTLStimSets = GetTTLstimSets(allTextualValues[i], sweeps[i])
 		if(WaveExists(TTLStimSets))
 			sweepSelectionChoices[i][][%TTLStimSet] = TTLStimSets[q]
 		else

--- a/Packages/MIES/MIES_OverlaySweeps.ipf
+++ b/Packages/MIES/MIES_OverlaySweeps.ipf
@@ -643,7 +643,7 @@ End
 static Function OVS_ChangeSweepSelection(win, choiceString)
 	string win, choiceString
 
-	variable i, j, numEntries, numLayers, offset, step
+	variable i, j, k, numEntries, numLayers, offset, step
 	string extPanel
 
 	ASSERT(OVS_IsActive(win), "Selecting sweeps is only supported if OVS is enabled")
@@ -682,8 +682,8 @@ static Function OVS_ChangeSweepSelection(win, choiceString)
 				endif
 
 				numEntries = DimSize(indizes, ROWS)
-				for(j = offset; j < numEntries; j += step)
-					listboxSelWave[indizes[j]][%Sweep] = listboxSelWave[p][q] | LISTBOX_CHECKBOX_SELECTED
+				for(k = offset; k < numEntries; k += step)
+					listboxSelWave[indizes[k]][%Sweep] = listboxSelWave[p][q] | LISTBOX_CHECKBOX_SELECTED
 				endfor
 			endfor
 		endfor

--- a/Packages/MIES/MIES_OverlaySweeps.ipf
+++ b/Packages/MIES/MIES_OverlaySweeps.ipf
@@ -243,7 +243,7 @@ Function OVS_UpdateSweepSelectionChoices(string win, WAVE/T sweepSelectionChoice
 
 		if(!WaveExists(clampMode))
 			WAVE/Z clampMode = GetLastSetting(allNumericalValues[i], sweeps[i], "Operating Mode", DATA_ACQUISITION_MODE)
-			ASSERT(WaveExists(clampMode), "Labnotebook is too old for NWB export.")
+			ASSERT(WaveExists(clampMode), "Labnotebook is too old.")
 		endif
 
 		sweepSelectionChoices[i][][%StimsetAndClampMode] = SelectString(IsFinite(clampMode[q]), "", stimsets[q] + " (" + ConvertAmplifierModeShortStr(clampMode[q]) + ")")

--- a/Packages/MIES/MIES_OverlaySweeps.ipf
+++ b/Packages/MIES/MIES_OverlaySweeps.ipf
@@ -220,14 +220,18 @@ Function OVS_UpdateSweepSelectionChoices(string win, WAVE/T sweepSelectionChoice
 
 	WAVE/Z sweeps = GetPlainSweepList(win)
 
-	numEntries = WaveExists(sweeps) ? DimSize(sweeps, ROWS) : 0
-
-	if(numEntries > 0)
-		WAVE/WAVE allNumericalValues = BSP_GetLBNWave(win, LBN_NUMERICAL_VALUES)
-		WAVE/WAVE allTextualValues   = BSP_GetLBNWave(win, LBN_TEXTUAL_VALUES)
+	if(!WaveExists(sweeps))
+		Redimension/N=(0, -1, -1, -1) sweepSelectionChoices
+		SetNumberInWaveNote(sweepSelectionChoices, NOTE_NEEDS_UPDATE, 0)
+		return NaN
 	endif
 
+	WAVE/WAVE allNumericalValues = BSP_GetLBNWave(win, LBN_NUMERICAL_VALUES)
+	WAVE/WAVE allTextualValues   = BSP_GetLBNWave(win, LBN_TEXTUAL_VALUES)
+
+	numEntries = DimSize(sweeps, ROWS)
 	Redimension/N=(numEntries, -1, -1, -1) sweepSelectionChoices
+	sweepSelectionChoices = ""
 
 	for(i = 0; i < numEntries; i += 1)
 		WAVE/T stimsets = GetLastSetting(allTextualValues[i], sweeps[i], STIM_WAVE_NAME_KEY, DATA_ACQUISITION_MODE)
@@ -235,8 +239,6 @@ Function OVS_UpdateSweepSelectionChoices(string win, WAVE/T sweepSelectionChoice
 		WAVE/T/Z TTLStimSets = GetTTLLabnotebookEntry(allTextualValues[i], LABNOTEBOOK_TTL_STIMSETS, sweeps[i])
 		if(WaveExists(TTLStimSets))
 			sweepSelectionChoices[i][][%TTLStimSet] = TTLStimSets[q]
-		else
-			sweepSelectionChoices[i][][%TTLStimSet] = ""
 		endif
 
 		WAVE/Z clampMode = GetLastSetting(allNumericalValues[i], sweeps[i], "Clamp Mode", DATA_ACQUISITION_MODE)

--- a/Packages/MIES/MIES_OverlaySweeps.ipf
+++ b/Packages/MIES/MIES_OverlaySweeps.ipf
@@ -643,7 +643,7 @@ End
 static Function OVS_ChangeSweepSelection(win, choiceString)
 	string win, choiceString
 
-	variable i, j, k, numEntries, numLayers, offset, step
+	variable i, j, numEntries, numLayers, offset, step
 	string extPanel
 
 	ASSERT(OVS_IsActive(win), "Selecting sweeps is only supported if OVS is enabled")
@@ -674,17 +674,14 @@ static Function OVS_ChangeSweepSelection(win, choiceString)
 
 		numLayers = DimSize(sweepSelectionChoices, LAYERS)
 		for(i = 0; i < NUM_HEADSTAGES; i += 1)
-			for(j = 0; j < numLayers; j += 1)
-				Duplicate/FREE/R=[][][j] sweepSelectionChoices, sweepSelectionChoicesSingle
-				WAVE/Z indizes = FindIndizes(sweepSelectionChoicesSingle, col=i, str=choiceString)
-				if(!WaveExists(indizes))
-					continue
-				endif
+			WAVE/Z indizes = FindIndizes(sweepSelectionChoices, col=i, str=choiceString, startLayer = 0, endLayer = numLayers - 1)
+			if(!WaveExists(indizes))
+				continue
+			endif
 
-				numEntries = DimSize(indizes, ROWS)
-				for(k = offset; k < numEntries; k += step)
-					listboxSelWave[indizes[k]][%Sweep] = listboxSelWave[p][q] | LISTBOX_CHECKBOX_SELECTED
-				endfor
+			numEntries = DimSize(indizes, ROWS)
+			for(j = offset; j < numEntries; j += step)
+				listboxSelWave[indizes[j]][%Sweep] = listboxSelWave[p][q] | LISTBOX_CHECKBOX_SELECTED
 			endfor
 		endfor
 	endif

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -2254,8 +2254,8 @@ Function/Wave GetSweepSettingsTextKeyWave(panelTitle)
 	wv[0][0]  = STIM_WAVE_NAME_KEY
 	wv[0][1]  = "DA unit"
 	wv[0][2]  = "AD unit"
-	wv[0][3]  = "TTL rack zero stim sets"
-	wv[0][4]  = "TTL rack one stim sets"
+	wv[0][3]  = "TTL rack zero " + LABNOTEBOOK_TTL_STIMSETS
+	wv[0][4]  = "TTL rack one " + LABNOTEBOOK_TTL_STIMSETS
 	wv[0][5]  = StringFromList(PRE_DAQ_EVENT, EVENT_NAME_LIST_LBN)
 	wv[0][6]  = StringFromList(MID_SWEEP_EVENT, EVENT_NAME_LIST_LBN)
 	wv[0][7]  = StringFromList(POST_SWEEP_EVENT, EVENT_NAME_LIST_LBN)
@@ -2269,10 +2269,10 @@ Function/Wave GetSweepSettingsTextKeyWave(panelTitle)
 	wv[0][15] = "Electrode"
 	wv[0][16] = HIGH_PREC_SWEEP_START_KEY
 	wv[0][17] = STIMSET_WAVE_NOTE_KEY
-	wv[0][18] = "TTL rack zero set sweep counts"
-	wv[0][19] = "TTL rack one set sweep counts"
-	wv[0][20] = "TTL set sweep counts"
-	wv[0][21] = "TTL stim sets"
+	wv[0][18] = "TTL rack zero " + LABNOTEBOOK_TTL_SETSWEEPCOUNTS
+	wv[0][19] = "TTL rack one  " + LABNOTEBOOK_TTL_SETSWEEPCOUNTS
+	wv[0][20] = "TTL " + LABNOTEBOOK_TTL_SETSWEEPCOUNTS
+	wv[0][21] = "TTL " + LABNOTEBOOK_TTL_STIMSETS
 	wv[0][22] = "TTL channels"
 	wv[0][23] = "Follower Device"
 	wv[0][24] = "MIES version"

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -5820,6 +5820,10 @@ Function/WAVE GetOverlaySweepSelectionChoices(win, dfr, [skipUpdate])
 	SetNumberInWaveNote(wv, "NeedsUpdate", 1)
 	SetWaveVersion(wv, versionOfNewWave)
 
+	if(!skipUpdate)
+		OVS_UpdateSweepSelectionChoices(win, wv)
+	endif
+
 	return wv
 End
 

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -5786,7 +5786,7 @@ Function/WAVE GetOverlaySweepSelectionChoices(win, dfr, [skipUpdate])
 	DFREF dfr
 	variable skipUpdate
 
-	variable versionOfNewWave = 3
+	variable versionOfNewWave = 4
 
 	if(ParamIsDefault(skipUpdate))
 		skipUpdate = 0
@@ -5810,14 +5810,14 @@ Function/WAVE GetOverlaySweepSelectionChoices(win, dfr, [skipUpdate])
 		endif
 		return wv
 	elseif(WaveExists(wv))
-		Redimension/N=(-1, -1, 3) wv
+		Redimension/N=(-1, -1, 7) wv
 	else
 		ASSERT(NUM_HEADSTAGES == NUM_DA_TTL_CHANNELS, "Unexpected channel count")
-		Make/T/N=(MINIMUM_WAVE_SIZE, NUM_HEADSTAGES, 3) dfr:$newName/Wave=wv
+		Make/T/N=(MINIMUM_WAVE_SIZE, NUM_HEADSTAGES, 7) dfr:$newName/Wave=wv
 	endif
 
-	SetDimensionLabels(wv, "Stimset;TTLStimset;StimsetAndClampMode", LAYERS)
-	SetNumberInWaveNote(wv, "NeedsUpdate", 1)
+	SetDimensionLabels(wv, "Stimset;TTLStimset;DAStimsetAndClampMode;DAStimsetAndSetSweepCount;TTLStimsetAndSetSweepCount;DAStimsetAndSetCycleCount;TTLStimsetAndSetCycleCount", LAYERS)
+	SetNumberInWaveNote(wv, NOTE_NEEDS_UPDATE, 1)
 	SetWaveVersion(wv, versionOfNewWave)
 
 	if(!skipUpdate)

--- a/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
+++ b/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
@@ -2537,7 +2537,7 @@ Function UnassociatedChannelsAndTTLs_REENTRY([str])
 
 			WAVE TTLs = GetTTLListFromConfig(config)
 
-			WAVE/Z ttlStimSets = GetTTLstimSets(numericalValues, textualValues, j)
+			WAVE/Z ttlStimSets = GetTTLstimSets(textualValues, j)
 			CHECK_EQUAL_TEXTWAVES(ttlStimSets, {"", "StimulusSetA_TTL_0", "", "StimulusSetB_TTL_0", "", "", "", ""})
 
 			switch(GetHardwareType(device))

--- a/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
+++ b/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
@@ -2537,7 +2537,7 @@ Function UnassociatedChannelsAndTTLs_REENTRY([str])
 
 			WAVE TTLs = GetTTLListFromConfig(config)
 
-			WAVE/Z ttlStimSets = GetTTLstimSets(textualValues, j)
+			WAVE/Z ttlStimSets = GetTTLLabnotebookEntry(textualValues, LABNOTEBOOK_TTL_STIMSETS, j)
 			CHECK_EQUAL_TEXTWAVES(ttlStimSets, {"", "StimulusSetA_TTL_0", "", "StimulusSetB_TTL_0", "", "", "", ""})
 
 			switch(GetHardwareType(device))

--- a/Packages/Testing-MIES/UTF_TestNWBExportV1.ipf
+++ b/Packages/Testing-MIES/UTF_TestNWBExportV1.ipf
@@ -367,7 +367,7 @@ static Function TestTimeSeries(fileID, device, groupID, channel, sweep, pxpSweep
 	elseif(params.channelType == XOP_CHANNEL_TYPE_ADC && IsNaN(params.electrodeNumber)) // unassoc AD
 		stimulus_expected = "PLACEHOLDER"
 	elseif(params.channelType == XOP_CHANNEL_TYPE_TTL)
-		WAVE/T/Z TTLStimsets = GetTTLStimSets(numericalValues, textualValues, sweep)
+		WAVE/T/Z TTLStimsets = GetTTLStimSets(textualValues, sweep)
 		CHECK_WAVE(TTLStimsets, TEXT_WAVE)
 
 		if(IsNaN(params.ttlBit))

--- a/Packages/Testing-MIES/UTF_TestNWBExportV1.ipf
+++ b/Packages/Testing-MIES/UTF_TestNWBExportV1.ipf
@@ -367,7 +367,7 @@ static Function TestTimeSeries(fileID, device, groupID, channel, sweep, pxpSweep
 	elseif(params.channelType == XOP_CHANNEL_TYPE_ADC && IsNaN(params.electrodeNumber)) // unassoc AD
 		stimulus_expected = "PLACEHOLDER"
 	elseif(params.channelType == XOP_CHANNEL_TYPE_TTL)
-		WAVE/T/Z TTLStimsets = GetTTLStimSets(textualValues, sweep)
+		WAVE/T/Z TTLStimsets = GetTTLLabnotebookEntry(textualValues, LABNOTEBOOK_TTL_STIMSETS, sweep)
 		CHECK_WAVE(TTLStimsets, TEXT_WAVE)
 
 		if(IsNaN(params.ttlBit))

--- a/Packages/Testing-MIES/UTF_TestNWBExportV2.ipf
+++ b/Packages/Testing-MIES/UTF_TestNWBExportV2.ipf
@@ -376,7 +376,7 @@ static Function TestTimeSeries(fileID, filepath, device, groupID, channel, sweep
 	elseif(params.channelType == XOP_CHANNEL_TYPE_ADC && IsNaN(params.electrodeNumber)) // unassoc AD
 		stimulus_expected = "PLACEHOLDER"
 	elseif(params.channelType == XOP_CHANNEL_TYPE_TTL)
-		WAVE/T/Z TTLStimsets = GetTTLStimSets(textualValues, sweep)
+		WAVE/T/Z TTLStimsets = GetTTLLabnotebookEntry(textualValues, LABNOTEBOOK_TTL_STIMSETS, sweep)
 		CHECK_WAVE(TTLStimsets, TEXT_WAVE)
 
 		if(IsNaN(params.ttlBit))

--- a/Packages/Testing-MIES/UTF_TestNWBExportV2.ipf
+++ b/Packages/Testing-MIES/UTF_TestNWBExportV2.ipf
@@ -376,7 +376,7 @@ static Function TestTimeSeries(fileID, filepath, device, groupID, channel, sweep
 	elseif(params.channelType == XOP_CHANNEL_TYPE_ADC && IsNaN(params.electrodeNumber)) // unassoc AD
 		stimulus_expected = "PLACEHOLDER"
 	elseif(params.channelType == XOP_CHANNEL_TYPE_TTL)
-		WAVE/T/Z TTLStimsets = GetTTLStimSets(numericalValues, textualValues, sweep)
+		WAVE/T/Z TTLStimsets = GetTTLStimSets(textualValues, sweep)
 		CHECK_WAVE(TTLStimsets, TEXT_WAVE)
 
 		if(IsNaN(params.ttlBit))


### PR DESCRIPTION
- [x] Add stimulus set cycles selection as well
- [x] Limit "set sweep count" list items to only have elements with 2 or more counts
- [x] Selection takes way too long
- [x] Only show stimsets which were acquired more than once (aka have a set cycle count of 1 or higher)

Close #157.