### PR TITLE
Docu for CI hints to inhibit tests

### DIFF
--- a/Packages/doc/developers.rst
+++ b/Packages/doc/developers.rst
@@ -316,6 +316,23 @@ Where ``$prefix`` is one of ``feature``/``bugfix``, ``$pr`` is the number of the
 Contributers are encouraged to install the ``pre-push`` git hook from the tools directory. The script
 ``tools/nextFreePRNumber.sh`` can get the soon-to-be-created PR number on the commandline (requires curl and jq) as well.
 
+Continuous Integration Hints
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+As part of the continuous integration pipeline tests are run. A full test run including the hardware tests
+tales several hours. Thus, if a lot of pull requests are updated pending test runs could queue up and
+it might take rather long until results are available.
+
+Thus, for changes where the commits are in a state where no full test run by the CI makes sense it is
+possible to inhibit the automatic tests. Typically this is the case if the developer commits changes
+in progress and pushes these for the purpose of a secondary backup or further commit organization.
+Inhibiting tests for these cases frees testing resources for other pull requests.
+
+To inhibit test runs the key ``[SKIP CI]`` has to be added to the commit message.
+
+The key can be removed later easily through a rebase with rewording the commit message.
+After pushing to the repository the CI queues the tests again for this pull request.
+
 Debugging threadsafe functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This PR tested the new CI config to prevent test runs by including the [SKIP CI] tag in a commit message.

Added documentation to describe the new key word for commit messages that inhibits test runs on the CI (bamboo).