### PR TITLE
fix wrong usage of BSP_GetLBNWave, return wave requires check against null wave

### DIFF
--- a/Packages/MIES/MIES_ArtefactRemoval.ipf
+++ b/Packages/MIES/MIES_ArtefactRemoval.ipf
@@ -382,7 +382,8 @@ Function AR_UpdateTracesIfReq(graph, sweepFolder, sweepNo)
 		return NaN
 	endif
 
-	WAVE numericalValues = BSP_GetLBNWave(device, LBN_NUMERICAL_VALUES, sweepNumber = sweepNo)
+	WAVE/Z numericalValues = BSP_GetLBNWave(device, LBN_NUMERICAL_VALUES, sweepNumber = sweepNo)
+	ASSERT(WaveExists(numericalValues), "Numerical LabNotebook not found.")
 
 	DFREF singleSweepDFR = GetSingleSweepFolder(sweepFolder, sweepNo)
 	WAVE ranges = AR_ComputeRanges(singleSweepDFR, sweepNo, numericalValues)

--- a/Packages/MIES/MIES_BrowserSettingsPanel.ipf
+++ b/Packages/MIES/MIES_BrowserSettingsPanel.ipf
@@ -1281,6 +1281,7 @@ End
 /// @param type              One of @ref LabnotebookWaveTypes
 /// @param sweepNumber       [optional] sweep number
 /// @param selectedExpDevice [optional, defaults to off] return the labnotebook for the selected experiment/device combination
+/// @returns returns the specified labnotebook wave or a null wave
 Function/WAVE BSP_GetLBNWave(string win, variable type, [variable sweepNumber, variable selectedExpDevice])
 	string shPanel, device, dataFolder
 
@@ -1562,7 +1563,8 @@ Function BSP_AddTracesForEpochs(string win)
 		headstage   = str2num(traceInfos[j][%headstage])
 		sweepNumber = str2num(traceInfos[j][%sweepNumber])
 
-		WAVE/T textualValues = BSP_GetlBNWave(win, LBN_TEXTUAL_VALUES, sweepNumber = sweepNumber)
+		WAVE/Z/T textualValues = BSP_GetlBNWave(win, LBN_TEXTUAL_VALUES, sweepNumber = sweepNumber)
+		ASSERT(WaveExists(textualValues), "Textual LabNotebook not found.")
 
 		WAVE/T epochLBEntries = GetLastSetting(textualValues, sweepNumber, EPOCHS_ENTRY_KEY, DATA_ACQUISITION_MODE)
 		WAVE/T epochs = EP_EpochStrToWave(epochLBEntries[headstage])

--- a/Packages/MIES/MIES_LogbookViewer.ipf
+++ b/Packages/MIES/MIES_LogbookViewer.ipf
@@ -243,18 +243,23 @@ End
 ///
 /// @return valid waves or null if it can not be found.
 Function [WAVE keys, WAVE values] LBV_GetLNBWavesForEntry(string win, string key)
+
 	variable col
 
-	WAVE numericalKeys   = BSP_GetLBNWave(win, LBN_NUMERICAL_KEYS, selectedExpDevice = 1)
-	WAVE numericalValues = BSP_GetLBNWave(win, LBN_NUMERICAL_VALUES, selectedExpDevice = 1)
-
-	WAVE textualKeys   = BSP_GetLBNWave(win, LBN_TEXTUAL_KEYS, selectedExpDevice = 1)
-	WAVE textualValues = BSP_GetLBNWave(win, LBN_TEXTUAL_VALUES, selectedExpDevice = 1)
+	WAVE/Z numericalKeys   = BSP_GetLBNWave(win, LBN_NUMERICAL_KEYS, selectedExpDevice = 1)
+	ASSERT(WaveExists(numericalKeys), "Numerical LabNotebook Keys not found.")
+	WAVE/Z numericalValues = BSP_GetLBNWave(win, LBN_NUMERICAL_VALUES, selectedExpDevice = 1)
+	ASSERT(WaveExists(numericalValues), "Numerical LabNotebook not found.")
 
 	col = FindDimLabel(numericalValues, COLS, key)
 	if(col >= 0)
 		return [numericalKeys, numericalValues]
 	endif
+
+	WAVE/Z textualKeys   = BSP_GetLBNWave(win, LBN_TEXTUAL_KEYS, selectedExpDevice = 1)
+	ASSERT(WaveExists(textualKeys), "Textual LabNotebook keys not found.")
+	WAVE/Z textualValues = BSP_GetLBNWave(win, LBN_TEXTUAL_VALUES, selectedExpDevice = 1)
+	ASSERT(WaveExists(textualValues), "Textual LabNotebook not found.")
 
 	col = FindDimLabel(textualValues, COLS, key)
 	if(col >= 0)
