### PR TITLE
Testpulse waves cleanup

### DIFF
--- a/Packages/MIES/MIES_AmplifierInteraction.ipf
+++ b/Packages/MIES/MIES_AmplifierInteraction.ipf
@@ -687,14 +687,14 @@ Function AI_ZeroAmps(panelTitle, [headStage])
 	// Ensure that data in BaselineSSAvg is up to date by verifying that TP is active
 	if(IsDeviceActiveWithBGTask(panelTitle, "TestPulse") || IsDeviceActiveWithBGTask(panelTitle, "TestPulseMD"))
 
-		WAVE baselineSSAvg = GetBaselineAverage(panelTitle)
+		WAVE TPResults = GetTPResults(panelTitle)
 		if(!ParamIsDefault(headstage))
-			if(abs(baselineSSAvg[headstage]) >= ZERO_TOLERANCE)
+			if(abs(TPResults[%BaselineSteadyState][headstage]) >= ZERO_TOLERANCE)
 				AI_MIESAutoPipetteOffset(panelTitle, headStage)
 			endif
 		else
 			for(i = 0; i < NUM_HEADSTAGES; i += 1)
-				if(abs(baselineSSAvg[i]) >= ZERO_TOLERANCE)
+				if(abs(TPResults[%BaselineSteadyState][headstage]) >= ZERO_TOLERANCE)
 					AI_MIESAutoPipetteOffset(panelTitle, i)
 				endif
 			endfor
@@ -713,15 +713,14 @@ Function AI_MIESAutoPipetteOffset(panelTitle, headStage)
 
 	variable clampMode, column, vDelta, offset, value
 
-	WAVE BaselineSSAvg = GetBaselineAverage(panelTitle)
-	WAVE SSResistance = GetSSResistanceWave(panelTitle)
+	WAVE TPResults = GetTPResults(panelTitle)
 
 	clampMode = DAG_GetHeadstageMode(panelTitle, headStage)
 
 	ASSERT(clampMode == V_CLAMP_MODE || clampMode == I_CLAMP_MODE, "Headstage must be in VC/IC mode to use this function")
 	ASSERT(column >= 0, "Invalid column number")
 	//calculate delta current to reach zero
-	vdelta = (baselineSSAvg[headstage] * SSResistance[headstage]) / 1000 // set to mV
+	vdelta = (TPResults[%BaselineSteadyState][headstage] * TPResults[%ResistanceSteadyState][headstage]) / 1000 // set to mV
 	// get current DC V offset
 	offset = AI_SendToAmp(panelTitle, headStage, clampMode, MCC_GETPIPETTEOFFSET_FUNC, nan)
 	// add delta to current DC V offset

--- a/Packages/MIES/MIES_Blowout.ipf
+++ b/Packages/MIES/MIES_Blowout.ipf
@@ -166,7 +166,8 @@ static Function BWO_CheckAndClearPipettes(panelTitle)
 	string panelTitle
 
 	variable i, j, col, initPressure, startTime, pressurePulseStartTime, pressurePulseTime
-	wave SSResistance = GetSSResistanceWave(panelTitle)
+
+	wave TPResults = GetTPResults(panelTitle)
 	WAVE pressure = P_GetPressureDataWaveRef(panelTitle)
 
 	STRUCT BackgroundStruct s
@@ -177,7 +178,7 @@ static Function BWO_CheckAndClearPipettes(panelTitle)
 	for(i = 0; i < NUM_HEADSTAGES; i += 1)
 
 
-		if(!P_ValidatePressureSetHeadstage(panelTitle, i) || SSResistance[i] < BWO_MAX_RESISTANCE)
+		if(!P_ValidatePressureSetHeadstage(panelTitle, i) || TPResults[%ResistanceSteadyState][i] < BWO_MAX_RESISTANCE)
 			continue
 		endif
 
@@ -203,12 +204,12 @@ static Function BWO_CheckAndClearPipettes(panelTitle)
 			endif
 			TPM_BkrdTPFuncMD(s)
 			DoUpdate/W=$SCOPE_GetPanel(panelTitle)
-		while(SSResistance[i] > BWO_MAX_RESISTANCE && ticks - startTime < FIFTEEN_SECONDS) // continue if the pipette is not clear AND the timeout hasn't been exceeded
+		while(TPResults[%ResistanceSteadyState][i] > BWO_MAX_RESISTANCE && ticks - startTime < FIFTEEN_SECONDS) // continue if the pipette is not clear AND the timeout hasn't been exceeded
 
 		PGC_SetAndActivateControl(panelTitle, "button_DataAcq_SSSetPressureMan") // turn off manual pressure
 		PGC_SetAndActivateControl(panelTitle, "setvar_DataAcq_SSPressure", val = 0)
 
-		if(SSResistance[i] > BWO_MAX_RESISTANCE)
+		if(TPResults[%ResistanceSteadyState][i] > BWO_MAX_RESISTANCE)
 			printf "Unable to clear pipette on headstage %d with %g psi\r" i, PressureTracking[i]
 		endif
 	endfor

--- a/Packages/MIES/MIES_DAEphys_Macro.ipf
+++ b/Packages/MIES/MIES_DAEphys_Macro.ipf
@@ -738,7 +738,7 @@ Window DA_Ephys() : Panel
 	SetVariable SetVar_DataAcq_TPBaselinePerc,userdata(ResizeControlsInfo)+=A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
 	SetVariable SetVar_DataAcq_TPBaselinePerc,userdata(Config_GroupPath)="Test Pulse"
 	SetVariable SetVar_DataAcq_TPBaselinePerc,limits={25,49,1},value=_NUM:35
