### PR TITLE
DAP_AddUserComment: Handle non-existing window

### DIFF
--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -4319,6 +4319,10 @@ static Function DAP_AddUserComment(panelTitle)
 	string commentNotebook, comment, formattedComment
 	variable sweepNo
 
+	if(!WindowExists(panelTitle))
+		return NaN
+	endif
+
 	comment = DAG_GetTextualValue(panelTitle, "SetVar_DataAcq_Comment")
 
 	if(isEmpty(comment))


### PR DESCRIPTION
Ever since d1c250ca (DAP_SerializeCommentNotebook: Add user comment from set variable, 2021-10-02)
ba83aae3 and (DAP_SerializeCommentNotebook: Call it before exporting the comment into NWB, 2021-10-02)
we do call DAP_AddUserComment() from the NWB export path.
But that also means that the pxp could be reopened and therefore the original
device window not being open anymore.

Let's just not do anything here in this case.

Closes #1134.

I can export the pxps with that fix.

@sfowen Does that fix the issue for you as well?