@@ -569,7 +574,8 @@ static Function LBV_AddTraceToLBGraphTPStorage(string graph, DFREF dfr, string k
 
 	axisBaseName = "tpstorage_" + VERT_AXIS_BASE_NAME
 
-	WAVE numericalValues = BSP_GetLBNWave(graph, LBN_NUMERICAL_VALUES, selectedExpDevice = 1)
+	WAVE/Z numericalValues = BSP_GetLBNWave(graph, LBN_NUMERICAL_VALUES, selectedExpDevice = 1)
+	ASSERT(WaveExists(numericalValues), "LabNotebook not found.")
 
 	// 5872e556 (Modified files: DR_MIES_TangoInteract:  changes recommended by Thomas ..., 2014-09-11)
 	//

--- a/Packages/MIES/MIES_OverlaySweeps.ipf
+++ b/Packages/MIES/MIES_OverlaySweeps.ipf
@@ -216,7 +216,8 @@ Function OVS_UpdatePanel(string win, [variable fullUpdate])
 		return NaN
 	endif
 
-	WAVE/WAVE allNumericalValues = BSP_GetLBNWave(win, LBN_NUMERICAL_VALUES)
+	WAVE/Z/WAVE allNumericalValues = BSP_GetLBNWave(win, LBN_NUMERICAL_VALUES)
+	ASSERT(WaveExists(allNumericalValues), "Numerical LabNotebook not found.")
 
 	numEntries = DimSize(sweeps, ROWS)
 	Redimension/N=(numEntries, -1, -1) listBoxWave, listBoxSelWave, headstageRemoval
@@ -288,8 +289,10 @@ Function OVS_UpdateSweepSelectionChoices(string win, WAVE/T sweepSelectionChoice
 		return NaN
 	endif
 
-	WAVE/WAVE allNumericalValues = BSP_GetLBNWave(win, LBN_NUMERICAL_VALUES)
-	WAVE/WAVE allTextualValues   = BSP_GetLBNWave(win, LBN_TEXTUAL_VALUES)
+	WAVE/Z/WAVE allNumericalValues = BSP_GetLBNWave(win, LBN_NUMERICAL_VALUES)
+	ASSERT(WaveExists(allNumericalValues), "Numerical LabNotebook not found.")
+	WAVE/Z/WAVE allTextualValues   = BSP_GetLBNWave(win, LBN_TEXTUAL_VALUES)
+	ASSERT(WaveExists(allTextualValues), "Textual LabNotebook not found.")
 
 	numEntries = DimSize(sweeps, ROWS)
 	Redimension/N=(numEntries, -1, -1, -1) sweepSelectionChoices

--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -1273,7 +1273,10 @@ static Function/WAVE SF_GetActiveChannelNumbers(graph, channels, sweeps, entrySo
 			continue
 		endif
 
-		WAVE numericalValues = BSP_GetLBNWave(graph, LBN_NUMERICAL_VALUES, sweepNumber = sweepNo)
+		WAVE/Z numericalValues = BSP_GetLBNWave(graph, LBN_NUMERICAL_VALUES, sweepNumber = sweepNo)
+		if(!WaveExists(numericalValues))
+			continue
+		endif
 
 		for(j = 0; j < DimSize(channels, ROWS); j += 1)
 			channelType = channels[j][0]
@@ -1604,8 +1607,11 @@ static Function/WAVE SF_OperationEpochs(variable jsonId, string jsonPath, string
 			continue
 		endif
 
-		WAVE numericalValues = BSP_GetLBNWave(graph, LBN_NUMERICAL_VALUES, sweepNumber = sweepNo)
-		WAVE textualValues = BSP_GetLBNWave(graph, LBN_TEXTUAL_VALUES, sweepNumber = sweepNo)
+		WAVE/Z numericalValues = BSP_GetLBNWave(graph, LBN_NUMERICAL_VALUES, sweepNumber = sweepNo)
+		WAVE/Z textualValues = BSP_GetLBNWave(graph, LBN_TEXTUAL_VALUES, sweepNumber = sweepNo)
+		if(!WaveExists(numericalValues) || !WaveExists(textualValues))
+			continue
+		endif
 
 		for(j = 0; j <  activeChannelCnt; j += 1)
 			[settings, index] = GetLastSettingChannel(numericalValues, textualValues, sweepNo, EPOCHS_ENTRY_KEY, activeChannels[j][%channelNumber], activeChannels[j][%channelType], DATA_ACQUISITION_MODE)
@@ -2145,8 +2151,11 @@ static Function/WAVE SF_OperationLabnotebook(variable jsonId, string jsonPath, s
 			continue
 		endif
 
-		WAVE numericalValues = BSP_GetLBNWave(graph, LBN_NUMERICAL_VALUES, sweepNumber = sweepNo)
-		WAVE textualValues = BSP_GetLBNWave(graph, LBN_TEXTUAL_VALUES, sweepNumber = sweepNo)
+		WAVE/Z numericalValues = BSP_GetLBNWave(graph, LBN_NUMERICAL_VALUES, sweepNumber = sweepNo)
+		WAVE/Z textualValues = BSP_GetLBNWave(graph, LBN_TEXTUAL_VALUES, sweepNumber = sweepNo)
+		if(!WaveExists(numericalValues) || !WaveExists(textualValues))
+			continue
+		endif
 
 		for(j = 0; j <  DimSize(activeChannels, ROWS); j += 1)
 			[settings, index] = GetLastSettingChannel(numericalValues, textualValues, sweeps[i], str, activeChannels[j][%channelNumber], activeChannels[j][%channelType], mode)


### PR DESCRIPTION
The MIES code had locations where BSP_GetLBNWave was used without properly
checking if the returned wave is a null wave.

Occurrences with that flaw were reviewed and adapted to react properly to
a returned null wave.
