### PR TITLE
tools/unit-testing: Check JUNIT xml files

### DIFF
--- a/Packages/doc/developers.rst
+++ b/Packages/doc/developers.rst
@@ -194,7 +194,7 @@ Install required software
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 -  Install `Docker <https://docker.io>`__
--  Misc required software: ``apt install git cron-apt``
+-  Misc required software: ``apt install git cron-apt xmllint``
 -  Enable automatic updates: ``echo "dist-upgrade -y -o APT::Get::Show-Upgraded=true" > /etc/cron-apt/action.d/4-upgrade``
 -  Install OpenJDK 8 by adding a file with the following
    sources in ``/etc/apt/sources.list.d/``:

--- a/tools/unit-testing/check_junit_xml_files.sh
+++ b/tools/unit-testing/check_junit_xml_files.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+for i in $(ls *.xml)
+do
+  xmllint --noout $i
+done


### PR DESCRIPTION
We have a report [1] that failing tests with ITC1600 hardware results in
invalid JUNIT files due to invalid UTF8-characters.

A preliminary analysis suggests that the problem is some kind of memory
corruption.

In order to debug that issue, we now check all generated JUNIT XML files
during CI are XML-compliant.

autorun-test.sh is used by all jobs which execute tests.

[1]: https://github.com/byte-physics/igor-unit-testing-framework/issues/236
