### PR TITLE
IP9: Raise required version

### DIFF
--- a/Packages/MIES_Include.ipf
+++ b/Packages/MIES_Include.ipf
@@ -16,12 +16,12 @@
 // They are defined here so that we can parse them from within IP.
 //
 // .. |IgorPro8Nightly| replace:: `Igor Pro 8 <https://www.byte-physics.de/Downloads/WinIgor8_12MAY2021.zip>`__
-// .. |IgorPro9Nightly| replace:: `Igor Pro 9 <https://www.byte-physics.de/Downloads/WinIgor9_13MAY2021.zip>`__
+// .. |IgorPro9Nightly| replace:: `Igor Pro 9 <https://www.byte-physics.de/Downloads/WinIgor9_14AUG2021.zip>`__
 
 #pragma IgorVersion=8.04
 
 #if IgorVersion() >= 9.0
-#if (NumberByKey("BUILD", IgorInfo(0)) < 37462)
+#if (NumberByKey("BUILD", IgorInfo(0)) < 37800)
 #define TOO_OLD_IGOR
 #endif
 #else


### PR DESCRIPTION
This fixes a crash in the BeforeUncompiledHook.

Will merge once CI passes.

Close #1026.