### PR TITLE
CONF_RestoreDAEphys: Switch back to Headstage 0 after configuration

### DIFF
--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -640,7 +640,8 @@ Function/S CONF_RestoreDAEphys(jsonID, fullFilePath, [middleOfExperiment, forceN
 			SetVariable SetVar_Sweep win=$panelTitle, noedit=1, limits={0,0,0}, help={"Sweep rollback is disabled by the configuration."}
 		endif
 
-		PGC_SetAndActivateControl(panelTitle, "StartTestPulseButton", switchTab = 1)
+		PGC_SetAndActivateControl(panelTitle, "slider_DataAcq_ActiveHeadstage", val = 0, switchTab = 1)
+		PGC_SetAndActivateControl(panelTitle, "StartTestPulseButton")
 
 		print "Start Sciencing"
 		SetWindow $panelTitle, hide=0, needUpdate=1


### PR DESCRIPTION
We currently have the slider position at the first non-configured
headstage after configuration.

As this is quite confusing we now switch back to the very first
headstage. This also is more convenient for the not-too-small crowd only
acquiring data on one headstage.

Close #1068
