### PR TITLE
.gitignore: Ignore all NWB files in tools/testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,4 @@ bld/
 [Oo]bj/
 UserConfig*.txt
 JU_*.xml
-tools/unit-testing/HardwareTests.nwb
+tools/unit-testing/HardwareTests*.nwb


### PR DESCRIPTION
This also catches the new naming scheme introduced in 989fa8ff (UTF_TestNWBExportV1.ipf: Use -V1 suffix for NWB files, 2020-02-09).
