### PR TITLE
LBV_CheckIfXAxisIsTime: Tweak default value depending on existing sweeps

### DIFF
--- a/Packages/MIES/MIES_LogbookViewer.ipf
+++ b/Packages/MIES/MIES_LogbookViewer.ipf
@@ -850,9 +850,11 @@ static Function LBV_CheckIfXAxisIsTime(string graph)
 
 	list = TraceNameList(graph, ";", 0 + 1)
 
-	// default is sweep axis
 	if(isEmpty(list))
-		return 0
+		WAVE/Z sweeps = GetPlainSweepList(graph)
+		// use sweeps axis as default if we have sweeps, use time axis otherwise
+		// this is useful for plotting TP data without any sweep data
+		return !WaveExists(sweeps)
 	endif
 
 	trace = StringFromList(0, list)


### PR DESCRIPTION
The default x axis of the logbook graph was always "sweeps". This is
good for acquired sweep data.

But if you play around with TP only, you currently don't see anything
when adding an entry as there are no sweeps, and plotting something
against NaN does not create anything in the graph.

So let's use a time axis if we don't have sweeps.