### PR TITLE
LBN: Add units to TP settings entries

### DIFF
--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -638,7 +638,7 @@ Constant ANALYSISBROWSER_PANEL_VERSION    =  1
 /// - Changed names of entries
 /// - Changed units or meaning of entries
 /// - New/Changed layers of entries
-Constant LABNOTEBOOK_VERSION = 53
+Constant LABNOTEBOOK_VERSION = 54
 
 /// Version of the stimset wave note
 Constant STIMSET_NOTE_VERSION = 7

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -6933,11 +6933,11 @@ Function/WAVE GetTPSettingsLabnotebookKeyWave(string device)
 	wv[%Tolerance][0]  = ""
 
 	wv[%Parameter][1]  = "TP Amplitude VC"
-	wv[%Units][1]      = ""
+	wv[%Units][1]      = "pA"
 	wv[%Tolerance][1]  = ""
 
 	wv[%Parameter][2]  = "TP Amplitude IC"
-	wv[%Units][2]      = ""
+	wv[%Units][2]      = "mV"
 	wv[%Tolerance][2]  = ""
 
 	wv[%Parameter][3]  = "TP Pulse Duration"


### PR DESCRIPTION
to TP Amplitude VC: pA
   TP Amplitude IC: mV

The units are required for axis labels of graphs that show this data,
e.g. in DataBrowser.

We want to show in graphs to correct units on the axes, so we need the unit names for certain values somewhere in MIES. A good location is the LBN, because it allows to retrieve the units from the time the value was created.