### PR TITLE
UpdateZeroMQXOPLoggingTemplate: Remove bogus returned string

### DIFF
--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -6989,7 +6989,7 @@ Function UploadLogFiles()
 End
 
 /// @brief Update the logging template used by the ZeroMQ-XOP
-Function/S UpdateZeroMQXOPLoggingTemplate()
+Function UpdateZeroMQXOPLoggingTemplate()
 	variable JSONid
 	string str
 
@@ -7006,8 +7006,6 @@ Function/S UpdateZeroMQXOPLoggingTemplate()
 	DEBUGPRINT("ZeroMQ XOP is not present")
 
 #endif
-
-	return str
 End
 
 /// @brief Return the disc location of the (possibly non-existing) ZeroMQ-XOP logfile


### PR DESCRIPTION
The returned string is null in case the ZeroMQ XOP is not present.

As we don't use the return value anywhere we can just remove it. Bug
introduced in 7fd21c6b (Set a custom logging template for the ZeroMQ-XOP, 2021-04-12).
