### PR TITLE
CreateTiledChannelGraph: Fix assertion with dDAQ slider

### DIFF
--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -2677,9 +2677,6 @@ Function CreateTiledChannelGraph(string graph, WAVE config, variable sweepNo, WA
 	endif
 
 	if(tgs.dDAQDisplayMode)
-		stimSetLength = GetLastSettingIndep(numericalValues, sweepNo, "Stim set length", DATA_ACQUISITION_MODE)
-		DEBUGPRINT("Stim set length (labnotebook, NaN for oodDAQ)", var=stimSetLength)
-
 		samplingInt = GetSamplingInterval(config) * 1e-3
 
 		// dDAQ data taken with versions prior to
@@ -2733,6 +2730,9 @@ Function CreateTiledChannelGraph(string graph, WAVE config, variable sweepNo, WA
 			sprintf str, "oodDAQRegions (%d) concatenated: _%s_, totalRange=%g", numRegions, oodDAQRegionsAll, totalXRange
 			DEBUGPRINT(str)
 		else
+			stimSetLength = GetLastSettingIndep(numericalValues, sweepNo, "Stim set length", DATA_ACQUISITION_MODE)
+			DEBUGPRINT("Stim set length (labnotebook, NaN for oodDAQ)", var=stimSetLength)
+
 			dDAQActiveHeadstageAll = ""
 
 			for(i = 0; i < NUM_HEADSTAGES; i += 1)


### PR DESCRIPTION
When acquiring oodDAQ data and when trying to view the data with dDAQ
checkbox enabled and AUTOMATED_TESTING being defined, we get an assertion from
EnforceIndependentSetting introduced in d0dfc2e8 (Labnotebook: Enforce
that the INDEP getters are correctly used, 2021-04-22).

We can avoid that by querying the INDEP_HEADSTAGE entry of "Stim set
length" only when dDAQ is enabled, as it is in the headstage dependent
entries for all other cases.