### PR TITLE
Make release package installation work again

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -28,6 +28,7 @@ LICENSE whitespace=cr-at-eol
 .git*                 export-ignore
 *.sh                  export-ignore
 tools                 export-ignore
+Packages/*/tools     -export-ignore
 Packages/Testing-MIES export-ignore
 Packages/Arduino/*zip export-ignore
 Packages/Arduino/*exe export-ignore

--- a/tools/clean_mies_installation.sh
+++ b/tools/clean_mies_installation.sh
@@ -162,6 +162,14 @@ do
 
     cp -r  "$base_folder"/XOPs-IP${i}/MIESUtils*  "$xops32"
     cp -r  "$base_folder"/XOPs-IP${i}-64bit/MIESUtils*  "$xops64"
+
+    cp -r  "$base_folder"/XOPs-IP${i}/JSON*  "$xops32"
+    cp -r  "$base_folder"/XOPs-IP${i}-64bit/JSON*  "$xops64"
+
+    cp -r  "$base_folder"/XOPs-IP${i}/ZeroMQ*  "$xops32"
+    cp -r  "$base_folder"/XOPs-IP${i}/libzmq*  "$xops32"
+    cp -r  "$base_folder"/XOPs-IP${i}-64bit/ZeroMQ*  "$xops64"
+    cp -r  "$base_folder"/XOPs-IP${i}-64bit/libzmq*  "$xops64"
   fi
 
   if [ "$sourceLoc" = "git" ]


### PR DESCRIPTION
Ever since we dropped the ITCXOP submodule in 254b1bca (Readd needed
ITCXOP2 scripts, 2021-04-08) we did not include the ITCXOP tools
directory in the release package.

This was due to export-ignore tag on all directories named tools.
We now readd Packages/*/tools as we want this.
