### PR TITLE
fix for unintended clearing of pending RTEs

### DIFF
--- a/Packages/MIES/MIES_AmplifierInteraction.ipf
+++ b/Packages/MIES/MIES_AmplifierInteraction.ipf
@@ -1026,8 +1026,8 @@ Function AI_SelectMultiClamp(panelTitle, headStage)
 		return AMPLIFIER_CONNECTION_INVAL_SER
 	endif
 
-	ClearRTError()
-	MCC_SelectMultiClamp700B(mccSerial, channel); err = GetRTError(1)
+	AssertOnAndClearRTError()
+	MCC_SelectMultiClamp700B(mccSerial, channel); err = GetRTError(1) // see developer docu section Preventing Debugger Popup
 
 	if(err)
 		return AMPLIFIER_CONNECTION_MCC_FAILED

--- a/Packages/MIES/MIES_AmplifierInteraction.ipf
+++ b/Packages/MIES/MIES_AmplifierInteraction.ipf
@@ -375,6 +375,7 @@ Function AI_UpdateAmpModel(panelTitle, ctrl, headStage, [value, sendToAll, check
 				AmpStorageWave[%$rowLabel][0][i] = value
 				AI_UpdateAmpView(panelTitle, i, ctrl=ctrlToCall)
 				// the pipette offset for the opposite mode has also changed, fetch that too
+				AssertOnAndClearRTError()
 				try
 					oldTab = GetTabID(panelTitle, "ADC")
 					if(oldTab != 0)
@@ -392,6 +393,7 @@ Function AI_UpdateAmpModel(panelTitle, ctrl, headStage, [value, sendToAll, check
 						PGC_SetAndActivateControl(panelTitle, "ADC", val=oldTab)
 					endif
 				catch
+					ClearRTError()
 					if(DAG_GetNumericalValue(panelTitle, "check_Settings_SyncMiesToMCC"))
 						printf "(%s) The pipette offset for %s of headstage %d is invalid.\r", panelTitle, ConvertAmplifierModeToString(oppositeMode), i
 					endif

--- a/Packages/MIES/MIES_AnalysisBrowser.ipf
+++ b/Packages/MIES/MIES_AnalysisBrowser.ipf
@@ -1000,9 +1000,11 @@ static Function/S AB_LoadLabNotebookFromNWB(discLocation)
 
 	Wave/T nwb = AB_GetMap(discLocation)
 
+	AssertOnAndClearRTError()
 	try
 		h5_fileID = H5_OpenFile(nwb[%DiscLocation])
 	catch
+		ClearRTError()
 		printf "Could not open the NWB file %s.\r", nwb[%DiscLocation]
 		H5_CloseFile(h5_fileID)
 		return ""

--- a/Packages/MIES/MIES_AnalysisBrowser.ipf
+++ b/Packages/MIES/MIES_AnalysisBrowser.ipf
@@ -492,8 +492,8 @@ static Function AB_LoadDataWrapper(tmpDFR, expFilePath, datafolderPath, listOfNa
 	debugOnError = DisableDebugOnError()
 
 	// also with "/Q" LoadData still complains if the subfolder path does not exist
+	AssertOnAndClearRTError()
 	try
-		ClearRTError()
 		if(FileExists(expFileOrFolder))
 			LoadData/Q/R/L=(typeFlags)/S=dataFolderPath/J=listOfNames/O=1 expFileOrFolder; AbortOnRTE
 		elseif(FolderExists(expFileOrFolder))

--- a/Packages/MIES/MIES_AnalysisFunctionHelpers.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctionHelpers.ipf
@@ -831,8 +831,8 @@ Function/S AFH_CheckAnalysisParameter(genericFunc, params)
 			continue
 		endif
 
+		AssertOnAndClearRTError()
 		try
-			ClearRTError()
 			message = f(name, params); AbortOnRTE
 
 			if(!IsEmpty(message))

--- a/Packages/MIES/MIES_AnalysisFunctionManagement.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctionManagement.ipf
@@ -111,8 +111,8 @@ Function AFM_CallAnalysisFunctions(panelTitle, eventType)
 		ChangeWaveLock(scaledDataWave, 1)
 
 		ret = NaN
+		AssertOnAndClearRTError()
 		try
-			ClearRTError()
 			if(valid_f1)
 				ret = f1(panelTitle, eventType, DAQDataWave, i); AbortOnRTE
 			elseif(valid_f2)

--- a/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
@@ -1638,8 +1638,8 @@ Function PSQ_DAScale(panelTitle, s)
 					sprintf msg, "Spike frequency %.2W1PHz, DAScale %.2W1PA", spikeFrequencies[acquiredSweepsInSet - 1], DAScalesPlot[acquiredSweepsInSet - 1]
 					DEBUGPRINT(msg)
 
+					AssertOnAndClearRTError()
 					try
-						ClearRTError()
 						V_FitError  = 0
 						V_AbortCode = 0
 

--- a/Packages/MIES/MIES_Async.ipf
+++ b/Packages/MIES/MIES_Async.ipf
@@ -1024,6 +1024,7 @@ static Function ASYNC_IsASYNCRunning()
 #ifdef THREADING_DISABLED
 	return !IsNaN(tgID)
 #else
+	AssertOnAndClearRTError()
 	waitResult = ThreadGroupWait(tgID, 0); err = GetRTError(1)
 #endif
 

--- a/Packages/MIES/MIES_Async.ipf
+++ b/Packages/MIES/MIES_Async.ipf
@@ -149,8 +149,8 @@ threadsafe static Function/DF ASYNC_Run_Worker(DFREF dfr)
 
 	err = 0
 	dfrOut = $""
+	AssertOnAndClearRTError()
 	try
-		ClearRTError()
 		dfrOut = f(dfrInp);AbortOnRTE
 	catch
 		errmsg = GetRTErrMessage()
@@ -252,8 +252,8 @@ Function ASYNC_ThreadReadOut()
 		SVAR errmsg = dfr:$ASYNC_ERRORMSG_STR
 
 		statCnt += 1
+		AssertOnAndClearRTError()
 		try
-			ClearRTError()
 			f(dfrOut, err, errmsg);AbortOnRTE
 		catch
 			rterrmsg = GetRTErrMessage()
@@ -473,8 +473,8 @@ Function ASYNC_Stop([timeout, fromAssert])
 
 	endTime = dateTime + timeout
 	do
+		AssertOnAndClearRTError()
 		try
-			ClearRTError()
 			waitResult = ThreadGroupWait(tgID, 0); AbortOnRTE
 		catch
 			ClearRTError()

--- a/Packages/MIES/MIES_BrowserSettingsPanel.ipf
+++ b/Packages/MIES/MIES_BrowserSettingsPanel.ipf
@@ -951,7 +951,8 @@ Function BSP_ParseChannelSelectionControl(ctrl, channelType, channelNum)
 	if(!cmpstr(channelNumStr, "All"))
 		channelNum = NaN
 	else
-		channelNum = str2num(channelNumStr); AbortOnRTE
+		channelNum = str2numSafe(channelNumStr)
+		ASSERT(IsInteger(channelNum) && channelNum >= 0, "Unexpected channelNumStr")
 	endif
 End
 

--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -366,8 +366,8 @@ Function CONF_SaveWindow(fName)
 	variable i, jsonID, saveMask, saveResult
 	string out, wName, errMsg
 
+	AssertOnAndClearRTError()
 	try
-		ClearRTError()
 		wName = GetMainWindow(GetCurrentWindow())
 		if(!CmpStr(wName, "HistoryCarbonCopy"))
 			printf "Please select a window.\r"
@@ -421,8 +421,8 @@ Function CONF_RestoreWindow(fName[, usePanelTypeFromFile, rigFile])
 
 	jsonID = NaN
 	restoreMask = EXPCONFIG_SAVE_VALUE | EXPCONFIG_SAVE_USERDATA | EXPCONFIG_SAVE_DISABLED
+	AssertOnAndClearRTError()
 	try
-		ClearRTError()
 		if(usePanelTypeFromFile)
 			[input, fullFilePath] = LoadTextFile(fName, fileFilter = EXPCONFIG_FILEFILTER, message = "Open configuration file")
 			if(IsEmpty(input))
@@ -492,8 +492,8 @@ static Function CONF_SaveDAEphys(fName)
 	variable i, jsonID, saveMask, saveResult
 	string out, wName, errMsg
 
+	AssertOnAndClearRTError()
 	try
-		ClearRTError()
 		wName = GetMainWindow(GetCurrentWindow())
 		ASSERT(PanelIsType(wName, PANELTAG_DAEPHYS), "Current window is no DA_Ephys panel")
 
@@ -544,8 +544,8 @@ Function/S CONF_RestoreDAEphys(jsonID, fullFilePath, [middleOfExperiment, forceN
 	string AmpSerialLocal, AmpTitleLocal, device, StimSetPath, path, filename, rStateSync
 	string input = ""
 
+	AssertOnAndClearRTError()
 	try
-		ClearRTError()
 		middleOfExperiment = ParamIsDefault(middleOfExperiment) ? 0 : !!middleOfExperiment
 		forceNewPanel = ParamIsDefault(forceNewPanel) ? 0 : !!forceNewPanel
 
@@ -686,8 +686,10 @@ End
 static Function CONF_ParseJSON(str)
 	string str
 
+	variable err
+
+	AssertOnAndClearRTError()
 	try
-		ClearRTError()
 		JSONXOP_Parse/Z=0/Q=0 str; AbortOnRTE
 		return V_Value
 	catch
@@ -974,8 +976,8 @@ Function/S CONF_JSONToWindow(wName, restoreMask, jsonID)
 	variable arrayNameIndex
 	string ctrlName, niceName, arrayName, ctrlList, wList, uData, winHandle, jsonCtrlGroupPath, subWinTarget, str, errMsg
 
+	AssertOnAndClearRTError()
 	try
-		ClearRTError()
 		ASSERT(WinType(wName), "Window " + wName + " does not exist!")
 		ASSERT(restoreMask & (EXPCONFIG_SAVE_VALUE | EXPCONFIG_SAVE_POSITION | EXPCONFIG_SAVE_USERDATA | EXPCONFIG_SAVE_DISABLED | EXPCONFIG_SAVE_CTRLTYPE), "No property class enabled to restore in restoreMask.")
 
@@ -1375,6 +1377,7 @@ Function CONF_AllWindowsToJSON(wName, saveMask[, excCtrlTypes])
 	string wList, curWinName, errMsg
 	variable i, numWins, jsonID, jsonIDWin
 
+	AssertOnAndClearRTError()
 	try
 		excCtrlTypes = SelectString(ParamIsDefault(excCtrlTypes), excCtrlTypes, "")
 
@@ -1430,8 +1433,8 @@ Function CONF_WindowToJSON(wName, saveMask[, excCtrlTypes])
 	variable numCtrl, i, j, jsonID, numCoupled, setRadioPos, ctrlType, coupledCnt, numUniqueCtrlArray, numDupCheck
 	variable rbcIndex
 
+	AssertOnAndClearRTError()
 	try
-		ClearRTError()
 		excCtrlTypes = SelectString(ParamIsDefault(excCtrlTypes), excCtrlTypes, "")
 		ASSERT(WinType(wName), "Window " + wName + " does not exist!")
 		jsonID = JSON_New()
@@ -1728,8 +1731,8 @@ static Function CONF_ControlToJSON(wName, ctrlName, saveMask, jsonID, excCtrlTyp
 					continue
 				endif
 				uData = GetUserData(wName, ctrlName, uDataKey)
+				AssertOnAndClearRTError()
 				try
-					ClearRTError()
 					s = ConvertTextEncoding(uData, TextEncodingCode("UTF-8"), TextEncodingCode("UTF-8"), 1, 0); AbortOnRTE
 				catch
 					ClearRTError()

--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -1807,7 +1807,7 @@ static Function CONF_ControlToJSON(wName, ctrlName, saveMask, jsonID, excCtrlTyp
 
 	WAVE/T ctrlProps = JSON_GetKeys(jsonID, controlPath)
 	if(!DimSize(ctrlProps, ROWS))
-		JSONXOP_Remove/Q=1 jsonID, controlPath; AbortOnRTE
+		JSONXOP_Remove/Q=1/Z=1 jsonID, controlPath
 	endif
 End
 

--- a/Packages/MIES/MIES_DAC-Hardware.ipf
+++ b/Packages/MIES/MIES_DAC-Hardware.ipf
@@ -2008,8 +2008,8 @@ Function HW_NI_StartAcq(deviceID, triggerMode, [flags, repeat])
 	device = HW_GetDeviceName(HARDWARE_NI_DAC, deviceID)
 	SVAR scanStr = $GetNI_AISetup(panelTitle)
 	fifoName = GetNIFIFOName(deviceID)
+	AssertOnAndClearRTError()
 	try
-		ClearRTError()
 		if(!HasEnoughDiskspaceFree(SpecialDirPath("Temporary", 0, 0, 0), HW_NI_FIFO_MIN_FREE_DISK_SPACE))
 			printf "%s: Can not start acquisition. Not enough free disk space for data buffer.\rThe free disk space is less than %.0W0PB.\r", panelTitle, HW_NI_FIFO_MIN_FREE_DISK_SPACE
 			ControlWindowToFront()
@@ -2098,8 +2098,8 @@ Function HW_NI_PrepareAcq(deviceID, mode, [data, dataFunc, config, configFunc, f
 	TTLStr = ""
 	Make/FREE/WAVE/N=(channels) TTLWaves
 
+	AssertOnAndClearRTError()
 	try
-		ClearRTError()
 		NewFIFO $fifoName
 		aiCnt = 0
 		ttlCnt = 0
@@ -2695,8 +2695,8 @@ Function HW_NI_KillFifo(deviceID)
 		return NaN
 	endif
 
+	AssertOnAndClearRTError()
 	try
-		ClearRTError()
 		if(V_FIFORunning)
 			CtrlFIFO $fifoName stop; AbortOnRTE
 		endif

--- a/Packages/MIES/MIES_DAC-Hardware.ipf
+++ b/Packages/MIES/MIES_DAC-Hardware.ipf
@@ -2332,7 +2332,7 @@ Function HW_NI_ReadDigital(device, [DIOPort, DIOLine, flags])
 		sprintf line "/%s/port%d/line%d", device, DIOPort, DIOline
 	endif
 
-	ClearRTError()
+	AssertOnAndClearRTError()
 	DAQmx_DIO_Config/DEV=device/DIR=1/LGRP=(lineGrouping) line
 
 	if(ClearRTError())
@@ -2392,7 +2392,7 @@ Function HW_NI_WriteDigital(device, value, [DIOPort, DIOLine, flags])
 		sprintf line "/%s/port%d/line%d", device, DIOPort, DIOline
 	endif
 
-	ClearRTError()
+	AssertOnAndClearRTError()
 	DAQmx_DIO_Config/DEV=device/DIR=1/LGRP=(lineGrouping) line
 
 	if(ClearRTError())
@@ -2649,7 +2649,7 @@ Function HW_NI_ZeroDAC(deviceID, [flags])
 	DEBUGPRINTSTACKINFO()
 
 	string device, panelTitle, paraStr
-	variable channels, i, err
+	variable channels, i
 
 	device = HW_GetDeviceName(HARDWARE_NI_DAC, deviceID)
 	panelTitle = HW_GetMainDeviceName(HARDWARE_NI_DAC, deviceID)
@@ -2663,7 +2663,7 @@ Function HW_NI_ZeroDAC(deviceID, [flags])
 		endif
 	endfor
 
-	ClearRTError()
+	AssertOnAndClearRTError()
 	DAQmx_AO_SetOutputs/DEV=device paraStr
 
 	if(ClearRTError())

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -970,6 +970,7 @@ Function DAP_DAorTTLCheckProc(cba) : CheckBoxControl
 
 	switch(cba.eventCode)
 		case 2:
+			AssertOnAndClearRTError()
 			try
 				paneltitle = cba.win
 				control    = cba.ctrlName
@@ -977,6 +978,7 @@ Function DAP_DAorTTLCheckProc(cba) : CheckBoxControl
 				DAP_AdaptAssocHeadstageState(panelTitle, control)
 				DAP_UpdateDAQControls(panelTitle, REASON_STIMSET_CHANGE | REASON_HEADSTAGE_CHANGE)
 			catch
+				ClearRTError()
 				SetCheckBoxState(panelTitle, control, !cba.checked)
 				DAG_Update(cba.win, cba.ctrlName, val = !cba.checked)
 				Abort
@@ -1076,6 +1078,7 @@ Function DAP_CheckProc_AD(cba) : CheckBoxControl
 
 	switch(cba.eventCode)
 		case 2: // mouse up
+			AssertOnAndClearRTError()
 			try
 				paneltitle = cba.win
 				control    = cba.ctrlName
@@ -1083,6 +1086,7 @@ Function DAP_CheckProc_AD(cba) : CheckBoxControl
 				DAG_Update(cba.win, cba.ctrlName, val = cba.checked)
 				DAP_AdaptAssocHeadstageState(panelTitle, control)
 			catch
+				ClearRTError()
 				SetCheckBoxState(panelTitle, control, !cba.checked)
 				DAG_Update(cba.win, cba.ctrlName, val = !cba.checked)
 				Abort
@@ -3289,6 +3293,7 @@ Function DAP_CheckProc_ClampMode(cba) : CheckBoxControl
 
 	switch(cba.eventCode)
 		case 2: // mouse up
+			AssertOnAndClearRTError()
 			try
 				panelTitle = cba.win
 				control    = cba.ctrlName
@@ -3303,6 +3308,7 @@ Function DAP_CheckProc_ClampMode(cba) : CheckBoxControl
 					DAP_SetAmpModeControls(panelTitle, headstage, mode, delayed = 1)
 				endif
 			catch
+				ClearRTError()
 				SetCheckBoxState(panelTitle, control, !cba.checked)
 				Abort
 			endtry
@@ -3320,12 +3326,14 @@ Function DAP_CheckProc_HedstgeChck(cba) : CheckBoxControl
 
 	switch(cba.eventCode)
 		case 2: // mouse up
+			AssertOnAndClearRTError()
 			try
 				panelTitle = cba.win
 				control    = cba.ctrlName
 				checked    = cba.checked
 				DAP_ChangeHeadstageState(panelTitle, control, checked)
 			catch
+				ClearRTError()
 				SetCheckBoxState(panelTitle, control, !checked)
 				Abort
 			endtry

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -758,6 +758,7 @@ Function DAP_WindowHook(s)
 				DAP_UnlockDevice(panelTitle); AbortOnRTE
 			catch
 				// do nothing
+				ClearRTError()
 			endtry
 
 			// return zero so that other hooks are called as well

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -755,9 +755,10 @@ Function DAP_WindowHook(s)
 
 			AssertOnAndClearRTError()
 			try
+				// catch all error conditions, asserts and aborts
+				// and silently ignore them
 				DAP_UnlockDevice(panelTitle); AbortOnRTE
 			catch
-				// do nothing
 				ClearRTError()
 			endtry
 

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -753,8 +753,8 @@ Function DAP_WindowHook(s)
 			NVAR JSONid = $GetSettingsJSONid()
 			PS_StoreWindowCoordinate(JSONid, panelTitle)
 
+			AssertOnAndClearRTError()
 			try
-				ClearRTError()
 				DAP_UnlockDevice(panelTitle); AbortOnRTE
 			catch
 				// do nothing

--- a/Packages/MIES/MIES_DataAcquisition.ipf
+++ b/Packages/MIES/MIES_DataAcquisition.ipf
@@ -21,7 +21,8 @@ Function DQ_StopOngoingDAQAllLocked(variable stopReason)
 	for(i = 0; i < numDev; i += 1)
 		device = StringFromList(i, devices)
 
-		DQ_StopOngoingDAQ(device, stopReason, startTPAfterDAQ = 0); err = GetRTError(1)
+		AssertOnAndClearRTError()
+		DQ_StopOngoingDAQ(device, stopReason, startTPAfterDAQ = 0); err = GetRTError(1) // see developer docu section Preventing Debugger Popup
 	endfor
 End
 

--- a/Packages/MIES/MIES_DataAcquisition_Multi.ipf
+++ b/Packages/MIES/MIES_DataAcquisition_Multi.ipf
@@ -170,6 +170,7 @@ Function DQM_StartDAQMultiDevice(panelTitle, [initialSetupReq])
 		initialSetupReq = !!initialSetupReq
 	endif
 
+	// catches Abort and AbortOnRTE
 	AssertOnAndClearRTError()
 	try
 		if(initialSetupReq)

--- a/Packages/MIES/MIES_DataAcquisition_Multi.ipf
+++ b/Packages/MIES/MIES_DataAcquisition_Multi.ipf
@@ -34,8 +34,8 @@ Function DQM_FIFOMonitor(s)
 		switch(hardwareType)
 			case HARDWARE_NI_DAC:
 
+				AssertOnAndClearRTError()
 				try
-					ClearRTError()
 					NVAR fifoPosGlobal = $GetFifoPosition(panelTitle)
 					fifoName = GetNIFIFOName(deviceID)
 					FIFOStatus/Q $fifoName

--- a/Packages/MIES/MIES_DataAcquisition_Multi.ipf
+++ b/Packages/MIES/MIES_DataAcquisition_Multi.ipf
@@ -170,6 +170,7 @@ Function DQM_StartDAQMultiDevice(panelTitle, [initialSetupReq])
 		initialSetupReq = !!initialSetupReq
 	endif
 
+	AssertOnAndClearRTError()
 	try
 		if(initialSetupReq)
 			DAP_OneTimeCallBeforeDAQ(panelTitle, DAQ_BG_MULTI_DEVICE)
@@ -178,6 +179,7 @@ Function DQM_StartDAQMultiDevice(panelTitle, [initialSetupReq])
 		DC_Configure(panelTitle, DATA_ACQUISITION_MODE)
 		NVAR maxITI = $GetMaxIntertrialInterval(panelTitle)
 	catch
+		ClearRTError()
 		if(initialSetupReq)
 			DAP_OneTimeCallAfterDAQ(panelTitle, DQ_STOP_REASON_CONFIG_FAILED, forcedStop = 1)
 		else // required for RA for the lead device only
@@ -202,6 +204,7 @@ Function DQM_StartDAQMultiDevice(panelTitle, [initialSetupReq])
 	SVAR listOfFollowerDevices = $GetFollowerList(panelTitle)
 	numFollower = ItemsInList(listOfFollowerDevices)
 
+	AssertOnAndClearRTError()
 	try
 		for(i = 0; i < numFollower; i += 1)
 			followerPanelTitle = StringFromList(i, listOfFollowerDevices)
@@ -216,6 +219,7 @@ Function DQM_StartDAQMultiDevice(panelTitle, [initialSetupReq])
 			acrossYokingMaxITI = max(maxITI, acrossYokingMaxITI)
 		endfor
 	catch
+		ClearRTError()
 		if(initialSetupReq)
 			for(i = 0; i < numFollower; i += 1)
 				followerPanelTitle = StringFromList(i, listOfFollowerDevices)

--- a/Packages/MIES/MIES_DataAcquisition_Single.ipf
+++ b/Packages/MIES/MIES_DataAcquisition_Single.ipf
@@ -31,9 +31,11 @@ Function DQS_StartDAQSingleDevice(panelTitle, [useBackground])
 
 	DAP_OneTimeCallBeforeDAQ(panelTitle, useBackground == 1 ? DAQ_BG_SINGLE_DEVICE : DAQ_FG_SINGLE_DEVICE)
 
+	AssertOnAndClearRTError()
 	try
 		DC_Configure(panelTitle, DATA_ACQUISITION_MODE)
 	catch
+		ClearRTError()
 		// we need to undo the earlier one time call only
 		DAP_OneTimeCallAfterDAQ(panelTitle, DQ_STOP_REASON_CONFIG_FAILED, forcedStop = 1)
 		return NaN

--- a/Packages/MIES/MIES_DataBrowser.ipf
+++ b/Packages/MIES/MIES_DataBrowser.ipf
@@ -734,6 +734,8 @@ Function DB_WindowHook(s)
 
 			AssertOnAndClearRTError()
 			try
+				// catch all error conditions, asserts and aborts
+				// and silently ignore them
 				DFREF dfr = BSP_GetFolder(win, MIES_BSP_PANEL_FOLDER); AbortOnRTE
 
 				KillOrMoveToTrash(dfr = dfr); AbortOnRTE

--- a/Packages/MIES/MIES_DataBrowser.ipf
+++ b/Packages/MIES/MIES_DataBrowser.ipf
@@ -732,6 +732,7 @@ Function DB_WindowHook(s)
 				break
 			endif
 
+			AssertOnAndClearRTError()
 			try
 				DFREF dfr = BSP_GetFolder(win, MIES_BSP_PANEL_FOLDER); AbortOnRTE
 

--- a/Packages/MIES/MIES_DataConfigurator.ipf
+++ b/Packages/MIES/MIES_DataConfigurator.ipf
@@ -796,7 +796,7 @@ static Function DC_PlaceDataInDAQDataWave(panelTitle, numActiveChannels, dataAcq
 	NVAR stopCollectionPoint = $GetStopCollectionPoint(panelTitle)
 	stopCollectionPoint = DC_GetStopCollectionPoint(panelTitle, s.dataAcqOrTP, s.setLength)
 
-	ClearRTError()
+	AssertOnAndClearRTError()
 
 	if(dataAcqOrTP == TEST_PULSE_MODE)
 		DC_FillDAQDataWaveForTP(panelTitle, s)

--- a/Packages/MIES/MIES_ExperimentDocumentation.ipf
+++ b/Packages/MIES/MIES_ExperimentDocumentation.ipf
@@ -312,7 +312,8 @@ static Function ED_WriteChangedValuesToNote(panelTitle, sweepNo)
 			endif
 
 			if (!cmpstr(factor, LABNOTEBOOK_NO_TOLERANCE))
-				sprintf text, "%s%s: %s\r" frontLabel, key, SelectString(currentSetting[i], "Off", "On"); err = GetRTError(1)
+				AssertOnAndClearRTError()
+				sprintf text, "%s%s: %s\r" frontLabel, key, SelectString(currentSetting[i], "Off", "On"); err = GetRTError(1) // see developer docu section Preventing Debugger Popup
 			else
 				sprintf text, "%s%s: %.2f %s\r" frontLabel, key, currentSetting[i], unit
 			endif

--- a/Packages/MIES/MIES_ExperimentDocumentation.ipf
+++ b/Packages/MIES/MIES_ExperimentDocumentation.ipf
@@ -312,8 +312,7 @@ static Function ED_WriteChangedValuesToNote(panelTitle, sweepNo)
 			endif
 
 			if (!cmpstr(factor, LABNOTEBOOK_NO_TOLERANCE))
-				AssertOnAndClearRTError()
-				sprintf text, "%s%s: %s\r" frontLabel, key, SelectString(currentSetting[i], "Off", "On"); err = GetRTError(1) // see developer docu section Preventing Debugger Popup
+				sprintf text, "%s%s: %s\r" frontLabel, key, SelectString(currentSetting[i], "Off", "On")
 			else
 				sprintf text, "%s%s: %.2f %s\r" frontLabel, key, currentSetting[i], unit
 			endif

--- a/Packages/MIES/MIES_IVSCC.ipf
+++ b/Packages/MIES/MIES_IVSCC.ipf
@@ -442,6 +442,7 @@ Function IVS_finishGigOhmSealQCCheck(s)
 
 	// See if we pass the Steady State Resistance
 	// added a second pass....if we don't pass the QC on the first go, check again before you fail out of the QC
+	AssertOnAndClearRTError()
 	try
 		if(ssResistanceVal > 1000) // ssResistance value is in MOhms
 			// and now run the EXTPCIIATT wave so that things are saved into the data record
@@ -454,6 +455,7 @@ Function IVS_finishGigOhmSealQCCheck(s)
 			Abort
 		endif
 	catch
+		ClearRTError()
 		ssResistanceVal = SSResistance[headstage]
 
 		printf "Second Pass: Steady State Resistance: %g\r", ssResistanceVal

--- a/Packages/MIES/MIES_IVSCC.ipf
+++ b/Packages/MIES/MIES_IVSCC.ipf
@@ -490,8 +490,15 @@ End
 Function IVS_SaveExperiment(filename)
 	string filename
 
+	variable err
+
 	AssertOnAndClearRTError()
-	SaveExperiment/C/F={1,"",2}/P=home as filename + ".pxp"; AbortOnRTE
+	try
+		SaveExperiment/C/F={1,"",2}/P=home as filename + ".pxp"; AbortOnRTE
+	catch
+		err = ClearRTError()
+		ASSERT(0, "Could not save experiment due to code: " + num2istr(err))
+	endtry
 End
 
 /// @brief Run a designated stim wave

--- a/Packages/MIES/MIES_IVSCC.ipf
+++ b/Packages/MIES/MIES_IVSCC.ipf
@@ -400,8 +400,8 @@ static Function IVS_PublishQCState(variable result, string description)
 	payload = JSON_Dump(jsonID)
 	JSON_Release(jsonID)
 
+	AssertOnAndClearRTError()
 	try
-		ClearRTError()
 #if exists("zeromq_pub_send")
 		zeromq_pub_send(IVS_PUB_FILTER, payload); AbortOnRTE
 #else

--- a/Packages/MIES/MIES_IVSCC.ipf
+++ b/Packages/MIES/MIES_IVSCC.ipf
@@ -488,7 +488,7 @@ End
 Function IVS_SaveExperiment(filename)
 	string filename
 
-	ClearRTError()
+	AssertOnAndClearRTError()
 	SaveExperiment/C/F={1,"",2}/P=home as filename + ".pxp"; AbortOnRTE
 End
 

--- a/Packages/MIES/MIES_IgorHooks.ipf
+++ b/Packages/MIES/MIES_IgorHooks.ipf
@@ -161,8 +161,8 @@ static Function IH_Cleanup()
 
 	debuggerState = DisableDebugger()
 
+	AssertOnAndClearRTError()
 	try
-		ClearRTError()
 		DAP_UnlockAllDevices(); AbortOnRTE
 		IH_RemoveAmplifierConnWaves(); AbortOnRTE
 		IH_KillTemporaries(); AbortOnRTE

--- a/Packages/MIES/MIES_IgorHooks.ipf
+++ b/Packages/MIES/MIES_IgorHooks.ipf
@@ -161,6 +161,8 @@ static Function IH_Cleanup()
 
 	debuggerState = DisableDebugger()
 
+	// catch all error conditions, asserts and aborts
+	// and silently ignore them
 	AssertOnAndClearRTError()
 	try
 		DAP_UnlockAllDevices(); AbortOnRTE

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -5106,7 +5106,7 @@ Function RemoveTracesFromGraph(graph, [trace, wv, dfr])
 	WAVE/Z wv
 	DFREF dfr
 
-	variable i, numEntries, numOptArgs, remove_all_traces, debugOnError
+	variable i, numEntries, numOptArgs, remove_all_traces, err
 	string traceList, refTrace
 
 	numOptArgs = ParamIsDefault(trace) + ParamIsDefault(wv) + ParamIsDefault(dfr)
@@ -5126,20 +5126,13 @@ Function RemoveTracesFromGraph(graph, [trace, wv, dfr])
 	if(remove_all_traces)
 #if IgorVersion() >= 9.0
 		RemoveFromGraph/ALL/W=$graph
-		return NaN
 #else
-		debugOnError = DisableDebugOnError()
+		AssertOnAndClearRTError()
 		do
-			AssertOnAndClearRTError()
-			try
-				RemoveFromGraph/W=$graph $("#0"); AbortOnRTE
-			catch
-				ClearRTError()
-				ResetDebugOnError(debugOnError)
-				return NaN
-			endtry
-		while(1)
+			RemoveFromGraph/W=$graph $("#0"); err = GetRTError(1)
+		while(err == 0)
 #endif
+		return NaN
 	endif
 
 	traceList  = TraceNameList(graph, ";", 1 )

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -5130,8 +5130,8 @@ Function RemoveTracesFromGraph(graph, [trace, wv, dfr])
 #else
 		debugOnError = DisableDebugOnError()
 		do
+			AssertOnAndClearRTError()
 			try
-				ClearRTError()
 				RemoveFromGraph/W=$graph $("#0"); AbortOnRTE
 			catch
 				ClearRTError()
@@ -6619,8 +6619,8 @@ Function UploadCrashDumpsDaily()
 
 	variable lastWrite
 
+	AssertOnAndClearRTError()
 	try
-		ClearRTError()
 		NVAR JSONid = $GetSettingsJSONid()
 
 		lastWrite = ParseISO8601TimeStamp(JSON_GetString(jsonID, "/diagnostics/last upload"))

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -4292,7 +4292,8 @@ Function EqualizeVerticalAxesRanges(graph, [ignoreAxesWithLevelCrossing, level, 
 		ASSERT(ignoreAxesWithLevelCrossing, "Optional argument level makes only sense if ignoreAxesWithLevelCrossing is enabled")
 	endif
 
-	GetAxis/W=$graph/Q bottom; err = GetRTError(1)
+	AssertOnAndClearRTError()
+	GetAxis/W=$graph/Q bottom; err = GetRTError(1) // see developer docu section Preventing Debugger Popup
 	if(!V_Flag)
 		xRangeBegin = V_min
 		xRangeEnd   = V_max
@@ -5500,7 +5501,8 @@ Function StartZeroMQSockets([variable forceRestart])
 
 	if(!forceRestart)
 		// do nothing if we are already running
-		zeromq_handler_start(); err = GetRTError(1)
+		AssertOnAndClearRTError()
+		zeromq_handler_start(); err = GetRTError(1) // see developer docu section Preventing Debugger Popup
 		if(ConvertXOPErrorCode(err) == ZeroMQ_HANDLER_ALREADY_RUNNING)
 			DEBUGPRINT("Already running, nothing to do.")
 			return NaN
@@ -5517,7 +5519,8 @@ Function StartZeroMQSockets([variable forceRestart])
 
 	for(i = 0; i < ZEROMQ_NUM_BIND_TRIALS; i += 1)
 		port = ZEROMQ_BIND_REP_PORT + i
-		zeromq_server_bind("tcp://127.0.0.1:" + num2str(port)); err = GetRTError(1)
+		AssertOnAndClearRTError()
+		zeromq_server_bind("tcp://127.0.0.1:" + num2str(port)); err = GetRTError(1) // see developer docu section Preventing Debugger Popup
 
 		if(!err)
 			DEBUGPRINT("Successfully listening with server on port:", var=port)
@@ -5528,7 +5531,8 @@ Function StartZeroMQSockets([variable forceRestart])
 
 	for(i = 0; i < ZEROMQ_NUM_BIND_TRIALS; i += 1)
 		port = ZEROMQ_BIND_PUB_PORT + i
-		zeromq_pub_bind("tcp://127.0.0.1:" + num2str(port)); err = GetRTError(1)
+		AssertOnAndClearRTError()
+		zeromq_pub_bind("tcp://127.0.0.1:" + num2str(port)); err = GetRTError(1) // see developer docu section Preventing Debugger Popup
 
 		if(!err)
 			DEBUGPRINT("Successfully listening with publisher on port:", var=port)

--- a/Packages/MIES/MIES_PackageSettings.ipf
+++ b/Packages/MIES/MIES_PackageSettings.ipf
@@ -125,8 +125,8 @@ static Function PS_ApplyStoredWindowCoordinate(variable JSONid, string win)
 		return NaN
 	endif
 
+	AssertOnAndClearRTError()
 	try
-		ClearRTError()
 		left = JSON_GetVariable(JSONid, path + "/left")
 		top = JSON_GetVariable(JSONid, path + "/top")
 		right = JSON_GetVariable(JSONid, path + "/right")
@@ -167,8 +167,8 @@ static Function PS_StoreWindowCoordinates(variable JSONid)
 			continue
 		endif
 
+		AssertOnAndClearRTError()
 		try
-			ClearRTError()
 			PS_StoreWindowCoordinate(JSONid, win); AbortOnRTE
 		catch
 			ClearRTError()
@@ -237,8 +237,8 @@ End
 /// Caller *must* invalidate JSONid after return.
 Function PS_SerializeSettings(string package, variable JSONid)
 
+	AssertOnAndClearRTError()
 	try
-		ClearRTError()
 		PS_StoreWindowCoordinates(JSONid); AbortOnRTE
 		PS_WriteSettings(package, JSONid); AbortOnRTE
 	catch

--- a/Packages/MIES/MIES_PackageSettings.ipf
+++ b/Packages/MIES/MIES_PackageSettings.ipf
@@ -125,15 +125,14 @@ static Function PS_ApplyStoredWindowCoordinate(variable JSONid, string win)
 		return NaN
 	endif
 
+	left = JSON_GetVariable(JSONid, path + "/left", ignoreErr = 1)
+	top = JSON_GetVariable(JSONid, path + "/top", ignoreErr = 1)
+	right = JSON_GetVariable(JSONid, path + "/right", ignoreErr = 1)
+	bottom = JSON_GetVariable(JSONid, path + "/bottom", ignoreErr = 1)
+
 	AssertOnAndClearRTError()
 	try
-		left = JSON_GetVariable(JSONid, path + "/left")
-		top = JSON_GetVariable(JSONid, path + "/top")
-		right = JSON_GetVariable(JSONid, path + "/right")
-		bottom = JSON_GetVariable(JSONid, path + "/bottom")
-
-		MoveWindow/W=$win left, top, right, bottom
-		AbortONRTE
+		MoveWindow/W=$win left, top, right, bottom; AbortOnRTE
 	catch
 		err = ClearRTError()
 		printf "Applying window coordinates for %s failed with %d\r", win, err

--- a/Packages/MIES/MIES_PressureControl.ipf
+++ b/Packages/MIES/MIES_PressureControl.ipf
@@ -229,8 +229,8 @@ static Function P_PublishPressureMethodChange(string panelTitle, variable headst
 	payload = JSON_Dump(jsonID)
 	JSON_Release(jsonID)
 
+	AssertOnAndClearRTError()
 	try
-		ClearRTError()
 #if exists("zeromq_pub_send")
 		zeromq_pub_send(PRESSURE_STATE_FILTER, payload); AbortOnRTE
 #else
@@ -252,8 +252,8 @@ static Function P_PublishSealedState(string panelTitle, variable headstage)
 	payload = JSON_Dump(jsonID)
 	JSON_Release(jsonID)
 
+	AssertOnAndClearRTError()
 	try
-		ClearRTError()
 #if exists("zeromq_pub_send")
 		zeromq_pub_send(PRESSURE_SEALED_FILTER, payload); AbortOnRTE
 #else

--- a/Packages/MIES/MIES_PulseAveraging.ipf
+++ b/Packages/MIES/MIES_PulseAveraging.ipf
@@ -2503,7 +2503,8 @@ threadsafe Function/WAVE PA_SpikePositionsForNonVC(WAVE wv, variable failedPulse
 			continue
 		endif
 
-		FindPeak/B=(PA_PEAK_BOX_AVERAGE)/M=(failedPulsesLevel)/R=(first, last) wv; err = GetRTError(1)
+		AssertOnAndClearRTError()
+		FindPeak/B=(PA_PEAK_BOX_AVERAGE)/M=(failedPulsesLevel)/R=(first, last) wv; err = GetRTError(1) // see developer docu section Preventing Debugger Popup
 
 		if(!err)
 			ASSERT_TS(!V_Flag, "Could not find peak but FindLevelWrapper was successfull, this is unexpected.")
@@ -3460,7 +3461,8 @@ static Function/S PA_ShowImage(string win, STRUCT PulseAverageSettings &pa, STRU
 				WAVE/WAVE set2 = PA_GetSetWaves(pasi.pulseAverageHelperDFR, channelNumber, region)
 				colStart = firstPulseIndex
 				colEnd = numPulses
-				Multithread img[][colStart, colEnd - 1] = WaveRef(set2[q][0])(x); err = GetRTError(1)
+				AssertOnAndClearRTError()
+				Multithread img[][colStart, colEnd - 1] = WaveRef(set2[q][0])(x); err = GetRTError(1) // see developer docu section Preventing Debugger Popup
 				for(k = colStart; k < colEnd; k += 1)
 					pulseScaleLeft = scaleLeft[k]
 					if(refScaleLeft != pulseScaleLeft && pulseScaleLeft > refScaleLeft + refScaleDelta)
@@ -3490,7 +3492,8 @@ static Function/S PA_ShowImage(string win, STRUCT PulseAverageSettings &pa, STRU
 				// when all pulses from the set fail, we don't have an average wave
 				colStart = numPulses
 				colEnd = numPulses + specialEntryHeight
-				Multithread img[][colStart, colEnd - 1] = averageWave(x); err = GetRTError(1)
+				AssertOnAndClearRTError()
+				Multithread img[][colStart, colEnd - 1] = averageWave(x); err = GetRTError(1) // see developer docu section Preventing Debugger Popup
 				val = leftx(averageWave)
 				if(refScaleLeft != val  && val > refScaleLeft + refScaleDelta)
 					img[0, ScaleToIndexWrapper(img, val, ROWS)][colStart, colEnd - 1] = NaN
@@ -3509,7 +3512,8 @@ static Function/S PA_ShowImage(string win, STRUCT PulseAverageSettings &pa, STRU
 				WAVE deconv = PA_Deconvolution(averageWave, pasi.pulseAverageDFR, PA_DECONVOLUTION_WAVE_PREFIX + baseName, pa.deconvolution)
 				colStart = numPulses + specialEntryHeight
 				colEnd = numPulses + 2 * specialEntryHeight
-				Multithread img[][colStart, colEnd - 1] = limit(deconv(x), vert_min, vert_max); err = GetRTError(1)
+				AssertOnAndClearRTError()
+				Multithread img[][colStart, colEnd - 1] = limit(deconv(x), vert_min, vert_max); err = GetRTError(1) // see developer docu section Preventing Debugger Popup
 				val = leftx(deconv)
 				if(refScaleLeft != val && val > refScaleLeft + refScaleDelta)
 					img[0, ScaleToIndexWrapper(img, val, ROWS)][colStart, colEnd - 1] = NaN

--- a/Packages/MIES/MIES_RepeatedAcquisition.ipf
+++ b/Packages/MIES/MIES_RepeatedAcquisition.ipf
@@ -234,6 +234,7 @@ Function RA_Counter(panelTitle)
 	numTotalSweeps = RA_GetTotalNumberOfSweeps(panelTitle)
 
 	if(Count < numTotalSweeps)
+		AssertOnAndClearRTError()
 		try
 			DC_Configure(panelTitle, DATA_ACQUISITION_MODE)
 
@@ -243,6 +244,7 @@ Function RA_Counter(panelTitle)
 				DQS_DataAcq(panelTitle)
 			endif
 		catch
+			ClearRTError()
 			RA_FinishAcquisition(panelTitle)
 		endtry
 	else

--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -1188,6 +1188,7 @@ Function SF_button_sweepFormula_check(ba) : ButtonControl
 				return 0
 			endif
 
+			AssertOnAndClearRTError()
 			try
 				jsonIDy = SF_FormulaParser(SF_FormulaPreParser(yFormula))
 				if(numFormulae == 1)
@@ -1204,6 +1205,7 @@ Function SF_button_sweepFormula_check(ba) : ButtonControl
 				JSON_AddJSON(jsonID, "/x", jsonIDx)
 				JSON_Release(jsonIDx)
 			catch
+				ClearRTError()
 				SetValDisplay(bsPanel, "status_sweepFormula_parser", var=0)
 				JSON_Release(jsonID, ignoreErr = 1)
 				SVAR result = $GetSweepFormulaParseErrorMessage()

--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -1253,8 +1253,8 @@ Function SF_button_sweepFormula_display(ba) : ButtonControl
 			SetSetVariableString(bsPanel, "setvar_sweepFormula_parseResult", "", setHelp = 1)
 			SetValDisplay(bsPanel, "status_sweepFormula_parser", var=1)
 
+			AssertOnAndClearRTError()
 			try
-				ClearRTError()
 				SF_FormulaPlotter(mainPanel, code, dfr = dfr); AbortONRTE
 			catch
 				ClearRTError()

--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -1257,7 +1257,7 @@ Function SF_button_sweepFormula_display(ba) : ButtonControl
 
 			AssertOnAndClearRTError()
 			try
-				SF_FormulaPlotter(mainPanel, code, dfr = dfr); AbortONRTE
+				SF_FormulaPlotter(mainPanel, code, dfr = dfr); AbortOnRTE
 			catch
 				ClearRTError()
 				SVAR result = $GetSweepFormulaParseErrorMessage()

--- a/Packages/MIES/MIES_SweepSaving.ipf
+++ b/Packages/MIES/MIES_SweepSaving.ipf
@@ -89,6 +89,8 @@ static Function SWS_AfterSweepDataChangeHook(panelTitle)
 		return NaN
 	endif
 
+	// catch all error conditions, asserts and aborts
+	// and silently ignore them
 	AssertOnAndClearRTError()
 	try
 		DB_UpdateToLastSweep(databrowser); AbortOnRTE

--- a/Packages/MIES/MIES_SweepSaving.ipf
+++ b/Packages/MIES/MIES_SweepSaving.ipf
@@ -89,8 +89,8 @@ static Function SWS_AfterSweepDataChangeHook(panelTitle)
 		return NaN
 	endif
 
+	AssertOnAndClearRTError()
 	try
-		ClearRTError()
 		DB_UpdateToLastSweep(databrowser); AbortOnRTE
 	catch
 		ClearRTError()

--- a/Packages/MIES/MIES_TestPulse.ipf
+++ b/Packages/MIES/MIES_TestPulse.ipf
@@ -507,8 +507,8 @@ threadsafe static Function CurveFitWrapper(TPStorage, startRow, endRow, headstag
 	Make/FREE/D/N=2 coefWave
 	V_FitOptions = 4
 
+	AssertOnAndClearRTError()
 	try
-		ClearRTError()
 		V_FitError  = 0
 		V_AbortCode = 0
 		CurveFit/Q/N=1/NTHR=1/M=0/W=2 line, kwCWave=coefWave, TPStorage[startRow,endRow][headstage][%SteadyStateResistance]/X=TPStorage[startRow,endRow][headstage][%TimeInSeconds]/AD=0/AR=0; AbortOnRTE

--- a/Packages/MIES/MIES_TestPulse.ipf
+++ b/Packages/MIES/MIES_TestPulse.ipf
@@ -552,7 +552,7 @@ static Function TP_AnalyzeTP(panelTitle, TPStorage, endRow)
 		statusHS[i] = 1
 	endfor
 
-	Multithread TPStorage[0][][%Rss_Slope] = statusHS[q] ? CurveFitWrapper(TPStorage, startRow, endRow, q) : NaN; AbortOnRTE
+	Multithread TPStorage[0][][%Rss_Slope] = statusHS[q] ? CurveFitWrapper(TPStorage, startRow, endRow, q) : NaN
 End
 
 /// @brief Stop running background testpulse on all locked devices

--- a/Packages/MIES/MIES_TestPulse_Multi.ipf
+++ b/Packages/MIES/MIES_TestPulse_Multi.ipf
@@ -43,10 +43,12 @@ Function TPM_StartTPMultiDeviceLow(panelTitle, [runModifier, fast])
 	endif
 
 	if(!DeviceHasFollower(panelTitle))
+		AssertOnAndClearRTError()
 		try
 			TP_Setup(panelTitle, runMode, fast = fast)
 			TPM_BkrdTPMD(panelTitle)
 		catch
+			ClearRTError()
 			TP_Teardown(panelTitle)
 		endtry
 
@@ -58,6 +60,7 @@ Function TPM_StartTPMultiDeviceLow(panelTitle, [runModifier, fast])
 	SVAR listOfFollowerDevices = $GetFollowerList(panelTitle)
 	numFollower = ItemsInList(listOfFollowerDevices)
 
+	AssertOnAndClearRTError()
 	try
 		// configure all followers
 		for(i = 0; i < numFollower; i += 1)
@@ -67,6 +70,7 @@ Function TPM_StartTPMultiDeviceLow(panelTitle, [runModifier, fast])
 
 		TP_Setup(panelTitle, runMode)
 	catch
+		ClearRTError()
 		// deconfigure all followers
 		for(i = 0; i < numFollower; i += 1)
 			followerPanelTitle = StringFromList(i, listOfFollowerDevices)

--- a/Packages/MIES/MIES_TestPulse_Multi.ipf
+++ b/Packages/MIES/MIES_TestPulse_Multi.ipf
@@ -220,8 +220,8 @@ Function TPM_BkrdTPFuncMD(s)
 					if(V_FIFOChunks >= endOfPulse)
 						WAVE/WAVE NIDataWave = GetDAQDataWave(panelTitle, TEST_PULSE_MODE)
 
+						AssertOnAndClearRTError()
 						try
-							ClearRTError()
 							for(j = 0; j < V_FIFOnchans; j += 1)
 								fifoChannelName = StringByKey("NAME" + num2str(j), S_Info)
 								channelNr = str2num(fifoChannelName)

--- a/Packages/MIES/MIES_TestPulse_Single.ipf
+++ b/Packages/MIES/MIES_TestPulse_Single.ipf
@@ -111,6 +111,7 @@ Function TPS_StartTestPulseSingleDevice(panelTitle, [fast])
 		return NaN
 	endif
 
+	AssertOnAndClearRTError()
 	try
 		if(bkg)
 			TP_Setup(panelTitle, TEST_PULSE_BG_SINGLE_DEVICE)
@@ -124,6 +125,7 @@ Function TPS_StartTestPulseSingleDevice(panelTitle, [fast])
 			TP_Teardown(panelTitle)
 		endif
 	catch
+		ClearRTError()
 		TP_Teardown(panelTitle)
 		return NaN
 	endtry

--- a/Packages/MIES/MIES_ThreadsafeUtilities.ipf
+++ b/Packages/MIES/MIES_ThreadsafeUtilities.ipf
@@ -28,8 +28,8 @@ Function TS_GetNewestFromThreadQueue(tgID, varName)
 	endif
 
 	for(;;)
+		AssertOnAndClearRTError()
 		try
-			ClearRTError()
 			DFREF dfr = ThreadGroupGetDFR(tgID, TS_GET_REPEAT_TIMEOUT_IN_MS); AbortOnRTE
 		catch
 			ClearRTError()
@@ -87,8 +87,8 @@ Function/WAVE TS_GetNewestFromThreadQueueMult(tgID, varNames)
 	endfor
 
 	for(;;)
+		AssertOnAndClearRTError()
 		try
-			ClearRTError()
 			DFREF dfr = ThreadGroupGetDFR(tgID, TS_GET_REPEAT_TIMEOUT_IN_MS); AbortOnRTE
 		catch
 			ClearRTError()

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -1606,8 +1606,8 @@ threadsafe Function/S RemovePrefix(string str, [string start, variable regExp])
 	endif
 
 	if(regExp)
-		ClearRTError()
-		SplitString/E="^(" + start + ")" str, regExpResult; err = GetRTError(1)
+		AssertOnAndClearRTError()
+		SplitString/E="^(" + start + ")" str, regExpResult; err = GetRTError(1) // see developer docu section Preventing Debugger Popup
 
 		if(V_flag == 1 && err == 0)
 			skipLength = strlen(regExpResult)
@@ -3827,12 +3827,12 @@ Function KillWindows(list)
 End
 
 /// @brief str2num variant with no runtime error on invalid conversions
-threadsafe Function str2numSafe(str)
-	string str
+threadsafe Function str2numSafe(string str)
 
-	variable err, var
+	variable var, err
 
-	var = str2num(str); err = GetRTError(1)
+	AssertOnAndClearRTError()
+	var = str2num(str); err = GetRTError(1) // see developer docu section Preventing Debugger Popup
 
 	return var
 End

--- a/Packages/MIES/MIES_WaveBuilderPanel.ipf
+++ b/Packages/MIES/MIES_WaveBuilderPanel.ipf
@@ -1807,8 +1807,8 @@ static Function WBP_UpdateParameterWave()
 			name = listWave[i][%Name]
 
 			if(WhichListItem(name, suggNames) != -1)
+				AssertOnAndClearRTError()
 				try
-					ClearRTError()
 					help = f(name); AbortOnRTE
 					listWave[i][%Help] = help
 					helpWave[i][%Help] = LineBreakingIntoPar(help, minimumWidth = 40)

--- a/Packages/Testing-MIES/UTF_PatchSeqChirp.ipf
+++ b/Packages/Testing-MIES/UTF_PatchSeqChirp.ipf
@@ -8,6 +8,7 @@ static Function AcquireData(s, device, [postInitializeFunc, preAcquireFunc])
 	string device
 	FUNCREF CALLABLE_PROTO postInitializeFunc, preAcquireFunc
 
+	KillWaves/Z root:overrideResults
 	Make/O/N=(0) root:overrideResults/Wave=overrideResults
 	Note/K overrideResults
 


### PR DESCRIPTION
In some cases we run code that may result in an RTE that we want to catch.
Out previous approach was that we enclose this part in a
try / catch / endtry block, where a critical RTE is caught through
an AbortOnRTE.
To prevent catching pending RTEs instead of the specific targeted RTE
we cleared any RTE condition with ClearRTError() directly after the try.

This poses a problem: Any pending RTE is silently cleared by the code which
generally hid all pending RTEs in the code that appeared before one of the
try clauses where executed. While for non-threadsafe code this still might
be found by executing with Debug-On-Error, with threadsafe code such conditions
got invisible.

The fix is to check the RTE code before clearing it as preparation for
critical code. So we can assert outt, if there is a pending RTE.
