### PR TITLE
fix to store resizeInfos automatically without pending RTE

### DIFF
--- a/Packages/MIES/MIES_AnalysisBrowser.ipf
+++ b/Packages/MIES/MIES_AnalysisBrowser.ipf
@@ -2448,7 +2448,7 @@ Function AB_BrowserStartupSettings()
 
 	AB_ResetListBoxWaves(0)
 
-	ResizeControlsPanel#SaveControlPositions(panel, 0)
+	StoreCurrentPanelsResizeInfo(panel)
 
 	SearchForInvalidControlProcs(panel)
 	print "Do not forget to increase ANALYSISBROWSER_PANEL_VERSION."

--- a/Packages/MIES/MIES_DataBrowser.ipf
+++ b/Packages/MIES/MIES_DataBrowser.ipf
@@ -90,7 +90,7 @@ Function DB_ResetAndStoreCurrentDBPanel()
 	BSP_UnsetDynamicSettingsHistory(panelTitle)
 
 	// store current positions as reference
-	ResizeControlsPanel#SaveControlPositions(bsPanel, 0)
+	StoreCurrentPanelsResizeInfo(bsPanel)
 
 	TabControl SF_InfoTab, WIN = $bsPanel, disable=2
 

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -5845,3 +5845,15 @@ Function/S GetCodeForWaveContents(WAVE/T wv)
 
 	return "{" + list + "}"
 End
+
+/// @brief If the layout of an panel was changed, this function calls the
+///        ResizeControlsPanel module functions of the Igor Pro native package
+///        to store the changed resize info. The original inteded way to do this
+///        was through the Packages GUI, which is clunky for some workflows.
+Function StoreCurrentPanelsResizeInfo(string panel)
+
+	ASSERT(!IsEmpty(panel), "Panel name can not be empty.")
+
+	ResizeControlsPanel#ResetListboxWaves()
+	ResizeControlsPanel#SaveControlPositions(panel, 0)
+End


### PR DESCRIPTION
Panel resize information was saved automatically by calling
SaveControlPositions from Igors own ResizeControlsPanel package.
However there was a wave referenced that did not exist, resulting in an RTE.
The RTE did not influence the correct execution.

This commit fixes the RTE by creating the required wave beforehand.

since 522082999cb4aea1c2252886995720d24ada9df0
and 74cc953eacd7c3d2a603806ad48fd639eac98832

close https://github.com/AllenInstitute/MIES/issues/1076