### PR TITLE
fix EP_AddEpochsFromStimSetNote for empty stimset wave notes

### DIFF
--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -639,7 +639,7 @@ Constant LABNOTEBOOK_VERSION = 49
 Constant STIMSET_NOTE_VERSION = 7
 
 /// Version of the epoch information for DA data
-Constant SWEEP_EPOCH_VERSION = 1
+Constant SWEEP_EPOCH_VERSION = 2
 
 /// @name The channel numbers for the different ITC devices used for accesssing
 ///       the TTLs

--- a/Packages/MIES/MIES_WaveBuilder.ipf
+++ b/Packages/MIES/MIES_WaveBuilder.ipf
@@ -2558,3 +2558,21 @@ Function WB_SplitStimsetName(string setName, string &setPrefix, variable &stimul
 	setPrefix    = setPrefixString
 	stimulusType = WB_ParseStimulusType(stimulusTypeString)
 End
+
+/// @brief Changes an existing stimset to a third party stimset
+Function WB_MakeStimsetThirdParty(string setName)
+
+	ASSERT(!IsEmpty(setName), "Stimset name can not be empty.")
+	ASSERT(!WB_StimsetIsFromThirdParty(setName), "Specified Stimset is already a third party stimset")
+
+	WAVE/Z stimset = WB_CreateAndGetStimSet(setName)
+	ASSERT(WaveExists(stimset), "Specified stimset does not exist.")
+	Note/k stimset
+
+	WAVE WP        = WB_GetWaveParamForSet(setName)
+	WAVE WPT       = WB_GetWaveTextParamForSet(setName)
+	WAVE SegWvType = WB_GetSegWvTypeForSet(setName)
+	KillOrMoveToTrash(wv=WP)
+	KillOrMoveToTrash(wv=WPT)
+	KillOrMoveToTrash(wv=SegWvType)
+End

--- a/Packages/MIES/MIES_WaveBuilder.ipf
+++ b/Packages/MIES/MIES_WaveBuilder.ipf
@@ -64,18 +64,15 @@ Function/Wave WB_CreateAndGetStimSet(setName)
 	DFREF dfr = GetSetFolder(type)
 	WAVE/Z/SDFR=dfr stimSet = $setName
 
-	if(!WaveExists(stimSet))
-		// catches non-existing stimsets as well
-		if(WB_StimsetIsFromThirdParty(setName))
+	if(WB_StimsetIsFromThirdParty(setName))
+		if(WaveExists(stimSet))
+			return stimSet
+		else
 			return $""
 		endif
-
-		needToCreateStimSet = 1
-	elseif(WB_StimsetNeedsUpdate(setName))
-		needToCreateStimSet = 1
-	else
-		needToCreateStimSet = 0
 	endif
+
+	needToCreateStimSet = (!WaveExists(stimSet) || WB_StimsetNeedsUpdate(setName))
 
 	if(needToCreateStimSet)
 		// create current stimset

--- a/Packages/Testing-MIES/UTF_Epochs.ipf
+++ b/Packages/Testing-MIES/UTF_Epochs.ipf
@@ -21,6 +21,7 @@ static Function AcquireData(s, devices, stimSetName1, stimSetName2[, dDAQ, oodDA
 
 	dDAQ = ParamIsDefault(dDAQ) ? 0 : !!dDAQ
 	oodDAQ = ParamIsDefault(oodDAQ) ? 0 : !!oodDAQ
+	analysisFunction = SelectString(ParamIsDefault(analysisFunction), analysisFunction, "")
 
 	numEntries = ItemsInList(devices)
 	for(i = 0; i < numEntries; i += 1)
@@ -76,8 +77,10 @@ static Function AcquireData(s, devices, stimSetName1, stimSetName2[, dDAQ, oodDA
 		PASS()
 	endfor
 
-	ST_SetStimsetParameter(stimsetName1, "Analysis function (Generic)", str = analysisFunction)
-	ST_SetStimsetParameter(stimsetName2, "Analysis function (Generic)", str = analysisFunction)
+	if(!IsEmpty(analysisFunction))
+		ST_SetStimsetParameter(stimsetName1, "Analysis function (Generic)", str = analysisFunction)
+		ST_SetStimsetParameter(stimsetName2, "Analysis function (Generic)", str = analysisFunction)
+	endif
 
 	device = devices
 


### PR DESCRIPTION
EP_AddEpochsFromStimSetNote was also called for stimsets with empty wave notes
such as TP during DAQ stimsets. This resulted in an ST_B (stimset baseline)
epoch added for this stimset, that is wrong.

Fix: - Added a check in callers of EP_AddEpochsFromStimSetNote to call only if
       the stimset is of a type that should contain epoch data.
	 - Added better checks in EP_AddEpochsFromStimSetNote
	 - increased sweep_epoch_version.

close https://github.com/AllenInstitute/MIES/issues/1063