### PR TITLE
BSP_UnsetDynamicStartupSettingsOfDataBrowser: Unset dashboard help wave

### DIFF
--- a/Packages/MIES/MIES_BrowserSettingsPanel.ipf
+++ b/Packages/MIES/MIES_BrowserSettingsPanel.ipf
@@ -248,7 +248,7 @@ Function BSP_UnsetDynamicStartupSettingsOfDataBrowser(mainPanel)
 	PopupMenu popup_TimeAlignment_Master win=$bsPanel, value = ""
 	ListBox list_of_ranges, win=$bsPanel, listWave=$"", selWave=$""
 	ListBox list_of_ranges1, win=$bsPanel, listWave=$"", selWave=$""
-	ListBox list_dashboard, win=$bsPanel, listWave=$"", colorWave=$"", selWave=$""
+	ListBox list_dashboard, win=$bsPanel, listWave=$"", colorWave=$"", selWave=$"", helpWave=$""
 End
 
 


### PR DESCRIPTION
Forgotten in f79e3e54 (Dashboard: Show the result message as tooltip for all columns, 2021-04-30).

The Databrowser macro was now with that change regenerated without
raising its version.
