### PR TITLE
Feature/1236 scaled data wave rte

### DIFF
--- a/Packages/MIES/MIES_AcquisitionStateHandling.ipf
+++ b/Packages/MIES/MIES_AcquisitionStateHandling.ipf
@@ -77,7 +77,7 @@ Function AS_HandlePossibleTransition(string device, variable newAcqState, [varia
 #endif
 
 	if(!AS_CheckStateTransition(oldAcqState, newAcqState))
-		sprintf msg, "The state transition %s -> %s is not expected.\r", AS_StateToString(oldAcqState), AS_StateToString(newAcqState)
+		sprintf msg, "The state transition %s -> %s is not expected.", AS_StateToString(oldAcqState), AS_StateToString(newAcqState)
 		BUG(msg)
 	endif
 

--- a/Packages/MIES/MIES_AnalysisFunctionManagement.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctionManagement.ipf
@@ -88,12 +88,17 @@ Function AFM_CallAnalysisFunctions(device, eventType)
 			case POST_SET_EVENT:
 			case POST_DAQ_EVENT: // fallthrough-by-design
 				sweepNo = DAG_GetNumericalValue(device, "SetVar_Sweep") - 1
-				WAVE scaledDataWave = GetSweepWave(device, sweepNo)
+				WAVE/Z scaledDataWave = GetSweepWave(device, sweepNo)
 				break
 			default:
 				ASSERT(0, "Invalid eventType")
 				break
 		endswitch
+
+		if(!WaveExists(scaledDataWave))
+			BUG("Analysis function could not be called due to missing scaledDataWave")
+			return NaN
+		endif
 
 		FUNCREF AF_PROTO_ANALYSIS_FUNC_V1 f1 = $func
 		FUNCREF AF_PROTO_ANALYSIS_FUNC_V2 f2 = $func

--- a/Packages/MIES/MIES_AnalysisFunctionManagement.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctionManagement.ipf
@@ -104,14 +104,15 @@ Function AFM_CallAnalysisFunctions(device, eventType)
 		valid_f3 = FuncRefIsAssigned(FuncRefInfo(f3))
 
 		// all functions are valid
-		WAVE DAQDataWave = GetDAQDataWave(device, DATA_ACQUISITION_MODE)
-		ChangeWaveLock(DAQDataWave, 1)
-
-		ChangeWaveLock(scaledDataWave, 1)
 
 		ret = NaN
 		AssertOnAndClearRTError()
 		try
+			WAVE DAQDataWave = GetDAQDataWave(device, DATA_ACQUISITION_MODE)
+			ChangeWaveLock(DAQDataWave, 1)
+
+			ChangeWaveLock(scaledDataWave, 1)
+
 			if(valid_f1)
 				ret = f1(device, eventType, DAQDataWave, i); AbortOnRTE
 			elseif(valid_f2)

--- a/Packages/MIES/MIES_AnalysisFunctions_Dashboard.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_Dashboard.ipf
@@ -156,9 +156,9 @@ static Function AD_FillWaves(win, list, info)
 	string win
 	WAVE/T list, info
 
-	variable i, j, headstage, passed, sweepNo, numEntries, ongoingDAQ
+	variable i, j, headstage, passed, sweepNo, numEntries, ongoingDAQ, acqState
 	variable index, anaFuncType, stimsetCycleID, firstValid, lastValid
-	string key, anaFunc, stimset, msg
+	string key, anaFunc, stimset, msg, device
 
 	WAVE/Z totalSweepsPresent = GetPlainSweepList(win)
 
@@ -168,6 +168,13 @@ static Function AD_FillWaves(win, list, info)
 
 	if(!WaveExists(numericalValuesWave) || !WaveExists(textualValuesWave) || !WaveExists(totalSweepsPresent))
 		return 0
+	endif
+
+	if(BSP_IsDataBrowser(win))
+		device = BSP_GetDevice(win)
+		acqState = ROVar(GetAcquisitionState(device))
+	else
+		acqState = AS_INACTIVE
 	endif
 
 	index = GetNumberFromWaveNote(list, NOTE_INDEX)
@@ -243,7 +250,7 @@ static Function AD_FillWaves(win, list, info)
 			else
 				key = CreateAnaFuncLBNKey(anaFuncType, PSQ_FMT_LBN_SET_PASS, query = 1)
 				passed = GetLastSettingIndepSCI(numericalValues, sweepNo, key, headstage, UNKNOWN_MODE)
-				ongoingDAQ = IsNaN(passed)
+				ongoingDAQ = IsNaN(passed) && (acqState != AS_INACTIVE)
 			endif
 
 			msg = AD_GetResultMessage(anaFuncType, passed, numericalValues, textualValues, sweepNo, headstage, ongoingDAQ)

--- a/Packages/MIES/MIES_AnalysisFunctions_Dashboard.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_Dashboard.ipf
@@ -175,7 +175,12 @@ static Function AD_FillWaves(win, list, info)
 		WAVE/Z/T anaFuncs = GetLastSetting(textualValues, sweepNo, key, DATA_ACQUISITION_MODE)
 
 		if(WaveExists(anaFuncs))
-			Make/N=(LABNOTEBOOK_LAYER_COUNT)/FREE anaFuncTypes = MapAnaFuncToConstant(anaFuncs[p])
+			if(GetLastSettingIndep(numericalValues, sweepNo, "Skip analysis functions", DATA_ACQUISITION_MODE, defValue = 0))
+				anaFuncs[] = anaFuncs[p] + " (Skipped)"
+				Make/N=(LABNOTEBOOK_LAYER_COUNT)/FREE anaFuncTypes = INVALID_ANALYSIS_FUNCTION
+			else
+				Make/N=(LABNOTEBOOK_LAYER_COUNT)/FREE anaFuncTypes = MapAnaFuncToConstant(anaFuncs[p])
+			endif
 		else
 			Make/N=(LABNOTEBOOK_LAYER_COUNT)/FREE/T anaFuncs = NOT_AVAILABLE
 			Make/N=(LABNOTEBOOK_LAYER_COUNT)/FREE anaFuncTypes = INVALID_ANALYSIS_FUNCTION

--- a/Packages/MIES/MIES_AnalysisFunctions_Dashboard.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_Dashboard.ipf
@@ -560,7 +560,8 @@ static Function/S AD_GetBaselineFailMsg(anaFuncType, numericalValues, sweepNo, h
 	variable headstage
 
 	variable i, chunkQC
-	string key, msg
+	string key
+	string msg = ""
 
 	switch(anaFuncType)
 		case PSQ_DA_SCALE:
@@ -596,7 +597,9 @@ static Function/S AD_GetBaselineFailMsg(anaFuncType, numericalValues, sweepNo, h
 					endif
 				endfor
 
-				ASSERT(!IsEmpty(msg), "Could not find a failing chunk")
+				if(IsEmpty(msg))
+					BUG("Could not find a failing chunk")
+				endif
 			endif
 			break
 	endswitch

--- a/Packages/MIES/MIES_AnalysisFunctions_Dashboard.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_Dashboard.ipf
@@ -76,11 +76,19 @@ Function AD_Update(win)
 End
 
 static Function/S AD_GetResultMessage(variable anaFuncType, variable passed, WAVE numericalValues, WAVE/T textualValues, variable sweepNo, variable headstage, variable ongoingDAQ)
+	variable stopReason
 
 	if(passed)
 		return "Pass"
-	elseif(ongoingDAQ)
-		return "Sweep not yet finished"
+	endif
+
+	if(ongoingDAQ)
+		// introduced in 87f9cbfa (DAQ: Add stopping reason to the labnotebook, 2021-05-13)
+		stopReason = GetLastSettingIndepSCI(numericalValues, sweepNo, "DAQ stop reason", headstage, UNKNOWN_MODE, defValue = NaN)
+
+		if(IsNaN(stopReason))
+			return "Sweep not yet finished"
+		endif
 	endif
 
 	// MSQ_DA

--- a/Packages/MIES/MIES_BrowserSettingsPanel.ipf
+++ b/Packages/MIES/MIES_BrowserSettingsPanel.ipf
@@ -1654,7 +1654,7 @@ Function BSP_AddTracesForEpochs(string win)
 		SetWindow $win tooltipHook(hook) = BSP_EpochGraphToolTip
 
 		DoWindow/F $win
-		ShowTraceInfoTags()
+		Execute/P/Q/Z "ShowTraceInfoTags()"
 
 		SetAxis/W=$win/A
 	endfor

--- a/Packages/MIES/MIES_BrowserSettingsPanel.ipf
+++ b/Packages/MIES/MIES_BrowserSettingsPanel.ipf
@@ -1677,10 +1677,10 @@ Function BSP_EpochGraphToolTip(s)
 			ASSERT(WaveExists(epochs), "Missing epoch info")
 			hookResult = 1 // 1 tells Igor to use our custom tooltip
 			idx = w[s.row][s.column][1]
-			first = num2strHighPrec(str2num(epochs[idx][0]) * 1000, precision = EPOCHTIME_PRECISION)
-			last  = num2strHighPrec(str2num(epochs[idx][1]) * 1000, precision = EPOCHTIME_PRECISION)
+			first = num2strHighPrec(str2num(epochs[idx][0]) * 1000, precision = EPOCHTIME_PRECISION, shorten = 1)
+			last  = num2strHighPrec(str2num(epochs[idx][1]) * 1000, precision = EPOCHTIME_PRECISION, shorten = 1)
 
-			s.tooltip = first + "<->" + last + "\n" + epochs[idx][2] + "TreeLevel=" + epochs[idx][3]
+			s.tooltip = first + " <-> " + last + "\n" + epochs[idx][2] + "TreeLevel=" + epochs[idx][3]
 		endif
 	endif
 

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -863,7 +863,7 @@ StrConstant TP_AMPLITUDE_VC_ENTRY_KEY = "TP Amplitude VC"
 StrConstant TP_AMPLITUDE_IC_ENTRY_KEY = "TP Amplitude IC"
 
 /// DA_Ephys controls which should be disabled during DAQ
-StrConstant CONTROLS_DISABLE_DURING_DAQ = "Check_DataAcqHS_All;Radio_ClampMode_AllIClamp;Radio_ClampMode_AllVClamp;Radio_ClampMode_AllIZero;SetVar_Sweep;Check_DataAcq_Indexing;check_DataAcq_IndexRandom;Check_DataAcq1_IndexingLocked;check_DataAcq_RepAcqRandom;Check_DataAcq1_RepeatAcq;Check_Settings_SkipAnalysFuncs"
+StrConstant CONTROLS_DISABLE_DURING_DAQ = "Check_DataAcqHS_All;Radio_ClampMode_AllIClamp;Radio_ClampMode_AllVClamp;Radio_ClampMode_AllIZero;SetVar_Sweep;Check_DataAcq_Indexing;check_DataAcq_IndexRandom;Check_DataAcq1_IndexingLocked;check_DataAcq_RepAcqRandom;Check_DataAcq1_RepeatAcq;Check_Settings_SkipAnalysFuncs;check_Settings_MD"
 StrConstant CONTROLS_DISABLE_DURING_IDX = "SetVar_DataAcq_ListRepeats;SetVar_DataAcq_SetRepeats"
 
 /// DA_Ephys controls which should be disabled during DAQ *and* TP

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -1322,7 +1322,6 @@ Function DAP_OneTimeCallBeforeDAQ(device, runMode)
 
 		HW_NI_ResetTaskIDs(device)
 	endif
-	DisableControls(device, "check_Settings_MD")
 
 	DAP_ToggleAcquisitionButton(device, DATA_ACQ_BUTTON_TO_STOP)
 	DisableControls(device, CONTROLS_DISABLE_DURING_DAQ_TP)
@@ -1416,9 +1415,6 @@ Function DAP_OneTimeCallAfterDAQ(string device, variable stopReason, [variable f
 				DisableControl(device, "check_Settings_MD")
 			endif
 			HW_NI_ResetTaskIDs(device)
-			break
-		default:
-			EnableControl(device, "check_Settings_MD")
 			break
 	endswitch
 

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -2595,12 +2595,11 @@ Function DAP_CheckSettings(device, mode)
 		endif
 
 		// unlock DAQDataWave, this happens if user functions error out and we don't catch it
-		// note: seems to work even if WAVE/WAVE would be required for NI
 		WAVE DAQDataWave = GetDAQDataWave(device, mode)
 		if(NumberByKey("LOCK", WaveInfo(DAQDataWave, 0)))
 			printf "(%s) Removing leftover lock on DAQDataWave\r", device
 			ControlWindowToFront()
-			SetWaveLock 0, DAQDataWave
+			ChangeWaveLock(DAQDataWave, 0)
 		endif
 	endfor
 

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -2596,7 +2596,7 @@ Function DAP_CheckSettings(device, mode)
 
 		// unlock DAQDataWave, this happens if user functions error out and we don't catch it
 		WAVE DAQDataWave = GetDAQDataWave(device, mode)
-		if(NumberByKey("LOCK", WaveInfo(DAQDataWave, 0)))
+		if(GetLockState(DAQDataWave))
 			printf "(%s) Removing leftover lock on DAQDataWave\r", device
 			ControlWindowToFront()
 			ChangeWaveLock(DAQDataWave, 0)

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -2164,7 +2164,7 @@ Function DAP_CheckSettings(device, mode)
 	variable lastStartSeconds, lastITI, nextStart, leftTime, sweepNo, validSampInt
 	variable DACchannel, ret
 	string ctrl, endWave, ttlWave, dacWave, refDacWave, reqParams
-	string list, lastStart
+	string list, lastStart, msg
 
 	ASSERT(mode == DATA_ACQUISITION_MODE || mode == TEST_PULSE_MODE, "Invalid mode")
 
@@ -2597,8 +2597,8 @@ Function DAP_CheckSettings(device, mode)
 		// unlock DAQDataWave, this happens if user functions error out and we don't catch it
 		WAVE DAQDataWave = GetDAQDataWave(device, mode)
 		if(GetLockState(DAQDataWave))
-			printf "(%s) Removing leftover lock on DAQDataWave\r", device
-			ControlWindowToFront()
+			sprintf msg, "(%s) Removing leftover lock on %s.\r", device, GetWavesDataFolder(DAQDataWave, 2)
+			BUG(msg)
 			ChangeWaveLock(DAQDataWave, 0)
 		endif
 	endfor

--- a/Packages/MIES/MIES_DataAcquisition_Multi.ipf
+++ b/Packages/MIES/MIES_DataAcquisition_Multi.ipf
@@ -24,7 +24,6 @@ Function DQM_FIFOMonitor(s)
 	variable bufferSize
 	string device, fifoChannelName, fifoName, errMsg
 	WAVE ActiveDeviceList = GetDQMActiveDeviceList()
-	Make/FREE/N=(0) wNIReadOut
 
 	for(i = 0; i < DimSize(ActiveDeviceList, ROWS); i += 1)
 		deviceID   = ActiveDeviceList[i][%DeviceID]
@@ -46,6 +45,7 @@ Function DQM_FIFOMonitor(s)
 						continue // no new data -> next device
 					endif
 
+					Make/FREE/N=(0) wNIReadOut
 					WAVE/WAVE NIDataWave = GetDAQDataWave(device, DATA_ACQUISITION_MODE)
 					for(j = 0; j < V_FIFOnchans; j += 1)
 

--- a/Packages/MIES/MIES_DataBrowser.ipf
+++ b/Packages/MIES/MIES_DataBrowser.ipf
@@ -599,10 +599,16 @@ Function DB_AddSweepToGraph(string win, variable index[, STRUCT BufferedDrawInfo
 		return NaN
 	endif
 
+	WAVE config = GetConfigWave(sweepWave)
+
+	if(!IsValidSweepAndConfig(sweepWave, config, configVersion = 0))
+		printf "The sweep %d of device %s does not match its configuration data. Therefore we can't display it.\r", sweepNo, device
+		return 1
+	endif
+
 	WAVE sweepChannelSel = BSP_FetchSelectedChannels(graph, sweepNo=sweepNo)
 
 	DB_SplitSweepsIfReq(win, sweepNo)
-	WAVE config = GetConfigWave(sweepWave)
 
 	WAVE axisLabelCache = GetAxisLabelCacheWave()
 

--- a/Packages/MIES/MIES_DataConfigurator.ipf
+++ b/Packages/MIES/MIES_DataConfigurator.ipf
@@ -495,6 +495,7 @@ End
 static Function DC_InitDataHoldingWave(wv, numRows, sampleInterval, numDACs, numADCs, numTTLs, [type, isFourierTransform])
 	WAVE wv
 	variable numRows, sampleInterval, numDACs, numADCs, numTTLs, type, isFourierTransform
+	string msg
 
 	ASSERT(numDACs > 0, "Invalid number of DACs")
 	ASSERT(numADCs > 0, "Invalid number of ADCs")
@@ -507,6 +508,12 @@ static Function DC_InitDataHoldingWave(wv, numRows, sampleInterval, numDACs, num
 		isFourierTransform = 0
 	else
 		isFourierTransform = !!isFourierTransform
+	endif
+
+	if(GetLockState(wv))
+		sprintf msg, "Clearing leftover lock in %s from earlier acquisition runs.\r", GetWavesDataFolder(wv, 2)
+		BUG(msg)
+		ChangeWaveLock(wv, 0)
 	endif
 
 	Redimension/N=(numRows, numDACs + numADCs + numTTLs)/Y=(type) wv

--- a/Packages/MIES/MIES_Debugging.ipf
+++ b/Packages/MIES/MIES_Debugging.ipf
@@ -503,6 +503,9 @@ End
 /// @brief Complain and ask the user to report the error
 ///
 /// In nearly all cases ASSERT() is the more appropriate method to use.
+///
+/// If a testcase wants to trigger a BUG message *and* needs to treat that as non-fatal,
+/// it needs to set `bugCount` to NaN before.
 Function BUG(msg)
 	string msg
 
@@ -524,7 +527,7 @@ Function BUG(msg)
 #ifdef AUTOMATED_TESTING
 	NVAR bugCount = $GetBugCount()
 	bugCount += 1
-	ASSERT(0, "BUG: Should never be called during automated testing.")
+	ASSERT(IsNaN(bugCount), "BUG: Should never be called during automated testing.")
 #endif
 End
 
@@ -559,7 +562,7 @@ threadsafe Function BUG_TS(string msg)
 	TUFXOP_ReleaseMutex/N=(TSDS_BUGCOUNT)
 #endif
 
-	ASSERT_TS(0, "BUG_TS: Should never be called during automated testing.")
+	ASSERT_TS(IsNaN(bugCount), "BUG_TS: Should never be called during automated testing.")
 #endif
 End
 

--- a/Packages/MIES/MIES_Debugging.ipf
+++ b/Packages/MIES/MIES_Debugging.ipf
@@ -512,6 +512,8 @@ Function BUG(msg)
 	string func, line, file
 	FindFirstOutsideCaller(func, line, file)
 
+	msg = RemoveEnding(msg, "\r")
+
 	if(!isEmpty(func))
 		printf "BUG %s(...)#L%s: %s\r", func, line, msg
 	else

--- a/Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf
+++ b/Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf
@@ -305,7 +305,9 @@ Function/S GetUserComment(device)
 	return GetSVARAsString(GetDevicePath(device), "userComment")
 End
 
-/// @brief Return the stop collection point as calculated by DC_GetStopCollectionPoint()
+/// @brief Return the stop collection point, this is a *length*.
+///
+/// @sa GetFifoPosition()
 Function/S GetStopCollectionPoint(device)
 	string device
 

--- a/Packages/MIES/MIES_GuiUtilities.ipf
+++ b/Packages/MIES/MIES_GuiUtilities.ipf
@@ -2082,6 +2082,9 @@ End
 #if IgorVersion() >= 9.0
 
 /// @brief Enable show trace info tags for the current top graph
+///
+/// Callers should call that via the operation queue to avoid
+/// GUI event processing from happening.
 Function ShowTraceInfoTags()
 
 	DoIgorMenu/C "Graph", "Show Trace Info Tags"

--- a/Packages/MIES/MIES_IgorHooks.ipf
+++ b/Packages/MIES/MIES_IgorHooks.ipf
@@ -136,7 +136,10 @@ static Function BeforeExperimentSaveHook(rN, fileName, path, type, creator, kind
 	IH_KillTemporaries()
 
 	NVAR fileIDExport = $GetNWBFileIDExport()
-	NWB_Flush(fileIDExport)
+
+	if(H5_IsFileOpen(fileIDExport))
+		NWB_Flush(fileIDExport)
+	endif
 
 	LOG_AddEntry(PACKAGE_MIES, "end")
 End

--- a/Packages/MIES/MIES_Oscilloscope.ipf
+++ b/Packages/MIES/MIES_Oscilloscope.ipf
@@ -796,9 +796,9 @@ static Function SCOPE_ITC_AdjustFIFOPos(device, fifopos)
 		return 0
 	elseif(IsNaN(fifoPos))
 		// we are done
-		// return the length of the DAQDataWave
+		// return the total length we wanted to acquire
 		stopCollectionPoint = ROVAR(GetStopCollectionPoint(device))
-		fifoPos = stopCollectionPoint - GetDataOffset(DAQConfigWave)
+		fifoPos = stopCollectionPoint
 	elseif(fifoPos < 0)
 		printf "fifoPos was clipped to zero, old value %g\r", fifoPos
 		return 0

--- a/Packages/MIES/MIES_SweepSaving.ipf
+++ b/Packages/MIES/MIES_SweepSaving.ipf
@@ -28,7 +28,11 @@ Function SWS_SaveAcquiredData(device, [forcedStop])
 	WAVE hardwareConfigWave = GetDAQConfigWave(device)
 	WAVE scaledDataWave = GetScaledDataWave(device)
 
-	ASSERT(IsValidSweepAndConfig(DAQDataWave, hardwareConfigWave), "Data and config wave are not compatible")
+	if(!IsValidSweepAndConfig(DAQDataWave, hardwareConfigWave)       \
+	   || !IsValidSweepAndConfig(scaledDataWave, hardwareConfigWave))
+		BUG("Scaled data and config wave are not compatible, nothing will be saved!")
+		return 0
+	endif
 
 	DFREF dfr = GetDeviceDataPath(device)
 

--- a/Packages/MIES/MIES_ThreadedFIFOHandling.ipf
+++ b/Packages/MIES/MIES_ThreadedFIFOHandling.ipf
@@ -89,7 +89,7 @@ End
 /// - The input queue is not empty
 ///
 /// Pushes the following entries into the thread queue:
-/// - fifoPos:       fifo position
+/// - fifoPos:       fifo position (relative to offset)
 /// - startSequence: (yoking only) inform the main thread
 ///                  that ARDStartSequence() commmand should be called
 threadsafe static Function TFH_FifoLoop(config, triggerMode, deviceID, stopCollectionPoint, ADChannelToMonitor, mode)

--- a/Packages/MIES/MIES_ThreadsafeUtilities.ipf
+++ b/Packages/MIES/MIES_ThreadsafeUtilities.ipf
@@ -213,7 +213,7 @@ Function TS_StopThreadGroup(tgID)
 	variable numThreadsRunning
 	string msg
 
-	if(!IsFinite(tgID))
+	if(!IsFinite(tgID) || TS_ThreadGroupFinished(tgID))
 		// nothing to do
 		return NaN
 	endif

--- a/Packages/MIES/MIES_ThreadsafeUtilities.ipf
+++ b/Packages/MIES/MIES_ThreadsafeUtilities.ipf
@@ -194,10 +194,13 @@ threadsafe Function TS_ThreadGroupPutDFR(tgID, dfr)
 End
 
 /// @brief Returns 1 if all worker threads have finished
-Function TS_ThreadGroupFinished(tgID)
-	variable tgID
+Function TS_ThreadGroupFinished(variable tgID)
+	variable err, ret
 
-	return !ThreadGroupWait(tgID, 0)
+	AssertOnAndClearRTError()
+	ret = !ThreadGroupWait(tgID, 0); err = GetRTError(1)
+
+	return ret
 End
 
 /// @brief Stop the given thread group

--- a/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
+++ b/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
@@ -1996,9 +1996,8 @@ static Function CheckThatTestpulseRan_IGNORE(device)
 	CHECK_WAVE(settings, NUMERIC_WAVE)
 End
 
-static Function CheckDAQStopReason(string device, variable stopReason)
+static Function CheckDAQStopReason(string device, variable stopReason, [variable sweepNo])
 	string key
-	variable sweepNo
 
 	key = "DAQ stop reason"
 
@@ -2007,7 +2006,10 @@ static Function CheckDAQStopReason(string device, variable stopReason)
 	CHECK_WAVE(sweeps, NUMERIC_WAVE)
 	CHECK_GE_VAR(DimSize(sweeps, ROWS), 1)
 
-	sweepNo = sweeps[0]
+	if(ParamIsDefault(sweepNo))
+		sweepNo = sweeps[0]
+	endif
+
 	WAVE/Z settings = GetLastSetting(numericalValues, sweepNo, key, UNKNOWN_MODE)
 	CHECK_WAVE(settings, NUMERIC_WAVE)
 	CHECK_EQUAL_VAR(settings[INDEP_HEADSTAGE], stopReason)
@@ -2436,6 +2438,9 @@ Function ChangeStimSetDuringDAQ_REENTRY([str])
 	endfor
 
 	CheckDAQStopReason(str, DQ_STOP_REASON_STIMSET_SELECTION)
+
+	// even with TP after DAQ we have "finished" as reason
+	CheckDAQStopReason(str, DQ_STOP_REASON_FINISHED, sweepNo = 2)
 End
 
 Function EnableUnassocChannels_IGNORE(device)

--- a/Packages/Testing-MIES/UTF_HardwareMain.ipf
+++ b/Packages/Testing-MIES/UTF_HardwareMain.ipf
@@ -360,13 +360,22 @@ Function TEST_CASE_END_OVERRIDE(name)
 	StopAllBackgroundTasks()
 
 	NVAR bugCount = $GetBugCount()
-	CHECK_EQUAL_VAR(bugCount, 0)
+	if(IsFinite(bugCount))
+		CHECK_EQUAL_VAR(bugCount, 0)
+	else
+		CHECK_EQUAL_VAR(bugCount, NaN)
+	endif
 
 #if IgorVersion() >= 9.0
 	TUFXOP_AcquireMutex/N=(TSDS_BUGCOUNT)
 	bugCount_ts = TSDS_ReadVar(TSDS_BUGCOUNT, defValue = 0)
 	TUFXOP_ReleaseMutex/N=(TSDS_BUGCOUNT)
-	CHECK_EQUAL_VAR(bugCount_ts, 0)
+
+	if(IsFinite(bugCount_ts))
+		CHECK_EQUAL_VAR(bugCount_ts, 0)
+	else
+		CHECK_EQUAL_VAR(bugCount_ts, NaN)
+	endif
 #endif
 
 	if(expensiveChecks)

--- a/Packages/Testing-MIES/UTF_HardwareMain.ipf
+++ b/Packages/Testing-MIES/UTF_HardwareMain.ipf
@@ -17,6 +17,7 @@
 #include "UTF_BasicHardwareTests"
 #include "UTF_DAEphys"
 #include "UTF_Epochs"
+#include "UTF_HardwareTestsWithBUG"
 #include "UTF_HelperFunctions"
 #include "UTF_IVSCC"
 #include "UTF_MultiPatchSeqDAScale"
@@ -108,6 +109,9 @@ Function RunWithOpts([string testcase, string testsuite, variable allowdebug, va
 	list = AddListItem("UTF_IVSCC.ipf", list)
 	list = AddListItem("UTF_AutoTestpulse.ipf", list)
 	list = AddListItem("UTF_VeryLastTestSuite.ipf", list, ";", inf)
+
+	// tests which BUG out must come after the test-all tests in UTF_VeryLastTestSuite.ipf
+	list = AddListItem("UTF_HardwareTestsWithBUG.ipf", list, ";", inf)
 
 	if(ParamIsDefault(testsuite))
 		testsuite = list

--- a/Packages/Testing-MIES/UTF_HardwareTestsWithBUG.ipf
+++ b/Packages/Testing-MIES/UTF_HardwareTestsWithBUG.ipf
@@ -1,0 +1,30 @@
+#pragma TextEncoding = "UTF-8"
+#pragma rtGlobals=3 // Use modern global access method and strict wave access.
+#pragma rtFunctionErrors=1
+#pragma ModuleName=HardwareTestsWithBUG
+
+Function CheckSweepSavingCompatible_IGNORE(string device)
+
+	ST_SetStimsetParameter("StimulusSetA_DA_0", "Analysis function (generic)", str = "BreakConfigWave")
+
+	NVAR bugCount = $GetBugCount()
+	bugCount = NaN
+End
+
+/// UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
+Function CheckSweepSavingCompatible([string str])
+
+	STRUCT DAQSettings s
+	InitDAQSettingsFromString(s, "MD1_RA0_I0_L0_BKG_1")
+
+	BasicHardwareTests#AcquireData(s, str, preAcquireFunc = CheckSweepSavingCompatible_IGNORE)
+End
+
+Function CheckSweepSavingCompatible_REENTRY([string str])
+	variable sweepNo
+
+	CHECK_EQUAL_VAR(GetSetVariable(str, "SetVar_Sweep"), 0)
+
+	sweepNo = AFH_GetLastSweepAcquired(str)
+	CHECK_EQUAL_VAR(sweepNo, NaN)
+End

--- a/Packages/Testing-MIES/UserAnalysisFunctions.ipf
+++ b/Packages/Testing-MIES/UserAnalysisFunctions.ipf
@@ -970,3 +970,22 @@ Function SetSweepFormula(string device, STRUCT AnalysisFunction_V3& s)
 			// do nothing
 	endswitch
 End
+
+Function BreakConfigWave(string device, STRUCT AnalysisFunction_V3& s)
+
+	switch(s.eventType)
+		case MID_SWEEP_EVENT:
+			if(s.lastKnownRowIndex > 0)
+				WAVE/Z configWave = GetDAQConfigWave(device)
+				CHECK_WAVE(configWave, NUMERIC_WAVE)
+				CHECK(IsValidSweepAndConfig(s.scaledDACWave, configWave))
+
+				// add one more row so that IsValidSweepAndConfig fails
+				Redimension/N=(DimSize(configWave, ROWS) + 1, -1) configWave
+				CHECK(!IsValidSweepAndConfig(s.scaledDACWave, configWave))
+
+				return ANALYSIS_FUNC_RET_EARLY_STOP
+			endif
+			break
+	endswitch
+End


### PR DESCRIPTION
@ru57y34nn @aleonlein 
This refers to #1234. I could not pin-down the exact reason for the runtime error relating to the scaled data wave. But I have done the following:
- Added better error handling so that if that happens again, we should have more information available
- Allow users to more easily get out of that situation again by removing stale wave locks

And it also has some other minor stuff I found while trying to reproduce it.

Please give that a shot. The installer is available from the "Installer and Release package" bamboo job once that is finished.

In case you have some hints/ideas/recipes I should try out for reproducing it, don't hesitate to post them.

I'm okay with merging as is, we don't need to wait for 2022.

Close #1234