-	SetVariable SetVar_DataAcq_TPAmplitude,pos={300.00,417.00},size={69.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVarProc_TPAmp
+	SetVariable SetVar_DataAcq_TPAmplitude,pos={300.00,417.00},size={69.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVarProc_TestPulseSett
 	SetVariable SetVar_DataAcq_TPAmplitude,title="VC"
 	SetVariable SetVar_DataAcq_TPAmplitude,help={"Amplitude of the testpulse in voltage clamp mode"}
 	SetVariable SetVar_DataAcq_TPAmplitude,userdata(tabnum)="0"
@@ -2402,7 +2402,7 @@ Window DA_Ephys() : Panel
 	ValDisplay valdisp_DataAcq_SweepsActiveSet,valueBackColor=(0,0,0)
 	ValDisplay valdisp_DataAcq_SweepsActiveSet,limits={0,0,0},barmisc={0,1000}
 	ValDisplay valdisp_DataAcq_SweepsActiveSet,value=_NUM:1
-	SetVariable SetVar_DataAcq_TPAmplitudeIC,pos={373.00,417.00},size={65.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVarProc_TPAmp
+	SetVariable SetVar_DataAcq_TPAmplitudeIC,pos={373.00,417.00},size={65.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVarProc_TestPulseSett
 	SetVariable SetVar_DataAcq_TPAmplitudeIC,title="IC"
 	SetVariable SetVar_DataAcq_TPAmplitudeIC,help={"Amplitude of the testpulse in current clamp mode"}
 	SetVariable SetVar_DataAcq_TPAmplitudeIC,userdata(tabnum)="0"
@@ -3322,7 +3322,7 @@ Window DA_Ephys() : Panel
 	CheckBox Check_DataAcq_Get_Set_ITI,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	CheckBox Check_DataAcq_Get_Set_ITI,userdata(ResizeControlsInfo)+=A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
 	CheckBox Check_DataAcq_Get_Set_ITI,value=1
-	SetVariable setvar_Settings_TPBuffer,pos={334.00,108.00},size={124.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
+	SetVariable setvar_Settings_TPBuffer,pos={334.00,108.00},size={124.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVarProc_TestPulseSett
 	SetVariable setvar_Settings_TPBuffer,title="TP Buffer size",userdata(tabnum)="5"
 	SetVariable setvar_Settings_TPBuffer,userdata(tabcontrol)="ADC"
 	SetVariable setvar_Settings_TPBuffer,userdata(ResizeControlsInfo)=A"!!,H]J,hpi!!#@^!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
@@ -3338,7 +3338,7 @@ Window DA_Ephys() : Panel
 	CheckBox check_Settings_SaveAmpSettings,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	CheckBox check_Settings_SaveAmpSettings,userdata(ResizeControlsInfo)+=A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
 	CheckBox check_Settings_SaveAmpSettings,value=1
-	SetVariable setvar_Settings_TP_RTolerance,pos={313.00,84.00},size={145.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
+	SetVariable setvar_Settings_TP_RTolerance,pos={313.00,84.00},size={145.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVarProc_TestPulseSett
 	SetVariable setvar_Settings_TP_RTolerance,title="Min delta R (MΩ)"
 	SetVariable setvar_Settings_TP_RTolerance,help={"Sets the minimum delta required for TP resistance values to be appended as a wave note to the data sweep. TP resistance values are always documented in the Lab Note Book."}
 	SetVariable setvar_Settings_TP_RTolerance,userdata(tabnum)="5"

--- a/Packages/MIES/MIES_DataAcquisition.ipf
+++ b/Packages/MIES/MIES_DataAcquisition.ipf
@@ -236,12 +236,11 @@ End
 
 /// @brief Handle automatic bias current injection
 ///
-/// @param panelTitle	locked panel with test pulse running occasionally
-/// @param BaselineSSAvg
-/// @param SSResistance
-Function DQ_ApplyAutoBias(panelTitle, BaselineSSAvg, SSResistance)
+/// @param panelTitle Locked panel with test pulse running occasionally
+/// @param TPResults  Data from TP_ROAnalysis()
+Function DQ_ApplyAutoBias(panelTitle, TPResults)
 	string panelTitle
-	Wave BaselineSSAvg, SSResistance
+	Wave TPResults
 
 	variable headStage, actualcurrent, current, targetVoltage, targetVoltageTol, setVoltage
 	variable resistance, maximumAutoBiasCurrent, lastInvocation, curTime
@@ -290,8 +289,8 @@ Function DQ_ApplyAutoBias(panelTitle, BaselineSSAvg, SSResistance)
 		targetVoltage    = ampSettings[%AutoBiasVcom][0][headStage] * 1e-3
 		targetVoltageTol = ampSettings[%AutoBiasVcomVariance][0][headStage] * 1e-3
 
-		resistance = SSResistance[headstage] * 1e6
-		setVoltage = BaselineSSAvg[headstage] * 1e-3
+		resistance = TPResults[%ResistanceSteadyState][headstage] * 1e6
+		setVoltage = TPResults[%BaselineSteadyState][headstage] * 1e-3
 
 		DEBUGPRINT("resistance[Ohm]=", var=resistance)
 		DEBUGPRINT("setVoltage[V]=", var=setVoltage)

--- a/Packages/MIES/MIES_DataAcquisition_Multi.ipf
+++ b/Packages/MIES/MIES_DataAcquisition_Multi.ipf
@@ -20,7 +20,7 @@ Function DQM_FIFOMonitor(s)
 	STRUCT WMBackgroundStruct &s
 
 	variable deviceID, isFinished, hardwareType
-	variable i, j, err, fifoLatest, result, channel, lastTP, tpLengthPoints, gotTPChannels
+	variable i, j, err, fifoLatest, result, channel, lastTP, gotTPChannels
 	variable bufferSize
 	string panelTitle, fifoChannelName, fifoName, errMsg
 	WAVE ActiveDeviceList = GetDQMActiveDeviceList()
@@ -30,6 +30,8 @@ Function DQM_FIFOMonitor(s)
 		deviceID   = ActiveDeviceList[i][%DeviceID]
 		hardwareType = ActiveDeviceList[i][%HardwareType]
 		panelTitle = HW_GetMainDeviceName(hardwareType, deviceID)
+
+		WAVE TPSettingsCalc = GetTPSettingsCalculated(panelTitle)
 
 		switch(hardwareType)
 			case HARDWARE_NI_DAC:
@@ -79,8 +81,7 @@ Function DQM_FIFOMonitor(s)
 				// Update ActiveChunk Entry for ITC, not used in DAQ mode
 				gotTPChannels = GotTPChannelsOnADCs(paneltitle)
 				if(gotTPChannels)
-					tpLengthPoints = ROVar(GetTestPulseLengthInPoints(panelTitle, DATA_ACQUISITION_MODE))
-					lastTP = trunc(fifoLatest / tpLengthPoints) - 1
+					lastTP = trunc(fifoLatest / TPSettingsCalc[%totalLengthPointsDAQ]) - 1
 					if(lastTP >= 0 && lastTP != ActiveDeviceList[i][%ActiveChunk])
 						ActiveDeviceList[i][%ActiveChunk] = lastTP
 					endif

--- a/Packages/MIES/MIES_DataConfigurator.ipf
+++ b/Packages/MIES/MIES_DataConfigurator.ipf
@@ -21,16 +21,10 @@ static Function DC_UpdateGlobals(panelTitle)
 	// @todo investigate if this is really required here
 	AFM_UpdateAnalysisFunctionWave(panelTitle)
 
-	TP_ReadTPSettingFromGUI(panelTitle)
+	TP_UpdateTPSettingsLBNWaves(panelTitle)
 
 	SVAR panelTitleG = $GetPanelTitleGlobal()
 	panelTitleG = panelTitle
-
-	NVAR tpLengthInPointsTP = $GetTestpulseLengthInPoints(panelTitle, TEST_PULSE_MODE)
-	tpLengthInPointsTP = TP_GetTestPulseLengthInPoints(panelTitle, TEST_PULSE_MODE)
-
-	NVAR tpLengthInPointsDAQ = $GetTestpulseLengthInPoints(panelTitle, DATA_ACQUISITION_MODE)
-	tpLengthInPointsDAQ = TP_GetTestPulseLengthInPoints(panelTitle, DATA_ACQUISITION_MODE)
 
 	NVAR fifoPosition = $GetFifoPosition(panelTitle)
 	fifoPosition = 0
@@ -411,6 +405,7 @@ static Function DC_MakeHelperWaves(panelTitle, dataAcqOrTP)
 	WAVE scaledDataWave = GetScaledDataWave(panelTitle)
 	WAVE ITCDataWave = GetDAQDataWave(panelTitle, dataAcqOrTP)
 	WAVE/WAVE NIDataWave = GetDAQDataWave(panelTitle, dataAcqOrTP)
+	WAVE TPSettingsCalc = GetTPSettingsCalculated(panelTitle)
 
 	hardwareType = GetHardwareType(panelTitle)
 
@@ -428,7 +423,7 @@ static Function DC_MakeHelperWaves(panelTitle, dataAcqOrTP)
 	endswitch
 
 	if(dataAcqOrTP == TEST_PULSE_MODE)
-		tpLength = ROVAR(GetTestPulseLengthInPoints(panelTitle, TEST_PULSE_MODE))
+		tpLength = TPSettingsCalc[%totalLengthPointsTP]
 		numRows = tpLength
 
 		decMethod = DECIMATION_NONE
@@ -1311,7 +1306,10 @@ static Function [STRUCT DataConfigurationResult s] DC_GetConfiguration(string pa
 	WAVE/T allSetNames = DAG_GetChannelTextual(panelTitle, CHANNEL_TYPE_DAC, CHANNEL_CONTROL_WAVE)
 	s.hardwareType     = GetHardwareType(panelTitle)
 
-	s.baselineFrac        = ROVar(GetTestpulseBaselineFraction(panelTitle))
+	WAVE TPSettings     = GetTPSettings(panelTitle)
+	WAVE TPSettingsCalc = GetTPSettingsCalculated(panelTitle)
+
+	s.baselineFrac        = TPSettingsCalc[%baselineFrac]
 	WAVE ChannelClampMode = GetChannelClampMode(panelTitle)
 	WAVE s.statusHS       = DAG_GetChannelState(panelTitle, CHANNEL_TYPE_HEADSTAGE)
 
@@ -1393,9 +1391,9 @@ static Function [STRUCT DataConfigurationResult s] DC_GetConfiguration(string pa
 		if(IsFinite(headstage))
 			channelMode = ChannelClampMode[channel][%DAC][%ClampMode]
 			if(channelMode == V_CLAMP_MODE)
-				s.DACAmp[i][%TPAMP] = TPAmpVClamp
+				s.DACAmp[i][%TPAMP] = TPSettings[%amplitudeVC][INDEP_HEADSTAGE]
 			elseif(channelMode == I_CLAMP_MODE || channelMode == I_EQUAL_ZERO_MODE)
-				s.DACAmp[i][%TPAMP] = TPAmpIClamp
+				s.DACAmp[i][%TPAMP] = TPSettings[%amplitudeIC][INDEP_HEADSTAGE]
 			else
 				ASSERT(0, "Unknown clamp mode")
 			endif

--- a/Packages/MIES/MIES_DataConfigurator.ipf
+++ b/Packages/MIES/MIES_DataConfigurator.ipf
@@ -42,7 +42,6 @@ Function DC_Configure(panelTitle, dataAcqOrTP, [multiDevice])
 	variable dataAcqOrTP, multiDevice
 
 	variable numActiveChannels
-	variable gotTPChannels
 	ASSERT(dataAcqOrTP == DATA_ACQUISITION_MODE || dataAcqOrTP == TEST_PULSE_MODE, "invalid mode")
 
 	if(ParamIsDefault(multiDevice))
@@ -99,11 +98,7 @@ Function DC_Configure(panelTitle, dataAcqOrTP, [multiDevice])
 	NVAR ADChannelToMonitor = $GetADChannelToMonitor(panelTitle)
 	ADChannelToMonitor = DimSize(GetDACListFromConfig(DAQConfigWave), ROWS)
 
-	gotTPChannels = GotTPChannelsOnADCs(paneltitle)
-
-	if(dataAcqOrTP == TEST_PULSE_MODE || gotTPChannels)
-		TP_CreateTPAvgBuffer(panelTitle)
-	endif
+	KillOrMoveToTrash(wv = GetTPResultsBuffer(panelTitle))
 
 	DC_MakeHelperWaves(panelTitle, dataAcqOrTP)
 	SCOPE_CreateGraph(panelTitle, dataAcqOrTP)

--- a/Packages/MIES/MIES_ExperimentDocumentation.ipf
+++ b/Packages/MIES/MIES_ExperimentDocumentation.ipf
@@ -639,6 +639,7 @@ Function ED_TPDocumentation(panelTitle)
 	variable sweepNo, RTolerance
 	variable i, j
 	WAVE hsProp = GetHSProperties(panelTitle)
+	WAVE TPSettings = GetTPsettings(panelTitle)
 
 	WAVE BaselineSSAvg = GetBaselineAverage(panelTitle)
 	WAVE InstResistance = GetInstResistanceWave(panelTitle)
@@ -677,7 +678,7 @@ Function ED_TPDocumentation(panelTitle)
 	TPKeyWave[1][10] = ""
 	TPKeyWave[1][11] = ""
 
-	RTolerance = DAG_GetNumericalValue(panelTitle, "setvar_Settings_TP_RTolerance")
+	RTolerance = TPSettings[%resistanceTol][INDEP_HEADSTAGE]
 	TPKeyWave[2][0]  = "1" // Assume a tolerance of 1 mV for V rest
 	TPKeyWave[2][1]  = "50" // Assume a tolerance of 50pA for I rest
 	TPKeyWave[2][2]  = num2str(RTolerance) // applies the same R tolerance for the instantaneous and steady state resistance
@@ -737,41 +738,9 @@ End
 /// @param panelTitle      device
 /// @param sweepNo         sweep number
 /// @param entrySourceType type of reporting subsystem, one of @ref DataAcqModes
-static Function ED_TPSettingsDocumentation(panelTitle, sweepNo, entrySourceType)
-	string panelTitle
-	variable sweepNo, entrySourceType
+static Function ED_TPSettingsDocumentation(string panelTitle, variable sweepNo, variable entrySourceType)
+	WAVE TPSettingsLBN        = GetTPSettingsLabnotebook(panelTitle)
+	WAVE TPSettingsLBNKeyWave = GetTPSettingsLabnotebookKeyWave(panelTitle)
 
-	NVAR pulseDuration = $GetTPPulseDuration(panelTitle)
-	NVAR AmplitudeVC = $GetTPAmplitudeVC(panelTitle)
-	NVAR AmplitudeIC = $GetTPAmplitudeIC(panelTitle)
-	NVAR baselineFrac = $GetTestpulseBaselineFraction(panelTitle)
-
-	Make/FREE/T/N=(3, 4) TPKeyWave
-	Make/FREE/N=(1, 4, LABNOTEBOOK_LAYER_COUNT) TPSettingsWave = NaN
-
-	// name
-	TPKeyWave[0][0] = "TP Baseline Fraction" // fraction of total TP duration
-	TPKeyWave[0][1] = "TP Amplitude VC"
-	TPKeyWave[0][2] = "TP Amplitude IC"
-	TPKeyWave[0][3] = "TP Pulse Duration"
-
-	// unit
-	TPKeyWave[1][0] = ""
-	TPKeyWave[1][1] = ""
-	TPKeyWave[1][2] = ""
-	TPKeyWave[1][3] = "ms"
-
-	// tolerance
-	TPKeyWave[2][0] = ""
-	TPKeyWave[2][1] = ""
-	TPKeyWave[2][2] = ""
-	TPKeyWave[2][3] = ""
-
-	// the settings are valid for all headstages
-	TPSettingsWave[0][0][INDEP_HEADSTAGE] = baselineFrac
-	TPSettingsWave[0][1][INDEP_HEADSTAGE] = AmplitudeVC
-	TPSettingsWave[0][2][INDEP_HEADSTAGE] = AmplitudeIC
-	TPSettingsWave[0][3][INDEP_HEADSTAGE] = pulseDuration
-
-	ED_AddEntriesToLabnotebook(TPSettingsWave, TPKeyWave, sweepNo, panelTitle, entrySourceType)
+	ED_AddEntriesToLabnotebook(TPSettingsLBN, TPSettingsLBNKeyWave, sweepNo, panelTitle, entrySourceType)
 End

--- a/Packages/MIES/MIES_ExperimentDocumentation.ipf
+++ b/Packages/MIES/MIES_ExperimentDocumentation.ipf
@@ -638,13 +638,10 @@ Function ED_TPDocumentation(panelTitle)
 
 	variable sweepNo, RTolerance
 	variable i, j
+
 	WAVE hsProp = GetHSProperties(panelTitle)
 	WAVE TPSettings = GetTPsettings(panelTitle)
-
-	WAVE BaselineSSAvg = GetBaselineAverage(panelTitle)
-	WAVE InstResistance = GetInstResistanceWave(panelTitle)
-	WAVE SSResistance = GetSSResistanceWave(panelTitle)
-
+	WAVE TPResults = GetTPResults(panelTitle)
 	WAVE statusHS = DAG_GetChannelState(panelTitle, CHANNEL_TYPE_HEADSTAGE)
 
 	Make/FREE/T/N=(3, 12) TPKeyWave
@@ -692,8 +689,8 @@ Function ED_TPDocumentation(panelTitle)
 	TPKeyWave[2][10] = "0.0001"
 	TPKeyWave[2][11] = LABNOTEBOOK_NO_TOLERANCE
 
-	TPSettingsWave[0][2][0, NUM_HEADSTAGES - 1]  = InstResistance[r]
-	TPSettingsWave[0][3][0, NUM_HEADSTAGES - 1]  = SSResistance[r]
+	TPSettingsWave[0][2][0, NUM_HEADSTAGES - 1]  = TPResults[%ResistanceInst][r]
+	TPSettingsWave[0][3][0, NUM_HEADSTAGES - 1]  = TPResults[%ResistanceSteadyState][r]
 
 	TPSettingsWave[0][8][0, NUM_HEADSTAGES - 1] = statusHS[r]
 
@@ -717,8 +714,8 @@ Function ED_TPDocumentation(panelTitle)
 		TPSettingsWave[0][7][i] = AI_SendToAmp(panelTitle, i, V_CLAMP_MODE, MCC_GETSLOWCOMPTAU_FUNC, NaN, selectAmp = 0)
 	endfor
 
-	TPSettingsWave[0][1][0, NUM_HEADSTAGES - 1] = hsProp[r][%ClampMode] == V_CLAMP_MODE ? BaselineSSAvg[r] : NaN
-	TPSettingsWave[0][0][0, NUM_HEADSTAGES - 1] = hsProp[r][%ClampMode] == I_CLAMP_MODE ? BaselineSSAvg[r] : NaN
+	TPSettingsWave[0][1][0, NUM_HEADSTAGES - 1] = hsProp[r][%ClampMode] == V_CLAMP_MODE ? TPResults[%BaselineSteadyState][r] : NaN
+	TPSettingsWave[0][0][0, NUM_HEADSTAGES - 1] = hsProp[r][%ClampMode] == I_CLAMP_MODE ? TPResults[%BaselineSteadyState][r] : NaN
 
 	TPSettingsWave[0][9][0, NUM_HEADSTAGES - 1]  = hsProp[r][%DAC]
 	TPSettingsWave[0][10][0, NUM_HEADSTAGES - 1] = hsProp[r][%ADC]

--- a/Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf
+++ b/Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf
@@ -291,28 +291,6 @@ Function/S GetCount(panelTitle)
 	return GetNVARAsString(GetDevicePath(panelTitle), "count", initialValue=0)
 End
 
-/// @brief Return the absolute path to the testpulse duration variable
-///
-/// The duration is for a single pulse only without baseline.
-///
-/// The duration is *not* in units of time but in number of points for
-/// the real (compared to #HARDWARE_ITC_MIN_SAMPINT/#HARDWARE_NI_DAC_MIN_SAMPINT) sampling interval
-Function/S GetTestpulseDuration(panelTitle)
-	string panelTitle
-
-	return GetNVARAsString(GetDeviceTestPulse(panelTitle), "duration", initialValue=NaN)
-End
-
-/// @brief Return the absolute path to the testpulse baseline fraction variable
-///
-/// The returned value is the fraction which the baseline occupies relative to the total
-/// testpulse length, before and after the pulse itself.
-Function/S GetTestpulseBaselineFraction(panelTitle)
-	string panelTitle
-
-	return GetNVARAsString(GetDeviceTestPulse(panelTitle), "baselineFrac", initialValue=NaN)
-End
-
 /// @brief Returns the list of locked device panels
 Function/S GetDevicePanelTitleList()
 	string panelTitle
@@ -416,27 +394,6 @@ Function/S GetNITestPulseCounter(panelTitle)
 	string panelTitle
 
 	return GetNVARAsString(GetDeviceTestPulse(panelTitle), "NITestPulseCounter", initialValue=0)
-End
-
-/// @brief Returns TestPulse pulseDuration in ms
-Function/S GetTPPulseDuration(panelTitle)
-	string panelTitle
-
-	return GetNVARAsString(GetDeviceTestPulse(panelTitle), "pulseDuration", initialValue=NaN)
-End
-
-/// @brief Returns TestPulse amplitude in voltage clamp mode in mV
-Function/S GetTPAmplitudeVC(panelTitle)
-	string panelTitle
-
-	return GetNVARAsString(GetDeviceTestPulse(panelTitle), "AmplitudeVC", initialValue=NaN)
-End
-
-/// @brief Returns TestPulse amplitude in current clamp mode in pA
-Function/S GetTPAmplitudeIC(panelTitle)
-	string panelTitle
-
-	return GetNVARAsString(GetDeviceTestPulse(panelTitle), "AmplitudeIC", initialValue=NaN)
 End
 
 /// @brief Returns the current NI setup string for analog in through DAQmx_Scan
@@ -612,32 +569,6 @@ Function/S GetPxPVersionForAB(dfr)
 	DFREF dfr
 
 	return GetNVARAsString(dfr, "pxpVersion", initialValue = NaN)
-End
-
-/// @brief Wrapper for fast access during DAQ/TP for TP_GetTestPulseLengthInPoints().
-///
-/// Can only be called during DAQ/TP, returns the same data as
-/// TP_GetTestPulseLengthInPoints().
-///
-/// @param panelTitle device
-/// @param mode       one of @ref DataAcqModes
-Function/S GetTestpulseLengthInPoints(panelTitle, mode)
-	string panelTitle
-	variable mode
-
-	switch(mode)
-		case TEST_PULSE_MODE:
-			DFREF dfr = GetDeviceTestPulse(panelTitle)
-			break
-		case DATA_ACQUISITION_MODE:
-			DFREF dfr = GetDevicePath(panelTitle)
-			break
-		default:
-			ASSERT(0, "Invalid mode")
-			break
-	endswitch
-
-	return GetNVARAsString(dfr, "testpulseLengthInPoints", initialValue=NaN)
 End
 
 /// @brief Return the JSON ID for the sweep formula

--- a/Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf
+++ b/Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf
@@ -281,13 +281,6 @@ Function/S GetDAQDeviceID(panelTitle)
 	return GetNVARAsString(GetDevicePath(panelTitle), "deviceID", initialValue=NaN)
 End
 
-/// @brief Returns the absolute path to the testpulse averaging buffer size
-Function/S GetTPBufferSizeGlobal(panelTitle)
-	string panelTitle
-
-	return GetNVARAsString(GetDeviceTestPulse(panelTitle), "n", initialValue=NaN)
-End
-
 /// @brief Returns the absolute path to the global variable `count` storing the
 ///        number of data acquisition cycles performed.
 ///

--- a/Packages/MIES/MIES_IVSCC.ipf
+++ b/Packages/MIES/MIES_IVSCC.ipf
@@ -227,10 +227,9 @@ Function IVS_FinishBaselineQCCheck(s)
 		return 0
 	endif
 
-	// grab the baseline avg value
-	WAVE BaselineSSAvg = GetBaselineAverage(panelTitle)
+	WAVE TPResults = GetTPResults(panelTitle)
 
-	baselineAverage = BaselineSSAvg[headstage]
+	baselineAverage = TPResults[%BaselineSteadyState][headstage]
 
 	printf "baseline Average: %g\r", baselineAverage
 
@@ -309,12 +308,10 @@ Function IVS_finishInitAccessQCCheck(s)
 		return 0
 	endif
 
-	// and grab the initial resistance avg value
-	WAVE InstResistance = GetInstResistanceWave(panelTitle)
-	WAVE SSResistance = GetSSResistanceWave(panelTitle)
+	WAVE TPResults = GetTPResults(panelTitle)
 
-	instResistanceVal = InstResistance[headstage]
-	ssResistanceVal = SSResistance[headstage]
+	instResistanceVal = TPResults[%ResistanceInst][headstage]
+	ssResistanceVal = TPResults[%ResistanceSteadyState][headstage]
 
 	printf "Initial Access Resistance: %g\r", instResistanceVal
 	printf "SS Resistance: %g\r", ssResistanceVal
@@ -430,9 +427,8 @@ Function IVS_finishGigOhmSealQCCheck(s)
 		return 0
 	endif
 
-	// and grab the Steady State Resistance
-	WAVE SSResistance = GetSSResistanceWave(panelTitle)
-	ssResistanceVal = SSResistance[headstage]
+	WAVE TPResults = GetTPResults(panelTitle)
+	ssResistanceVal = TPResults[%ResistanceSteadyState][headstage]
 
 	printf "Steady State Resistance: %g\r", ssResistanceVal
 
@@ -452,7 +448,7 @@ Function IVS_finishGigOhmSealQCCheck(s)
 		endif
 	catch
 		ClearRTError()
-		ssResistanceVal = SSResistance[headstage]
+		ssResistanceVal = TPResults[%ResistanceSteadyState][headstage]
 
 		printf "Second Pass: Steady State Resistance: %g\r", ssResistanceVal
 

--- a/Packages/MIES/MIES_Oscilloscope.ipf
+++ b/Packages/MIES/MIES_Oscilloscope.ipf
@@ -12,7 +12,7 @@
 static Constant SCOPE_TIMEAXIS_RESISTANCE_RANGE = 120
 static Constant SCOPE_GREEN                     = 26122
 static Constant SCOPE_BLUE                      = 39168
-static StrConstant RES_FORMAT_STR               = "\\[1\\K(%d, %d, %d)\\{\"%%s\", FloatWithMinSigDigits(%s[%d], numMinSignDigits = 2)}\\]1\\K(0, 0, 0)"
+static StrConstant RES_FORMAT_STR               = "\\[1\\K(%d, %d, %d)\\{\"%%s\", FloatWithMinSigDigits(%s[%%%s][%d], numMinSignDigits = 2)}\\]1\\K(0, 0, 0)"
 static Constant PRESSURE_SPECTRUM_PERCENT       = 0.05
 
 Function/S SCOPE_GetGraph(panelTitle)
@@ -213,13 +213,12 @@ Function SCOPE_CreateGraph(panelTitle, dataAcqOrTP)
 	scopeScaleMode = DAG_GetNumericalValue(panelTitle, "Popup_Settings_OsciUpdMode")
 
 	WAVE DAQConfigWave      = GetDAQConfigWave(panelTitle)
-	WAVE SSResistance       = GetSSResistanceWave(panelTitle)
-	WAVE InstResistance     = GetInstResistanceWave(panelTitle)
 	WAVE TPStorage          = GetTPStorage(panelTitle)
 	WAVE OscilloscopeData   = GetOscilloscopeWave(panelTitle)
 	WAVE TPOscilloscopeData = GetTPOscilloscopeWave(panelTitle)
 	WAVE PressureData       = P_GetPressureDataWaveRef(panelTitle)
 	WAVE TPSettings         = GetTPSettings(panelTitle)
+	WAVE TPResults          = GetTPResults(panelTitle)
 
 	WAVE ADCmode = GetADCTypesFromConfig(DAQConfigWave)
 	WAVE ADCs = GetADCListFromConfig(DAQConfigWave)
@@ -349,9 +348,9 @@ Function SCOPE_CreateGraph(panelTitle, dataAcqOrTP)
 			endif
 
 			resPosPercY = 100 * (1 - ((YaxisHigh - YaxisLow) / 2 + YaxisLow))
-			sprintf str, RES_FORMAT_STR, steadyColor.red, steadyColor.green, steadyColor.blue, GetWavesDataFolder(SSResistance, 2), headstage
+			sprintf str, RES_FORMAT_STR, steadyColor.red, steadyColor.green, steadyColor.blue, GetWavesDataFolder(TPResults, 2), "ResistanceSteadyState", headstage
 			TextBox/W=$graph/A=RT/B=1/F=0/X=-10 /Y=(resPosPercY - 1) str
-			sprintf str, RES_FORMAT_STR, peakColor.red, peakColor.green, peakColor.blue, GetWavesDataFolder(InstResistance, 2), headstage
+			sprintf str, RES_FORMAT_STR, peakColor.red, peakColor.green, peakColor.blue, GetWavesDataFolder(TPResults, 2), "ResistanceInst", headstage
 			TextBox/W=$graph/A=RT/B=1/F=0/X=-10 /Y=(resPosPercY + 1) str
 
 		endif

--- a/Packages/MIES/MIES_TestPulse.ipf
+++ b/Packages/MIES/MIES_TestPulse.ipf
@@ -21,7 +21,11 @@ static Constant TP_EVAL_POINT_OFFSET          = 5
 Function TP_CreateTPAvgBuffer(panelTitle)
 	string panelTitle
 
-	NVAR tpBufferSize = $GetTPBufferSizeGlobal(panelTitle)
+	variable tpBufferSize
+
+	// tpBufSizeGlobal determines the number of TP cycles to average at end of TP_Delta
+	tpBufferSize = DAG_GetNumericalValue(panelTitle, "setvar_Settings_TPBuffer")
+
 	WAVE TPBaselineBuffer = GetGetBaselineBuffer(panelTitle)
 	WAVE TPInstBuffer = GetInstantaneousBuffer(panelTitle)
 	WAVE TPSSBuffer = GetSteadyStateBuffer(panelTitle)
@@ -40,7 +44,6 @@ Function TP_ReadTPSettingFromGUI(panelTitle)
 	NVAR AmplitudeVC = $GetTPAmplitudeVC(panelTitle)
 	NVAR AmplitudeIC = $GetTPAmplitudeIC(panelTitle)
 	NVAR baselineFrac = $GetTestpulseBaselineFraction(panelTitle)
-	NVAR tpBufSizeGlobal = $GetTPBufferSizeGlobal(panelTitle)
 
 	pulseDuration = DAG_GetNumericalValue(panelTitle, "SetVar_DataAcq_TPDuration")
 	// pulseDuration in ms, SampInt in microSec, test pulse mode ignores sample int multiplier for DAQ
@@ -51,8 +54,6 @@ Function TP_ReadTPSettingFromGUI(panelTitle)
 	AmplitudeVC = DAG_GetNumericalValue(panelTitle, "SetVar_DataAcq_TPAmplitude")
 	AmplitudeIC = DAG_GetNumericalValue(panelTitle, "SetVar_DataAcq_TPAmplitudeIC")
 
-	// tpBufSizeGlobal determines the number of TP cycles to average at end of TP_Delta
-	tpBufSizeGlobal = DAG_GetNumericalValue(panelTitle, "setvar_Settings_TPBuffer")
 End
 
 /// @brief Return the total length of a single testpulse with baseline
@@ -159,7 +160,7 @@ Function TP_ROAnalysis(dfr, err, errmsg)
 	string errmsg
 
 	variable i, j, bufSize
-	variable posMarker, posAsync
+	variable posMarker, posAsync, tpBufferSize
 	variable posBaseline, posSSRes, posInstRes
 
 	if(err)
@@ -215,7 +216,7 @@ Function TP_ROAnalysis(dfr, err, errmsg)
 			KillOrMoveToTrash(wv=asyncBuffer)
 		endif
 
-		NVAR tpBufferSize = $GetTPBufferSizeGlobal(panelTitle)
+		tpBufferSize = DAG_GetNumericalValue(panelTitle, "setvar_Settings_TPBuffer")
 		if(tpBufferSize > 1)
 			DFREF dfr = GetDeviceTestPulse(panelTitle)
 			WAVE/SDFR=dfr TPBaselineBuffer, TPInstBuffer, TPSSBuffer

--- a/Packages/MIES/MIES_TestPulse_Multi.ipf
+++ b/Packages/MIES/MIES_TestPulse_Multi.ipf
@@ -209,6 +209,8 @@ Function TPM_BkrdTPFuncMD(s)
 		hardwareType = ActiveDeviceList[i][%HardwareType]
 		panelTitle = HW_GetMainDeviceName(hardwareType, deviceID)
 
+		WAVE TPSettingsCalc = GetTPsettingsCalculated(panelTitle)
+
 		switch(hardwareType)
 			case HARDWARE_NI_DAC:
 				// Pull data until end of FIFO, after BGTask finishes Graph shows only last update
@@ -302,8 +304,7 @@ Function TPM_BkrdTPFuncMD(s)
 
 			// extract the last fully completed chunk
 			// for ITC only the last complete TP is evaluated, all earlier TPs get discarded
-			tpLengthPoints = ROVAR(GetTestPulseLengthInPoints(panelTitle, TEST_PULSE_MODE))
-			lastTP = trunc(fifoLatest / tpLengthPoints) - 1
+			lastTP = trunc(fifoLatest / TPSettingsCalc[%totalLengthPointsTP]) - 1
 
 			// Ensures that the new TP chunk isn't the same as the last one.
 			// This is required to keep the TP buffer in sync.

--- a/Packages/Testing-MIES/UTF_HardwareMain.ipf
+++ b/Packages/Testing-MIES/UTF_HardwareMain.ipf
@@ -424,14 +424,15 @@ End
 ///        as reentry part of the given test case.
 ///
 /// Does nothing if the reentry function does not exist. Supports both plain test cases and multi data test cases
-/// accepting string arguments.
+/// accepting string/ref wave arguments.
 Function RegisterReentryFunction(string testcase)
 
 	string reentryFuncName = testcase + "_REENTRY"
 	FUNCREF TEST_CASE_PROTO reentryFuncPlain = $reentryFuncName
 	FUNCREF TEST_CASE_PROTO_MD_STR reentryFuncMDStr = $reentryFuncName
+	FUNCREF TEST_CASE_PROTO_MD_WVWAVEREF reentryFuncRefWave = $reentryFuncName
 
-	if(FuncRefIsAssigned(FuncRefInfo(reentryFuncPlain)) || FuncRefIsAssigned(FuncRefInfo(reentryFuncMDStr)))
+	if(FuncRefIsAssigned(FuncRefInfo(reentryFuncPlain)) || FuncRefIsAssigned(FuncRefInfo(reentryFuncMDStr)) || FuncRefIsAssigned(FuncRefInfo(reentryFuncRefWave)))
 		CtrlNamedBackGround DAQWatchdog, start, period=120, proc=WaitUntilDAQDone_IGNORE
 		CtrlNamedBackGround TPWatchdog, start, period=120, proc=WaitUntilTPDone_IGNORE
 		RegisterUTFMonitor(TASKNAMES + "DAQWatchdog;TPWatchdog", BACKGROUNDMONMODE_AND, reentryFuncName, timeout = 600, failOnTimeout = 1)

--- a/Packages/Testing-MIES/UTF_HardwareMain.ipf
+++ b/Packages/Testing-MIES/UTF_HardwareMain.ipf
@@ -1167,3 +1167,15 @@ Function/S GetExperimentNWBFileForExport()
 
 	return S_path + experimentName + ".nwb"
 End
+
+Function StopTPWhenWeHaveOne(STRUCT WMBackgroundStruct &s)
+	SVAR devices = $GetDevicePanelTitleList()
+	string device = StringFromList(0, devices)
+
+	if(TP_TestPulseHasCycled(device, 1))
+		PGC_SetAndActivateControl(device, "StartTestPulseButton")
+		return 1
+	endif
+
+	return 0
+End

--- a/Packages/Testing-MIES/UTF_Main.ipf
+++ b/Packages/Testing-MIES/UTF_Main.ipf
@@ -15,6 +15,7 @@
 #include "UTF_PGCSetAndActivateControl"
 #include "UTF_StimsetAPI"
 #include "UTF_SweepFormula"
+#include "UTF_Testpulse"
 #include "UTF_TraceUserData"
 #include "UTF_UpgradeDataFolderLocation"
 #include "UTF_UpgradeWaveLocationAndGetIt"
@@ -66,6 +67,7 @@ Function RunWithOpts([string testcase, string testsuite, variable allowdebug])
 	list = AddListItem("UTF_Pressure.ipf", list, ";", inf)
 	list = AddListItem("UTF_StimsetAPI.ipf", list, ";", inf)
 	list = AddListItem("UTF_SweepFormula.ipf", list, ";", inf)
+	list = AddListItem("UTF_Testpulse.ipf", list, ";", inf)
 	list = AddListItem("UTF_TraceUserData.ipf", list, ";", inf)
 	list = AddListItem("UTF_UpgradeDataFolderLocation.ipf", list, ";", inf)
 	list = AddListItem("UTF_UpgradeWaveLocationAndGetIt.ipf", list, ";", inf)

--- a/Packages/Testing-MIES/UTF_Testpulse.ipf
+++ b/Packages/Testing-MIES/UTF_Testpulse.ipf
@@ -1,0 +1,36 @@
+﻿#pragma TextEncoding = "UTF-8"
+#pragma rtGlobals=3 // Use modern global access method and strict wave access.
+#pragma rtFunctionErrors=1
+#pragma ModuleName=UTF_Testpulse
+
+static Function AveragingWorks()
+	// rows: values
+	// cols: headstages
+	// layers: buffered entries
+	Make/FREE/N=(2, 1, 3) buffer = NaN
+	SetNumberInWaveNote(buffer, NOTE_INDEX, 0)
+
+	Make/FREE results = {1, 2}
+
+	MIES_TP#TP_CalculateAverage(buffer, results)
+	CHECK_EQUAL_WAVES({{{1, 2}}, {{NaN, NaN}}, {{NaN, NaN}}}, buffer, mode = WAVE_DATA)
+	CHECK_EQUAL_WAVES({1, 2}, results, mode = WAVE_DATA)
+
+	results = {3, 4}
+	MIES_TP#TP_CalculateAverage(buffer, results)
+
+	CHECK_EQUAL_WAVES({{{3, 4}}, {{1, 2}}, {{NaN, NaN}}}, buffer, mode = WAVE_DATA)
+	CHECK_EQUAL_WAVES({2, 3}, results, mode = WAVE_DATA)
+
+	results = {5, 6}
+	MIES_TP#TP_CalculateAverage(buffer, results)
+
+	CHECK_EQUAL_WAVES({{{5, 6}}, {{3, 4}}, {{1, 2}}}, buffer, mode = WAVE_DATA)
+	CHECK_EQUAL_WAVES({3, 4}, results, mode = WAVE_DATA)
+
+	results = {7, 8}
+	MIES_TP#TP_CalculateAverage(buffer, results)
+
+	CHECK_EQUAL_WAVES({{{7, 8}}, {{5, 6}}, {{3, 4}}}, buffer, mode = WAVE_DATA)
+	CHECK_EQUAL_WAVES({5, 6}, results, mode = WAVE_DATA)
+End

--- a/Packages/doc/TPAnalysis_algorithm.rst
+++ b/Packages/doc/TPAnalysis_algorithm.rst
@@ -176,11 +176,6 @@ Retrieve device specific Current Clamp and Voltage Clamp amplitudes. The values
 are in ``pA`` and ``mV`` and can be set on the front panel in the tab
 "Data Acquisition". Default: -50 pA / 10 mV.
 
-.. code-block:: igorpro
-
-   NVAR/SDFR=dfr amplitudeICGlobal = amplitudeIC
-   NVAR/SDFR=dfr amplitudeVCGlobal = amplitudeVC
-
 Retrieve the column of the first ADC channel in OscilloscopeData wave,
 due to the DAC, ADC, TTL order it is 1 for one enabled head stage,
 2 for two enabled head stages a.s.o.
@@ -197,35 +192,15 @@ stage operates in current clamp or voltage clamp mode.
 
    WAVE activeHSProp = GetActiveHSProperties(panelTitle)
 
-Duration of the test pulse (active time) in points.
-
-.. code-block:: igorpro
-
-   NVAR duration     = $GetTestpulseDuration(panelTitle)
-
 The test pulse is centered on a baseline, the baselineFrac is a number < 1, that
 defines the fraction in front and after the test pulse. Example: With a typical
 value of 0.25 for baselineFrac, the whole test pulse consists of parts of
 0.25_baseline + 0.5_testpulse + 0.25_baseline.
 
-.. code-block:: igorpro
-
-   NVAR baselineFrac = $GetTestpulseBaselineFraction(panelTitle)
-
-Length of the test pulse in points
-
-.. code-block:: igorpro
-
-   lengthTPInPoints  = TP_GetTestPulseLengthInPoints(panelTitle)
-
 Length of the buffer that stores previous results of ``BaselineSSAvg``,
 ``SSResistance`` and ``InstResistance`` for a running average. The running
 average is later applied by :cpp:func:`TP_CalculateAverage` if the size is > 1.
 The size is set on the front panel in the *Settings* tab.
-
-.. code-block:: igorpro
-
-   NVAR tpBufferSize = $GetTPBufferSizeGlobal(panelTitle)
 
 The later resistance calculation is based on R = U / I. Since R is always
 positive, the sign of the local clamp current/voltage variables is removed.


### PR DESCRIPTION
This is a preparational PR for #1016.

- [x] TPSettingsCalc[%totalLengthPointsTP] is not an integer anymore, therefore TPDuringDAQTPStoreCheck now fails for NI hardware.
- [x] Adapt developer documentation to tell people that AD/DA have to be connected.

Close #1015.