### PR TITLE
Make dimension labels valid liberal object names

### DIFF
--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -623,7 +623,7 @@ Constant HARDWARE_DAC_EXTERNAL_TRIGGER = 0x1
 /// Used to upgrade the GuiStateWave as well as the DA Ephys panel
 Constant DA_EPHYS_PANEL_VERSION           = 53
 Constant DATA_SWEEP_BROWSER_PANEL_VERSION = 30
-Constant WAVEBUILDER_PANEL_VERSION        = 10
+Constant WAVEBUILDER_PANEL_VERSION        = 11
 Constant ANALYSISBROWSER_PANEL_VERSION    =  1
 
 /// Version of the labnotebooks (numerical and textual)

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -633,7 +633,7 @@ Constant ANALYSISBROWSER_PANEL_VERSION    =  1
 /// - Changed names of entries
 /// - Changed units or meaning of entries
 /// - New/Changed layers of entries
-Constant LABNOTEBOOK_VERSION = 48
+Constant LABNOTEBOOK_VERSION = 49
 
 /// Version of the stimset wave note
 Constant STIMSET_NOTE_VERSION = 7

--- a/Packages/MIES/MIES_DataConfigurator.ipf
+++ b/Packages/MIES/MIES_DataConfigurator.ipf
@@ -1021,9 +1021,9 @@ static Function DC_PrepareLBNEntries(string panelTitle, STRUCT DataConfiguration
 	DC_DocumentChannelProperty(panelTitle, "Igor Pro version", INDEP_HEADSTAGE, NaN, NaN, str=GetIgorProVersion())
 	DC_DocumentChannelProperty(panelTitle, "Igor Pro build", INDEP_HEADSTAGE, NaN, NaN, str=GetIgorProBuildVersion())
 	DC_DocumentChannelProperty(panelTitle, "Igor Pro bitness", INDEP_HEADSTAGE, NaN, NaN, var=GetArchitectureBits())
-	DC_DocumentChannelProperty(panelTitle, "JSON config file: path", INDEP_HEADSTAGE, NaN, NaN, str=GetUserData(panelTitle, "", EXPCONFIG_UDATA_SOURCEFILE_PATH))
-	DC_DocumentChannelProperty(panelTitle, "JSON config file: SHA-256 hash", INDEP_HEADSTAGE, NaN, NaN, str=GetUserData(panelTitle, "", EXPCONFIG_UDATA_SOURCEFILE_HASH))
-	DC_DocumentChannelProperty(panelTitle, "JSON config file: stimset nwb file path", INDEP_HEADSTAGE, NaN, NaN, str=GetUserData(panelTitle, "", EXPCONFIG_UDATA_STIMSET_NWB_PATH))
+	DC_DocumentChannelProperty(panelTitle, "JSON config file [path]", INDEP_HEADSTAGE, NaN, NaN, str=GetUserData(panelTitle, "", EXPCONFIG_UDATA_SOURCEFILE_PATH))
+	DC_DocumentChannelProperty(panelTitle, "JSON config file [SHA-256 hash]", INDEP_HEADSTAGE, NaN, NaN, str=GetUserData(panelTitle, "", EXPCONFIG_UDATA_SOURCEFILE_HASH))
+	DC_DocumentChannelProperty(panelTitle, "JSON config file [stimset nwb file path]", INDEP_HEADSTAGE, NaN, NaN, str=GetUserData(panelTitle, "", EXPCONFIG_UDATA_STIMSET_NWB_PATH))
 	DC_DocumentChannelProperty(panelTitle, "TP after DAQ", INDEP_HEADSTAGE, NaN, NaN, var=DAG_GetNumericalValue(panelTitle, "check_Settings_TPAfterDAQ"))
 
 	for(i = 0; i < NUM_HEADSTAGES; i += 1)

--- a/Packages/MIES/MIES_ExperimentDocumentation.ipf
+++ b/Packages/MIES/MIES_ExperimentDocumentation.ipf
@@ -437,7 +437,6 @@ static Function/Wave ED_FindIndizesAndRedimension(incomingKey, key, values, rowI
 	numCols = DimSize(incomingKey, COLS)
 	for(i = 0; i < numCols; i += 1)
 		searchStr = incomingKey[0][i]
-		ASSERT(!isEmpty(searchStr), "Incoming key can not be empty")
 
 		FindValue/TXOP=4/TEXT=(searchStr) key
 		col = floor(V_value / numKeyRows)
@@ -449,6 +448,7 @@ static Function/Wave ED_FindIndizesAndRedimension(incomingKey, key, values, rowI
 			sprintf msg, "Found key \"%s\" from incoming column %d in key column %d", incomingKey[0][i], i, idx
 			DEBUGPRINT(msg)
 		else
+			ASSERT(IsValidLiberalObjectName(searchStr), "Incoming key is not a valid liberal object name: " + searchStr)
 			idx = numKeyCols + numAdditions
 			EnsureLargeEnoughWave(key, minimumSize=idx, dimension=COLS)
 			key[0, lastValidIncomingKeyRow][idx] = incomingKey[p][i]

--- a/Packages/MIES/MIES_StimsetAPI.ipf
+++ b/Packages/MIES/MIES_StimsetAPI.ipf
@@ -165,7 +165,7 @@ End
 static Function/S ST_ParameterStringValues(string entry)
 	// translate passed string values which are numeric internally
 	//                                  WBP_GetDeltaModes() WBP_GetNoiseTypes()               WBP_GetNoiseBuildResolution() WBP_GetTriggerTypes()             WBP_GetPulseTypes()
-	Make/FREE/T translateableEntries = {"^.* op$",          "Noise Type: White, Pink, Brown", "Build resolution (index)",   "Trigonometric function Sin/Cos", "Pulse train type (index)"}
+	Make/FREE/T translateableEntries = {"^.* op$",          "Noise Type [White, Pink, Brown]", "Build resolution (index)",   "Trigonometric function Sin/Cos", "Pulse train type (index)"}
 
 	if(GrepString(entry, translateableEntries[0]))
 		return WBP_GetDeltaModes()

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -3435,7 +3435,8 @@ threadsafe Function IsValidLiberalObjectName(string name)
 End
 
 threadsafe static Function NameChecker(string name, variable liberal)
-	return !cmpstr(name, CleanupName(name, !!liberal, MAX_OBJECT_NAME_LENGTH_IN_BYTES))
+   // @todo remove the IsEmpty check once this is resolved upstream.
+	return !IsEmpty(name) && !cmpstr(name, CleanupName(name, !!liberal, MAX_OBJECT_NAME_LENGTH_IN_BYTES))
 End
 
 /// @brief Find an integer `x` which is larger than `a` but the

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -3422,11 +3422,13 @@ End
 
 /// @brief Check if a name for an object adheres to the strict naming rules
 ///
-/// @see `DisplayHelpTopic "ObjectName"`
-threadsafe Function IsValidObjectName(name)
-	string name
+/// @see `DisplayHelpTopic "Standard Object Names"`
+threadsafe Function IsValidObjectName(string name)
+	return NameChecker(name, 0)
+End
 
-	return !cmpstr(name, CleanupName(name, 0, MAX_OBJECT_NAME_LENGTH_IN_BYTES))
+threadsafe static Function NameChecker(string name, variable liberal)
+	return !cmpstr(name, CleanupName(name, !!liberal, MAX_OBJECT_NAME_LENGTH_IN_BYTES))
 End
 
 /// @brief Find an integer `x` which is larger than `a` but the

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -3427,6 +3427,13 @@ threadsafe Function IsValidObjectName(string name)
 	return NameChecker(name, 0)
 End
 
+/// @brief Check if a name for an object adheres to the liberal naming rules
+///
+/// @see `DisplayHelpTopic "Liberal Object Names"`
+threadsafe Function IsValidLiberalObjectName(string name)
+	return NameChecker(name, 1)
+End
+
 threadsafe static Function NameChecker(string name, variable liberal)
 	return !cmpstr(name, CleanupName(name, !!liberal, MAX_OBJECT_NAME_LENGTH_IN_BYTES))
 End

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -1687,7 +1687,7 @@ threadsafe Function/WAVE GetLBNidCache(numericalValues)
 	return wv
 End
 
-static Constant SWEEP_SETTINGS_WAVE_VERSION = 31
+static Constant SWEEP_SETTINGS_WAVE_VERSION = 32
 
 /// @brief Uses the parameter names from the `sourceKey` columns and
 ///        write them as dimension into the columns of dest.
@@ -2174,9 +2174,9 @@ End
 /// - 26: Digitizer Hardware Name
 /// - 27: Digitizer Serial Numbers
 /// - 28: Epochs
-/// - 29: JSON config file: path (`|` separated list of full file paths)
-/// - 30: JSON config file: SHA-256 hash (`|` separated list of hashes)
-/// - 31: JSON config file: stimset nwb file path
+/// - 29: JSON config file [path] (`|` separated list of full file paths)
+/// - 30: JSON config file [SHA-256 hash] (`|` separated list of hashes)
+/// - 31: JSON config file [stimset nwb file path]
 /// - 32: Igor Pro build
 /// - 33: Indexing End Stimset
 /// - 34: TTL Indexing End Stimset (hardware agnostic), string list in `INDEP_HEADSTAGE` layer with empty entries indexed by [0, NUM_DA_TTL_CHANNELS[
@@ -2240,9 +2240,9 @@ Function/Wave GetSweepSettingsTextKeyWave(panelTitle)
 	wv[0][26] = "Digitizer Hardware Name"
 	wv[0][27] = "Digitizer Serial Numbers"
 	wv[0][28] = EPOCHS_ENTRY_KEY
-	wv[0][29] = "JSON config file: path"
-	wv[0][30] = "JSON config file: SHA-256 hash"
-	wv[0][31] = "JSON config file: stimset nwb file path"
+	wv[0][29] = "JSON config file [path]"
+	wv[0][30] = "JSON config file [SHA-256 hash]"
+	wv[0][31] = "JSON config file [stimset nwb file path]"
 	wv[0][32] = "Igor Pro build"
 	wv[0][33] = "Indexing End Stimset"
 	wv[0][34] = "TTL Indexing End Stimset"
@@ -3927,7 +3927,7 @@ End
 /// - 2: Async Alarm $Channel OnOff
 /// - 3: Async Alarm $Channel Min
 /// - 4: Async Alarm  $Channel Max
-/// - 5: Async AD $Channel
+/// - 5: Async AD $Channel [$Title]
 Function/Wave GetAsyncSettingsKeyWave(WAVE settingsWave, variable channel, string title, string unit)
 	string prefix
 
@@ -3967,7 +3967,7 @@ Function/Wave GetAsyncSettingsKeyWave(WAVE settingsWave, variable channel, strin
 	wv[%Units][4]     = ""
 	wv[%Tolerance][4] = ".001"
 
-	sprintf prefix, "Async AD %d: %s", channel, title
+	sprintf prefix, "Async AD %d [%s]", channel, title
 
 	wv[%Parameter][5] = prefix
 	wv[%Units][5]     = unit

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -3258,7 +3258,7 @@ Function/WAVE GetTestPulse()
 	return wv
 End
 
-static Constant WP_WAVE_LAYOUT_VERSION = 11
+static Constant WP_WAVE_LAYOUT_VERSION = 12
 
 /// @brief Automated testing helper
 static Function GetWPVersion()
@@ -3312,6 +3312,8 @@ Function UpgradeWaveParam(wv)
 
 	// upgrade to wave version 11
 	// nothing to do as we keep them float
+
+	// upgrade to wave version 12 is done in AddDimLabelsToWP (liberal object names)
 
 	SetWaveVersion(wv, WP_WAVE_LAYOUT_VERSION)
 End
@@ -3368,19 +3370,19 @@ static Function AddDimLabelsToWP(wv)
 	SetDimLabel ROWS, 25, $("Chirp end frequency delta")      , wv
 	SetDimLabel ROWS, 26, $("Noise filter order")             , wv
 	SetDimLabel ROWS, 27, $("Noise filter order delta")       , wv
-	SetDimLabel ROWS, 28, $("PT: First Mixed Frequency")      , wv
-	SetDimLabel ROWS, 29, $("PT: First Mixed Frequency delta"), wv
-	SetDimLabel ROWS, 30, $("PT: Last Mixed Frequency")       , wv
-	SetDimLabel ROWS, 31, $("PT: Last Mixed Frequency delta") , wv
+	SetDimLabel ROWS, 28, $("PT [First Mixed Frequency]")     , wv
+	SetDimLabel ROWS, 29, $("PT [First Mixed Frequency] delta"), wv
+	SetDimLabel ROWS, 30, $("PT [Last Mixed Frequency]")      , wv
+	SetDimLabel ROWS, 31, $("PT [Last Mixed Frequency] delta"), wv
 	// unused entries are not labeled
 	SetDimLabel ROWS, 39, $("Reseed RNG for each epoch")      , wv
 	// unused entry, previously the global delta operation
-	SetDimLabel ROWS, 41, $("PT: Mixed Frequency")            , wv
-	SetDimLabel ROWS, 42, $("PT: Shuffle")                    , wv
-	SetDimLabel ROWS, 43, $("Chirp type: Log or sin")         , wv
+	SetDimLabel ROWS, 41, $("PT [Mixed Frequency]")           , wv
+	SetDimLabel ROWS, 42, $("PT [Shuffle]")                   , wv
+	SetDimLabel ROWS, 43, $("Chirp type [Log or sin]")        , wv
 	SetDimLabel ROWS, 44, $("Poisson distribution true/false"), wv
 	SetDimLabel ROWS, 45, $("Number of pulses")               , wv
-	SetDimLabel ROWS, 46, $("Duration type: User/Automatic")  , wv
+	SetDimLabel ROWS, 46, $("Duration type [User/Automatic]") , wv
 	SetDimLabel ROWS, 47, $("Number of pulses delta")         , wv
 	SetDimLabel ROWS, 48, $("Random Seed")                    , wv
 	SetDimLabel ROWS, 49, $("Reseed RNG for each step")       , wv
@@ -3389,7 +3391,7 @@ static Function AddDimLabelsToWP(wv)
 	SetDimLabel ROWS, 51, $("Offset dme")                     , wv
 	SetDimLabel ROWS, 52, $("Duration dme")                   , wv
 	SetDimLabel ROWS, 53, $("Trigonometric function Sin/Cos") , wv
-	SetDimLabel ROWS, 54, $("Noise Type: White, Pink, Brown") , wv
+	SetDimLabel ROWS, 54, $("Noise Type [White, Pink, Brown]"), wv
 	SetDimLabel ROWS, 55, $("Build resolution (index)")       , wv
 	SetDimLabel ROWS, 56, $("Pulse train type (index)")       , wv
 	SetDimLabel ROWS, 57, $("Sin/chirp/saw frequency dme")    , wv
@@ -3402,8 +3404,8 @@ static Function AddDimLabelsToWP(wv)
 	SetDimLabel ROWS, 64, $("High pass filter cut off dme")   , wv
 	SetDimLabel ROWS, 65, $("Chirp end frequency dme")        , wv
 	SetDimLabel ROWS, 66, $("Noise filter order dme")         , wv
-	SetDimLabel ROWS, 67, $("PT: First Mixed Frequency dme")  , wv
-	SetDimLabel ROWS, 68, $("PT: Last Mixed Frequency dme")   , wv
+	SetDimLabel ROWS, 67, $("PT [First Mixed Frequency] dme") , wv
+	SetDimLabel ROWS, 68, $("PT [Last Mixed Frequency] dme")  , wv
 	SetDimLabel ROWS, 69, $("Number of pulses dme")           , wv
 	SetDimLabel ROWS, 70, $("Amplitude op")                   , wv
 	SetDimLabel ROWS, 71, $("Offset op")                      , wv
@@ -3418,8 +3420,8 @@ static Function AddDimLabelsToWP(wv)
 	SetDimLabel ROWS, 80, $("High pass filter cut off op")    , wv
 	SetDimLabel ROWS, 81, $("Chirp end frequency op")         , wv
 	SetDimLabel ROWS, 82, $("Noise filter order op")          , wv
-	SetDimLabel ROWS, 83, $("PT: First Mixed Frequency op")   , wv
-	SetDimLabel ROWS, 84, $("PT: Last Mixed Frequency op")    , wv
+	SetDimLabel ROWS, 83, $("PT [First Mixed Frequency] op")  , wv
+	SetDimLabel ROWS, 84, $("PT [Last Mixed Frequency] op")   , wv
 	SetDimLabel ROWS, 85, $("Number of pulses op")            , wv
 End
 
@@ -3482,7 +3484,7 @@ Function/WAVE GetWaveBuilderWaveParamAsFree()
 	return wv
 End
 
-static Constant WPT_WAVE_LAYOUT_VERSION = 10
+static Constant WPT_WAVE_LAYOUT_VERSION = 11
 
 /// @brief Automated testing helper
 static Function GetWPTVersion()
@@ -3554,6 +3556,8 @@ Function UpgradeWaveTextParam(wv)
 		wv[10][%Set][INDEP_EPOCH_TYPE] = ""
 	endif
 
+	// upgrade to wave version 11 is done in AddDimLabelsToWPT (liberal object names)
+
 	SetWaveVersion(wv, WPT_WAVE_LAYOUT_VERSION)
 End
 
@@ -3590,8 +3594,8 @@ static Function AddDimLabelsToWPT(wv)
 	SetDimLabel ROWS, 21, $("High pass filter cut off ldel") , wv
 	SetDimLabel ROWS, 22, $("Chirp end frequency ldel")      , wv
 	SetDimLabel ROWS, 23, $("Noise filter order ldel")       , wv
-	SetDimLabel ROWS, 24, $("PT: First Mixed Frequency ldel"), wv
-	SetDimLabel ROWS, 25, $("PT: Last Mixed Frequency ldel") , wv
+	SetDimLabel ROWS, 24, $("PT [First Mixed Frequency] ldel"), wv
+	SetDimLabel ROWS, 25, $("PT [Last Mixed Frequency] ldel"), wv
 	SetDimLabel ROWS, 26, $("Number of pulses ldel")         , wv
 	SetDimLabel ROWS, 27, $("Analysis pre set function")     , wv
 	SetDimLabel ROWS, 28, $("Inter trial interval ldel")     , wv
@@ -3879,10 +3883,10 @@ Function/WAVE GetEpochParameterNames()
 	/// @{
 	Make/T/FREE st_0 = {"Amplitude", "Amplitude delta", "Amplitude dme", "Amplitude ldel", "Amplitude op", "Duration", "Duration delta", "Duration dme", "Duration ldel", "Duration op"}
 	Make/T/FREE st_1 = {"Amplitude", "Amplitude delta", "Amplitude dme", "Amplitude ldel", "Amplitude op", "Duration", "Duration delta", "Duration dme", "Duration ldel", "Duration op", "Offset", "Offset delta", "Offset dme", "Offset ldel", "Offset op"}
-	Make/T/FREE st_2 = {"Amplitude", "Amplitude delta", "Amplitude dme", "Amplitude ldel", "Amplitude op", "Build resolution (index)", "Duration", "Duration delta", "Duration dme", "Duration ldel", "Duration op", "High pass filter cut off", "High pass filter cut off delta", "High pass filter cut off dme", "High pass filter cut off ldel", "High pass filter cut off op", "Low pass filter cut off", "Low pass filter cut off delta", "Low pass filter cut off dme", "Low pass filter cut off ldel", "Low pass filter cut off op", "Noise filter order", "Noise filter order delta", "Noise filter order dme", "Noise filter order ldel", "Noise filter order op", "Noise Type: White, Pink, Brown", "Offset", "Offset delta", "Offset dme", "Offset ldel", "Offset op", "Random Seed", "Reseed RNG for each epoch", "Reseed RNG for each step"}
-	Make/T/FREE st_3 = {"Amplitude", "Amplitude delta", "Amplitude dme", "Amplitude ldel", "Amplitude op", "Chirp end frequency", "Chirp end frequency delta", "Chirp end frequency dme", "Chirp end frequency ldel", "Chirp end frequency op", "Chirp type: Log or sin", "Duration", "Duration delta", "Duration dme", "Duration ldel", "Duration op", "Offset", "Offset delta", "Offset dme", "Offset ldel", "Offset op", "Sin/chirp/saw frequency", "Sin/chirp/saw frequency delta", "Sin/chirp/saw frequency dme", "Sin/chirp/saw frequency ldel", "Sin/chirp/saw frequency op", "Trigonometric function Sin/Cos"}
+	Make/T/FREE st_2 = {"Amplitude", "Amplitude delta", "Amplitude dme", "Amplitude ldel", "Amplitude op", "Build resolution (index)", "Duration", "Duration delta", "Duration dme", "Duration ldel", "Duration op", "High pass filter cut off", "High pass filter cut off delta", "High pass filter cut off dme", "High pass filter cut off ldel", "High pass filter cut off op", "Low pass filter cut off", "Low pass filter cut off delta", "Low pass filter cut off dme", "Low pass filter cut off ldel", "Low pass filter cut off op", "Noise filter order", "Noise filter order delta", "Noise filter order dme", "Noise filter order ldel", "Noise filter order op", "Noise Type [White, Pink, Brown]", "Offset", "Offset delta", "Offset dme", "Offset ldel", "Offset op", "Random Seed", "Reseed RNG for each epoch", "Reseed RNG for each step"}
+	Make/T/FREE st_3 = {"Amplitude", "Amplitude delta", "Amplitude dme", "Amplitude ldel", "Amplitude op", "Chirp end frequency", "Chirp end frequency delta", "Chirp end frequency dme", "Chirp end frequency ldel", "Chirp end frequency op", "Chirp type [Log or sin]", "Duration", "Duration delta", "Duration dme", "Duration ldel", "Duration op", "Offset", "Offset delta", "Offset dme", "Offset ldel", "Offset op", "Sin/chirp/saw frequency", "Sin/chirp/saw frequency delta", "Sin/chirp/saw frequency dme", "Sin/chirp/saw frequency ldel", "Sin/chirp/saw frequency op", "Trigonometric function Sin/Cos"}
 	Make/T/FREE st_4 = {"Amplitude", "Amplitude delta", "Amplitude dme", "Amplitude ldel", "Amplitude op", "Duration", "Duration delta", "Duration dme", "Duration ldel", "Duration op", "Offset", "Offset delta", "Offset dme", "Offset ldel", "Offset op", "Sin/chirp/saw frequency", "Sin/chirp/saw frequency delta", "Sin/chirp/saw frequency dme", "Sin/chirp/saw frequency ldel", "Sin/chirp/saw frequency op"}
-	Make/T/FREE st_5 = {"Amplitude", "Amplitude delta", "Amplitude dme", "Amplitude ldel", "Amplitude op", "Duration", "Duration delta", "Duration dme", "Duration ldel", "Duration op", "Duration type: User/Automatic", "Number of pulses", "Number of pulses delta", "Number of pulses dme", "Number of pulses ldel", "Number of pulses op", "Offset", "Offset delta", "Offset dme", "Offset ldel", "Offset op", "Poisson distribution true/false", "PT: First Mixed Frequency", "PT: First Mixed Frequency delta", "PT: First Mixed Frequency dme", "PT: First Mixed Frequency ldel", "PT: First Mixed Frequency op", "PT: Last Mixed Frequency", "PT: Last Mixed Frequency delta", "PT: Last Mixed Frequency dme", "PT: Last Mixed Frequency ldel", "PT: Last Mixed Frequency op", "PT: Mixed Frequency", "PT: Shuffle", "Pulse train type (index)", "Random Seed", "Reseed RNG for each epoch", "Reseed RNG for each step", "Sin/chirp/saw frequency", "Sin/chirp/saw frequency delta", "Sin/chirp/saw frequency dme", "Sin/chirp/saw frequency ldel", "Sin/chirp/saw frequency op", "Train pulse duration", "Train pulse duration delta", "Train pulse duration dme", "Train pulse duration ldel", "Train pulse duration op"}
+	Make/T/FREE st_5 = {"Amplitude", "Amplitude delta", "Amplitude dme", "Amplitude ldel", "Amplitude op", "Duration", "Duration delta", "Duration dme", "Duration ldel", "Duration op", "Duration type [User/Automatic]", "Number of pulses", "Number of pulses delta", "Number of pulses dme", "Number of pulses ldel", "Number of pulses op", "Offset", "Offset delta", "Offset dme", "Offset ldel", "Offset op", "Poisson distribution true/false", "PT [First Mixed Frequency]", "PT [First Mixed Frequency] delta", "PT [First Mixed Frequency] dme", "PT [First Mixed Frequency] ldel", "PT [First Mixed Frequency] op", "PT [Last Mixed Frequency]", "PT [Last Mixed Frequency] delta", "PT [Last Mixed Frequency] dme", "PT [Last Mixed Frequency] ldel", "PT [Last Mixed Frequency] op", "PT [Mixed Frequency]", "PT [Shuffle]", "Pulse train type (index)", "Random Seed", "Reseed RNG for each epoch", "Reseed RNG for each step", "Sin/chirp/saw frequency", "Sin/chirp/saw frequency delta", "Sin/chirp/saw frequency dme", "Sin/chirp/saw frequency ldel", "Sin/chirp/saw frequency op", "Train pulse duration", "Train pulse duration delta", "Train pulse duration dme", "Train pulse duration ldel", "Train pulse duration op"}
 	Make/T/FREE st_6 = {"Amplitude", "Amplitude delta", "Amplitude dme", "Amplitude ldel", "Amplitude op", "Duration", "Duration delta", "Duration dme", "Duration ldel", "Duration op", "Offset", "Offset delta", "Offset dme", "Offset ldel", "Offset op", "PSC exp decay time 1/2", "PSC exp decay time 1/2 delta", "PSC exp decay time 1/2 dme", "PSC exp decay time 1/2 ldel", "PSC exp decay time 1/2 op", "PSC exp decay time 2/2", "PSC exp decay time 2/2 delta", "PSC exp decay time 2/2 dme", "PSC exp decay time 2/2 ldel", "PSC exp decay time 2/2 op", "PSC exp rise time", "PSC exp rise time delta", "PSC exp rise time dme", "PSC exp rise time ldel", "PSC exp rise time op", "PSC ratio decay times", "PSC ratio decay times delta", "PSC ratio decay times dme", "PSC ratio decay times ldel", "PSC ratio decay times op"}
 	Make/T/FREE st_7 = {"Custom epoch wave name", "Offset", "Offset delta", "Offset dme", "Offset ldel", "Offset op"}
 	Make/T/FREE st_8 = {"Combine epoch formula"}

--- a/Packages/MIES_Include.ipf
+++ b/Packages/MIES_Include.ipf
@@ -21,9 +21,7 @@
 #pragma IgorVersion=8.04
 
 #if IgorVersion() >= 9.0
-#if (NumberByKey("BUILD", IgorInfo(0)) < 37800)
-#define TOO_OLD_IGOR
-#endif
+// 37840 is the released version of IP9
 #else
 #if (NumberByKey("BUILD", IgorInfo(0)) < 37456)
 #define TOO_OLD_IGOR

--- a/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
+++ b/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
@@ -4357,7 +4357,7 @@ Function AsyncAcquisitionLBN_REENTRY([str])
 	var = GetLastSettingIndep(numericalValues, 0, "Async Alarm  2 Max", DATA_ACQUISITION_MODE)
 	CHECK_EQUAL_VAR(var, 0.5)
 
-	var = GetLastSettingIndep(numericalValues, 0, "Async AD 2: myTitle", DATA_ACQUISITION_MODE)
+	var = GetLastSettingIndep(numericalValues, 0, "Async AD 2 [myTitle]", DATA_ACQUISITION_MODE)
 	CHECK(var >= 0)
 
 	readStr = GetLastSettingTextIndep(textualValues, 0, "Async AD2 Title", DATA_ACQUISITION_MODE)

--- a/Packages/Testing-MIES/UTF_StimsetAPI.ipf
+++ b/Packages/Testing-MIES/UTF_StimsetAPI.ipf
@@ -242,9 +242,9 @@ static Function GetStimsetParameterAsStringWorks()
 
 	// 1 == Pink
 	// internally stored as numeric, but with the API as string for better readability
-	WP[%$("Noise Type: White, Pink, Brown")][1][%$("Noise")] = 1
+	WP[%$("Noise Type [White, Pink, Brown]")][1][%$("Noise")] = 1
 
-	str = ST_GetStimsetParameterAsString(name, "Noise Type: White, Pink, Brown", epochIndex = 1)
+	str = ST_GetStimsetParameterAsString(name, "Noise Type [White, Pink, Brown]", epochIndex = 1)
 	ref = "Pink"
 	CHECK_EQUAL_STR(str, ref)
 
@@ -283,8 +283,8 @@ static Function SetStimsetParameterWorks()
 	CHECK_WAVE(WP, NUMERIC_WAVE)
 
 	// string given but stored as numeric
-	ST_SetStimsetParameter(name, "Noise Type: White, Pink, Brown", epochIndex = 1, str = "Brown")
-	CHECK_EQUAL_VAR(WP[%$("Noise Type: White, Pink, Brown")][1][%$("Noise")], 2)
+	ST_SetStimsetParameter(name, "Noise Type [White, Pink, Brown]", epochIndex = 1, str = "Brown")
+	CHECK_EQUAL_VAR(WP[%$("Noise Type [White, Pink, Brown]")][1][%$("Noise")], 2)
 
 	// really stored numerical, per epoch
 	ST_SetStimsetParameter(name, "Duration", epochIndex = 0, var = 123)
@@ -414,12 +414,12 @@ static Function SetStimsetParameterChecksInput()
 	ParameterWavesAreUnchanged_IGNORE(s)
 
 	// indexed epoch does not have that parameter
-	ST_SetStimsetParameter(name, "Noise Type: White, Pink, Brown", epochIndex = 0, str = "Brown")
+	ST_SetStimsetParameter(name, "Noise Type [White, Pink, Brown]", epochIndex = 0, str = "Brown")
 	CHECK_EQUAL_VAR(ret, 1)
 	ParameterWavesAreUnchanged_IGNORE(s)
 
 	// translated string parameter with invalid string
-	ST_SetStimsetParameter(name, "Noise Type: White, Pink, Brown", epochIndex = 1, str = "I DON'T EXIST")
+	ST_SetStimsetParameter(name, "Noise Type [White, Pink, Brown]", epochIndex = 1, str = "I DON'T EXIST")
 	CHECK_EQUAL_VAR(ret, 1)
 	ParameterWavesAreUnchanged_IGNORE(s)
 End


### PR DESCRIPTION
- [x] Search for invalid dim labels in some sample pxp files
- [x] Add `IsValidLiberalObjectName`, modelled after `IsValidObjectName`
- [x] Enforce valid liberal names in `ED_FindIndizesAndRedimension` via IsValidLiberalObjectName assertion
- [x] Change existing LBN keys which are now invalid to be valid again. Maybe replace ":" with "|"?. Raise LBN version.
- [x] Upgrade existing labnotebooks (values and keys) in UpgradeLabNotebook, raise LBN version
- [x] Change wavebuilder parameter names and upgrade WP/WPT waves (`AddDimLabelsToWP`/`AddDimLabelsToWPT`)
- [x] Adapt `GetAsyncSettingsKeyWave`

Close #1027.