### PR TITLE
[Backport] PSQ_EvaluateBaselineProperties: Fix scale of average voltage

### DIFF
--- a/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
@@ -545,7 +545,7 @@ static Function PSQ_EvaluateBaselineProperties(string device, STRUCT AnalysisFun
 
 	if(HasOneValidEntry(avgVoltage))
 		// mV -> V
-		avgVoltage[] *= 1000
+		avgVoltage[] *= 1e-3
 		key = CreateAnaFuncLBNKey(type, PSQ_FMT_LBN_TARGETV, chunk = chunk)
 		ED_AddEntryToLabnotebook(device, key, avgVoltage, unit = "Volt", overrideSweepNo = s.sweepNo)
 	endif

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -1023,10 +1023,10 @@ StrConstant FMT_LBN_ANA_FUNC_VERSION = "%s version"
 
 /// @name Analysis function versions
 /// @{
-Constant PSQ_CHIRP_VERSION         = 5
-Constant PSQ_DA_SCALE_VERSION      = 2
-Constant PSQ_RAMP_VERSION          = 3
-Constant PSQ_RHEOBASE_VERSION      = 2
+Constant PSQ_CHIRP_VERSION         = 6
+Constant PSQ_DA_SCALE_VERSION      = 3
+Constant PSQ_RAMP_VERSION          = 4
+Constant PSQ_RHEOBASE_VERSION      = 3
 Constant PSQ_SQUARE_PULSE_VERSION  = 1
 Constant MSQ_FAST_RHEO_EST_VERSION = 0
 Constant MSQ_DA_SCALE_VERSION      = 0


### PR DESCRIPTION
When going from milli to unity the factor is 1e-3. Bug introduced in
0a86df51 (PSQ Analysis functions: Store the baseline voltage when
evaluated, 2021-01-15).

https://github.com/AllenInstitute/MIES/pull/1243 got merged to main but should have been merged to release/2.4.