### PR TITLE
DC_GetConfiguration: Use NaN for "Set Cycle Count" in TP case

### DIFF
--- a/Packages/MIES/MIES_DataConfigurator.ipf
+++ b/Packages/MIES/MIES_DataConfigurator.ipf
@@ -1377,10 +1377,12 @@ static Function [STRUCT DataConfigurationResult s] DC_GetConfiguration(string pa
 		endif
 
 		if(dataAcqOrTP == TEST_PULSE_MODE)
-			s.setColumn[i] = 0
+			s.setColumn[i]     = 0
+			s.setCycleCount[i] = NaN
 		elseif(config[i][%DAQChannelType] == DAQ_CHANNEL_TYPE_TP)
 			// DATA_ACQUISITION_MODE cases
-			s.setColumn[i] = 0
+			s.setColumn[i]     = 0
+			s.setCycleCount[i] = NaN
 		elseif(config[i][%DAQChannelType] == DAQ_CHANNEL_TYPE_DAQ)
 			// only call DC_CalculateChannelColumnNo for real data acquisition
 			[ret, setCycleCountLocal] = DC_CalculateChannelColumnNo(panelTitle, s.setName[i], channel, CHANNEL_TYPE_DAC)

--- a/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
+++ b/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
@@ -1631,7 +1631,7 @@ Function RepeatSets_8_REENTRY([str])
 
 	t.acquiredStimSets_HS1      = "Testpulse"
 	t.sweepCount_HS1            = {0, 0, 0, 0}
-	t.setCycleCount_HS1         = {0, 0, 0, 0}
+	t.setCycleCount_HS1         = {NaN, NaN, NaN, NaN}
 	WAVEClear t.stimsetCycleID_HS1
 
 	t.DAQChannelTypeDA = {DAQ_CHANNEL_TYPE_DAQ, DAQ_CHANNEL_TYPE_TP, NaN, NaN, NaN, NaN, NaN, NaN, NaN}
@@ -1676,7 +1676,7 @@ Function RepeatSets_9_REENTRY([str])
 
 	t.acquiredStimSets_HS1      = "Testpulse"
 	t.sweepCount_HS1            = {0, 0, 0, 0}
-	t.setCycleCount_HS1         = {0, 0, 0, 0}
+	t.setCycleCount_HS1         = {NaN, NaN, NaN, NaN}
 	WAVEClear t.stimsetCycleID_HS1
 
 	t.DAQChannelTypeDA = {DAQ_CHANNEL_TYPE_DAQ, DAQ_CHANNEL_TYPE_TP, NaN, NaN, NaN, NaN, NaN, NaN, NaN}
@@ -3348,6 +3348,9 @@ Function TPDuringDAQTPAndAssoc_REENTRY([str])
 	WAVE numericalValues = GetLBNumericalValues(str)
 	WAVE textualValues = GetLBTextualValues(str)
 
+	WAVE/Z setCycleCount = GetLastSetting(numericalValues, sweepNo, "Set Cycle Count", DATA_ACQUISITION_MODE)
+	CHECK_WAVE(setCycleCount, NULL_WAVE)
+
 	WAVE DAChannelTypes = GetLastSetting(numericalValues, sweepNo, "DA ChannelType", DATA_ACQUISITION_MODE)
 	CHECK_EQUAL_WAVES(DAChannelTypes, {DAQ_CHANNEL_TYPE_TP, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode = WAVE_DATA)
 
@@ -3426,6 +3429,9 @@ Function TPDuringDAQ_REENTRY([str])
 
 	WAVE numericalValues = GetLBNumericalValues(str)
 	WAVE textualValues = GetLBTextualValues(str)
+
+	WAVE setCycleCount = GetLastSetting(numericalValues, sweepNo, "Set Cycle Count", DATA_ACQUISITION_MODE)
+	CHECK_EQUAL_WAVES(setCycleCount, {NaN, 0, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode = WAVE_DATA)
 
 	WAVE DAChannelTypes = GetLastSetting(numericalValues, sweepNo, "DA ChannelType", DATA_ACQUISITION_MODE)
 	CHECK_EQUAL_WAVES(DAChannelTypes, {DAQ_CHANNEL_TYPE_TP, DAQ_CHANNEL_TYPE_DAQ, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode = WAVE_DATA)


### PR DESCRIPTION
The labnotebook entry "Set Cycle Count" only makes sense when doing DAQ or
channels with DAQ channel type.

Close #1024