### PR TITLE
tools/sign-installer.sh: Return error code from sign_tool

### DIFF
--- a/tools/sign-installer.sh
+++ b/tools/sign-installer.sh
@@ -42,6 +42,4 @@ fi
 # signtool does not accept a path for the certificate
 cp $top_level/tools/installer/public-key.cer public-key.cer
 
-MSYS_NO_PATHCONV=1 "$sign_tool_exe" sign /tr http://timestamp.sectigo.com /fd sha256 /td sha256 /csp "eToken Base Cryptographic Provider" /kc $(cat ~/.credentials/code-signing) /f public-key.cer tools/installer/MIES*.exe
-
-rm -f signing.cer
+MSYS_NO_PATHCONV=1 "$sign_tool_exe" sign /tr http://timestamp.sectigo.com /fd sha256 /td sha256 /csp "eToken Base Cryptographic Provider" /kc $(cat ~/.credentials/code-signing) /f public-key.cer tools/installer/MIES*.exe || exit $?


### PR DESCRIPTION
This makes CI fail when the signing fails.

Broken since 7399680d (tools/sign-installer.sh: Add script to sign the
installer, 2021-09-24).
