### PR TITLE
Documentation: Clean docu output folders on new documentation build

### DIFF
--- a/tools/build-documentation.sh
+++ b/tools/build-documentation.sh
@@ -37,6 +37,8 @@ echo "Start building the documentation"
 
 cd "$top_level/Packages/doc"
 
+git clean -fdx xml struct group file namespace _images html
+
 output=$( (cat Doxyfile ; echo "HAVE_DOT = NO" ; echo "GENERATE_HTML = NO") | doxygen - 2>&1  >/dev/null | grep -v "warning: ignoring unsupported tag" )
 
 if [ ! -z  "$output" ]


### PR DESCRIPTION
- output folders xml, struct, group, file, namespace, _images and html
  are cleaned to the checked-in files only before a new build is attempted.
