### PR TITLE
Track analysis function calls in labnotebook

### DIFF
--- a/Packages/MIES/MIES_AcquisitionStateHandling.ipf
+++ b/Packages/MIES/MIES_AcquisitionStateHandling.ipf
@@ -70,6 +70,8 @@ Function AS_HandlePossibleTransition(string device, variable newAcqState, [varia
 
 	if(oldAcqState == AS_PRE_SWEEP && newAcqState == AS_MID_SWEEP)
 		ED_MarkSweepStart(device)
+	elseif(newAcqState == AS_PRE_SWEEP_CONFIG)
+		DC_ClearWaves(device)
 	endif
 
 #ifdef AUTOMATED_TESTING

--- a/Packages/MIES/MIES_AcquisitionStateHandling.ipf
+++ b/Packages/MIES/MIES_AcquisitionStateHandling.ipf
@@ -74,6 +74,14 @@ Function AS_HandlePossibleTransition(string device, variable newAcqState, [varia
 		DC_ClearWaves(device)
 	endif
 
+	if(newAcqState == AS_PRE_DAQ)
+		AFM_ClearCallCount(device)
+	elseif(oldAcqState == AS_ITI && newAcqState == AS_PRE_SWEEP_CONFIG \
+		   || oldAcqState == AS_POST_DAQ && newAcqState == AS_INACTIVE)
+		ED_WriteAnalysisFunctionCallCount(device)
+		AFM_ClearCallCount(device)
+	endif
+
 #ifdef AUTOMATED_TESTING
 	AS_RecordStateTransition(oldAcqState, newAcqState)
 #endif

--- a/Packages/MIES/MIES_AnalysisFunctionManagement.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctionManagement.ipf
@@ -128,6 +128,7 @@ Function AFM_CallAnalysisFunctions(device, eventType)
 				s.sweepsInSet        = sweepsInSet
 				s.params             = analysisFunctions[i][ANALYSIS_FUNCTION_PARAMS]
 
+				AFM_IncreaseCallCount(device, i, eventType)
 				ret = f3(device, s); AbortOnRTE
 			else
 				ASSERT(0, "impossible case")
@@ -212,4 +213,19 @@ Function AFM_UpdateAnalysisFunctionWave(device)
 
 		analysisFunctions[i][ANALYSIS_FUNCTION_PARAMS] = ExtractAnalysisFunctionParams(stimSet)
 	endfor
+End
+
+Function AFM_ClearCallCount(string device)
+	WAVE callCount = GetAnalysisFunctionCallCount(device)
+	callCount[][] = NaN
+End
+
+static Function AFM_IncreaseCallCount(string device, variable headstage, variable event)
+	WAVE callCount = GetAnalysisFunctionCallCount(device)
+
+	if(IsNaN(callCount[headstage][event]))
+		callCount[headstage][event] = 1
+	else
+		callCount[headstage][event] +=1
+	endif
 End

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -638,7 +638,7 @@ Constant ANALYSISBROWSER_PANEL_VERSION    =  1
 /// - Changed names of entries
 /// - Changed units or meaning of entries
 /// - New/Changed layers of entries
-Constant LABNOTEBOOK_VERSION = 53
+Constant LABNOTEBOOK_VERSION = 54
 
 /// Version of the stimset wave note
 Constant STIMSET_NOTE_VERSION = 7

--- a/Packages/MIES/MIES_DataConfigurator.ipf
+++ b/Packages/MIES/MIES_DataConfigurator.ipf
@@ -20,9 +20,6 @@ static Function DC_UpdateGlobals(string device, variable dataAcqOrTP)
 
 	TP_UpdateTPSettingsCalculated(device)
 
-	KillOrMoveToTrash(wv=GetTPSettingsLabnotebook(device))
-	KillOrMoveToTrash(wv=GetTPSettingsLabnotebookKeyWave(device))
-
 	if(dataAcqOrTP == DATA_ACQUISITION_MODE)
 		TP_UpdateTPLBNSettings(device)
 	endif
@@ -32,6 +29,21 @@ static Function DC_UpdateGlobals(string device, variable dataAcqOrTP)
 
 	NVAR fifoPosition = $GetFifoPosition(device)
 	fifoPosition = 0
+End
+
+Function DC_ClearWaves(string device)
+
+	KillOrMoveToTrash(wv=GetTPSettingsLabnotebook(device))
+	KillOrMoveToTrash(wv=GetTPSettingsLabnotebookKeyWave(device))
+
+	KillOrMoveToTrash(wv = GetTPResultsBuffer(device))
+
+	KillOrMoveToTrash(wv=GetSweepSettingsWave(device))
+	KillOrMoveToTrash(wv=GetSweepSettingsTextWave(device))
+	KillOrMoveToTrash(wv=GetSweepSettingsKeyWave(device))
+	KillOrMoveToTrash(wv=GetSweepSettingsTextKeyWave(device))
+
+	EP_ClearEpochs(device)
 End
 
 /// @brief Prepare test pulse/data acquisition
@@ -67,12 +79,9 @@ Function DC_Configure(device, dataAcqOrTP, [multiDevice])
 	variable hardwareType = GetHardwareType(device)
 	ASSERT(!HW_IsRunning(hardwareType, deviceID, flags=HARDWARE_ABORT_ON_ERROR | HARDWARE_PREVENT_ERROR_POPUP), "Hardware is still running and it shouldn't. Please report that as a bug.")
 
-	KillOrMoveToTrash(wv=GetSweepSettingsWave(device))
-	KillOrMoveToTrash(wv=GetSweepSettingsTextWave(device))
-	KillOrMoveToTrash(wv=GetSweepSettingsKeyWave(device))
-	KillOrMoveToTrash(wv=GetSweepSettingsTextKeyWave(device))
-
-	EP_ClearEpochs(device)
+	if(dataAcqOrTP == TEST_PULSE_MODE)
+		DC_ClearWaves(device)
+	endif
 
 	if(dataAcqOrTP == DATA_ACQUISITION_MODE)
 		if(AFM_CallAnalysisFunctions(device, PRE_SET_EVENT))
@@ -101,8 +110,6 @@ Function DC_Configure(device, dataAcqOrTP, [multiDevice])
 
 	NVAR ADChannelToMonitor = $GetADChannelToMonitor(device)
 	ADChannelToMonitor = DimSize(GetDACListFromConfig(DAQConfigWave), ROWS)
-
-	KillOrMoveToTrash(wv = GetTPResultsBuffer(device))
 
 	DC_MakeHelperWaves(device, dataAcqOrTP)
 	SCOPE_CreateGraph(device, dataAcqOrTP)

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -6122,6 +6122,34 @@ Function/WAVE GetAnalysisFunctionStorage(device)
 	return wv
 End
 
+/// @brief Return the call count wave for the analysis functions
+///
+/// Rows:
+/// - Head stage number
+///
+/// Columns:
+/// - 0-#TOTAL_NUM_EVENTS - 1: Counts how often the analysis function was called during a complete sweep
+Function/WAVE GetAnalysisFunctionCallCount(string device)
+	variable versionOfWave = 1
+	DFREF dfr = GetDevicePath(device)
+	WAVE/D/Z/SDFR=dfr wv = analysisFunctionCallCount
+
+	if(ExistsWithCorrectLayoutVersion(wv, versionOfWave))
+		return wv
+	elseif(WaveExists(wv))
+		 // handle upgrade
+		Redimension/N=(NUM_HEADSTAGES, TOTAL_NUM_EVENTS) wv
+	else
+		Make/D/N=(NUM_HEADSTAGES, TOTAL_NUM_EVENTS) dfr:analysisFunctionCallCount/WAVE=wv
+	endif
+
+	wv = NaN
+
+	SetWaveVersion(wv, versionOfWave)
+
+	return wv
+End
+
 /// @brief Used for storing a true/false state that the pre and/or post set event
 /// should be fired *after* the sweep which is currently prepared in DC_PlaceDataInDAQDataWave().
 ///


### PR DESCRIPTION
- [ ] Finalize
- [ ] Commit cleanup
- [ ] Tests: Ditch TrackAnalysisFunctionCalls and translate all tests to GetAnalysisFunctionCallCountsFromLBN
- [ ] One entry per event in Text LBN: Format: "$count"
- [ ] Change UNKNOWN_MODE for writing to 2, introduce new variable for "not-caring-about-entry-source" on reading, adapt cache for these changes
- [ ] Use this new entry source type for call count to avoid LBN querying issues with UNKNOWN_MODE entries being between DATA_ACQUISITION_MODE entries.
- [ ] The code in 96519036de080d84e78c6f310bcee70e3c25cadc seems odd. With calling DC_ClearWaves from AS_PRE_SWEEP_CONFIG we are now actually calling it later than before.

Close #1081.