### PR TITLE
Change isEmpty to not use string parameter by reference

### DIFF
--- a/Packages/MIES/MIES_AnalysisFunctionHelpers.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctionHelpers.ipf
@@ -574,7 +574,9 @@ Function/S AFH_GetAnalysisParamType(name, params, [typeCheck, expectedType])
 	string type = ""
 	variable pos
 
-	if(!ParamIsDefault(expectedType))
+	if(ParamIsDefault(expectedType))
+		expectedType = ""
+	else
 		typeCheck = 1
 		ASSERT(AFH_IsValidAnalysisParamType(expectedType), "Invalid expectedType")
 	endif

--- a/Packages/MIES/MIES_AnalysisFunctionHelpers.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctionHelpers.ipf
@@ -868,7 +868,8 @@ Function/S AFH_CheckAnalysisParameter(string genericFunc, STRUCT CheckParameters
 				ASSERT(0, "impossible case")
 			endif
 
-			if(!IsEmpty(message))
+			// allow null return string meaning no error
+			if(!IsNull(message) && !IsEmpty(message))
 				errorMessages[index++] = name + ": " + trimstring(message)
 			endif
 		catch

--- a/Packages/MIES/MIES_BrowserSettingsPanel.ipf
+++ b/Packages/MIES/MIES_BrowserSettingsPanel.ipf
@@ -1665,7 +1665,7 @@ Function BSP_EpochGraphToolTip(s)
 	Variable hookResult = 0 // 0 tells Igor to use the standard tooltip
 
 	// traceName is set only for graphs and only if the mouse hovered near a trace
-	if (strlen(s.traceName) > 0)
+	if(!IsEmpty(s.traceName))
 		s.tooltip = "a <-> b"
 		s.isHtml = 1
 		WAVE w = s.yWave // The trace's Y wave

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -2369,6 +2369,7 @@ Function DAP_CheckSettings(device, mode)
 
 			// classic distributed acquisition requires that all stim sets are the same
 			// oodDAQ allows different stim sets
+			refDacWave = ""
 			if(DAG_GetNumericalValue(device, "Check_DataAcq1_DistribDaq") || DAG_GetNumericalValue(device, "Check_DataAcq1_dDAQOptOv"))
 				WAVE statusDAFiltered = DC_GetFilteredChannelState(device, mode, CHANNEL_TYPE_DAC)
 				numEntries = DimSize(statusDAFiltered, ROWS)

--- a/Packages/MIES/MIES_Epochs.ipf
+++ b/Packages/MIES/MIES_Epochs.ipf
@@ -286,6 +286,8 @@ static Function EP_AddEpochsFromStimSetNote(device, channel, stimset, stimsetBeg
 		epSubTags = ReplaceNumberByKey("Epoch", epSubTags, epochNr, STIMSETKEYNAME_SEP, EPOCHNAME_SEP)
 		epSubTags = ReplaceNumberByKey(EPOCH_AMPLITUDE_KEY, epSubTags, amplitude, STIMSETKEYNAME_SEP, EPOCHNAME_SEP)
 
+		epSpecifier = ""
+
 		if(epochType == EPOCH_TYPE_PULSE_TRAIN)
 			if(!CmpStr(WB_GetWaveNoteEntry(stimNote, EPOCH_ENTRY, sweep = sweep, epoch = epochNr, key = "Mixed frequency"), "True"))
 				epSpecifier = "Mixed frequency"
@@ -295,9 +297,8 @@ static Function EP_AddEpochsFromStimSetNote(device, channel, stimset, stimsetBeg
 			if(!CmpStr(WB_GetWaveNoteEntry(stimNote, EPOCH_ENTRY, key="Mixed frequency shuffle", sweep=sweep, epoch=epochNr), "True"))
 				epSpecifier += " shuffled"
 			endif
-		else
-			epSpecifier = ""
 		endif
+
 		if(!isEmpty(epSpecifier))
 			epSubTags = ReplaceStringByKey("Details", epSubTags, epSpecifier, STIMSETKEYNAME_SEP, EPOCHNAME_SEP)
 		endif

--- a/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
+++ b/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
@@ -1314,7 +1314,7 @@ threadsafe static Function NWB_ClearWriteChannelParams(s)
 	string device
 	variable sweep, startingTime, samplingRate, groupIndex
 
-	if(strlen(s.device) > 0)
+	if(!IsEmpty(s.device))
 		device = s.device
 	endif
 
@@ -1327,7 +1327,7 @@ threadsafe static Function NWB_ClearWriteChannelParams(s)
 
 	s = defaultValues
 
-	if(strlen(device) > 0)
+	if(!IsEmpty(device))
 		s.device = device
 	endif
 
@@ -1752,7 +1752,7 @@ threadsafe static Function NWB_GetTimeSeriesProperties(variable nwbVersion, WAVE
 		return NaN
 	endif
 
-	if(strlen(tsp.missing_fields) > 0)
+	if(!IsEmpty(tsp.missing_fields))
 		ASSERT_TS(IsFinite(p.electrodeNumber), "Expected finite electrode number with non empty \"missing_fields\"")
 	endif
 

--- a/Packages/MIES/MIES_PulseAveraging.ipf
+++ b/Packages/MIES/MIES_PulseAveraging.ipf
@@ -1721,7 +1721,7 @@ static Function/S PA_ShowPulses(string win, STRUCT PulseAverageSettings &pa, STR
 			AccelerateHideTraces(hiddenTracesGraphs[j], hiddenTracesNames, DimSize(hiddenTracesNames, ROWS), hideTrace)
 		endfor
 		JSON_Release(hideTraceJsonID)
-	elseif(!IsEmpty(graph))
+	elseif(!IsNull(graph) && !IsEmpty(graph))
 		AccelerateHideTraces(graph, hiddenTraces, hiddenTracesCount, hideTrace)
 	endif
 

--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -491,7 +491,7 @@ static Function SF_FormulaParser(string formula, [variable &createdArray, variab
 				lastCalculation = state
 			case SF_ACTION_SAMECALCULATION:
 			default:
-				if(strlen(buffer) > 0)
+				if(!IsEmpty(buffer))
 					JSON_AddJSON(jsonID, jsonPath, SF_FormulaParser(buffer, indentLevel = indentLevel + 1))
 				endif
 		endswitch
@@ -511,7 +511,7 @@ static Function SF_FormulaParser(string formula, [variable &createdArray, variab
 		else
 			JSON_AddString(jsonID, jsonPath, buffer)
 		endif
-	elseif(strlen(buffer) > 0)
+	elseif(!IsEmpty(buffer))
 		JSON_AddJSON(jsonID, jsonPath, SF_FormulaParser(buffer))
 	endif
 

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -131,7 +131,7 @@ Function ASSERT(variable var, string errorMsg, [variable extendedOutput])
 			Make/FREE/T tpStates = { NONE }
 			Make/FREE/T daqStates = { NONE }
 
-			if(!SVAR_Exists(lockedDevices) || strlen(lockedDevices) == 0)
+			if(!SVAR_Exists(lockedDevices) || IsEmpty(lockedDevices))
 				lockedDevicesStr = NONE
 			else
 				lockedDevicesStr = lockedDevices
@@ -2157,7 +2157,7 @@ End
 /// 	Function SearchString(str, substring)
 /// 		string str, substring
 ///
-/// 		ASSERT(strlen(substring) > 0, "supplied substring has zero length")
+/// 		ASSERT(!IsEmpty(substring), "supplied substring is empty")
 /// 		WAVE/Z/T wv = SearchStringBase(str, "(.*)\\Q" + substring + "\\E(.*)")
 ///
 /// 		return WaveExists(wv)

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -44,16 +44,14 @@ threadsafe Function IsNull(str)
 	return numtype(len) == 2
 End
 
-/// @brief Returns one if str is empty or null, zero otherwise.
-/// @param str must not be a SVAR
+/// @brief Returns one if str is empty, zero otherwise.
+/// @param str any non-null string variable or text wave element
 ///
 /// @hidecallgraph
 /// @hidecallergraph
-threadsafe Function IsEmpty(str)
-	string& str
+threadsafe Function IsEmpty(string str)
 
-	variable len = strlen(str)
-	return numtype(len) == 2 || len <= 0
+	return !(strlen(str) > 0)
 End
 
 /// @brief Low overhead function to check assertions

--- a/Packages/Testing-MIES/UTF_TestNWBExportV1.ipf
+++ b/Packages/Testing-MIES/UTF_TestNWBExportV1.ipf
@@ -176,7 +176,7 @@ static Function TestTimeSeriesProperties(groupID, channel)
 	STRUCT TimeSeriesProperties tsp
 	ReadTimeSeriesProperties(groupID, channel, tsp)
 
-	if(strlen(tsp.missing_fields) == 0)
+	if(IsEmpty(tsp.missing_fields))
 		missing_fields = "PLACEHOLDER;"
 	else
 		missing_fields = tsp.missing_fields

--- a/Packages/Testing-MIES/UTF_Utils.ipf
+++ b/Packages/Testing-MIES/UTF_Utils.ipf
@@ -2193,7 +2193,7 @@ Function/S TrimVolatileFolderName_IGNORE(list)
 	string str
 	string result = ""
 
-	if(strlen(list) == 0)
+	if(isEmpty(list))
 		return list
 	endif
 


### PR DESCRIPTION
After a discussion with Thomas about the disadvantages of isEmpty when using strings from structures or text wave elements we decided to give this change a try.

Since Igor generates a RTE if a null string is used as parameter as a non-ref parameter isEmpty will now generate an RTE if it is used to check against a null string. (Where IsNull should be used). Despite the RTE it will still work correctly for the case of a null string parameter though.

CI will hopefully show locations in the code where such lingering RTEs are generated.