### PR TITLE
SCOPE_ITC_UpdateOscilloscope: Fix debug mode

### DIFF
--- a/Packages/MIES/MIES_Oscilloscope.ipf
+++ b/Packages/MIES/MIES_Oscilloscope.ipf
@@ -699,8 +699,8 @@ static Function SCOPE_ITC_UpdateOscilloscope(panelTitle, dataAcqOrTP, chunk, fif
 				Display/N=DAQDataWaveTPMD DAQDataWave[][1]
 			endif
 
-			Cursor/W=DAQDataWaveTPMD/H=2/P A DAQDataWave first
-			Cursor/W=DAQDataWaveTPMD/H=2/P B DAQDataWave last
+			Cursor/W=DAQDataWaveTPMD/H=2/P A $NameOfWave(DAQDataWave) first
+			Cursor/W=DAQDataWaveTPMD/H=2/P B $NameOfWave(DAQDataWave) last
 		endif
 #endif
 


### PR DESCRIPTION
The name of the DAQDataWave is not the same anymore as the wave
reference name  since 1776cd86 (GetDAQDataWave: Introduce separate waves for DAQ/TP, 2020-12-15).
