### PR TITLE
bugfix SweepFormula use of previous X-values in multi-plot

### DIFF
--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -800,7 +800,9 @@ static Function SF_FormulaPlotter(string graph, string formula, [DFREF dfr, vari
 		endfor
 	endif
 
+	WAVE/Z wvX
 	for(j = 0; j < numGraphs; j += 1)
+		WaveClear wvX
 		xFormula = formulaPairs[j][%FORMULA_X]
 		if(!IsEmpty(xFormula))
 			WAVE/Z wv = SF_FormulaExecutor(SF_FormulaParser(SF_FormulaPreParser(xFormula)), graph = graph)


### PR DESCRIPTION
When plotting multiple graphs in a panel then the wave with the
x-values were not properly cleared and thus reused on a following
plot where no X-values were specified.

This wave is now properly cleared.

since b257f7999e7b6445e116b33140dbc18dba9558a9

Close https://github.com/AllenInstitute/MIES/issues/1160  :sparkles:!

