### PR TITLE
Add instrumentation helper function for macro-only procedure files

### DIFF
--- a/Packages/MIES/MIES_DAEphys_Macro.ipf
+++ b/Packages/MIES/MIES_DAEphys_Macro.ipf
@@ -9,6 +9,9 @@
 /// @file MIES_DAEphys_Macro.ipf
 /// @brief __DA__ DA_Ephys panel macro
 
+static Function IUTF_InstrumentationHelper()
+End
+
 Window DA_Ephys() : Panel
 	PauseUpdate; Silent 1		// building window...
 	NewPanel /K=1 /W=(1315,92,1818,968)

--- a/Packages/MIES/MIES_DataBrowser_Macro.ipf
+++ b/Packages/MIES/MIES_DataBrowser_Macro.ipf
@@ -9,6 +9,9 @@
 /// @file MIES_DataBrowser_Macro.ipf
 /// @brief __DB__ Macro for DataBrowser
 
+static Function IUTF_InstrumentationHelper()
+End
+
 Window DataBrowser() : Graph
 	PauseUpdate; Silent 1		// building window...
 	Display /W=(487.5,83,918,420.5)/K=1  as "DataBrowser"

--- a/Packages/MIES/MIES_WaveBuilder_Macro.ipf
+++ b/Packages/MIES/MIES_WaveBuilder_Macro.ipf
@@ -9,6 +9,9 @@
 /// @file MIES_WaveBuilder_Macro.ipf
 /// @brief __WBPM__ WaveBuilder panel macro
 
+static Function IUTF_InstrumentationHelper()
+End
+
 Window WaveBuilder() : Panel
 	PauseUpdate; Silent 1		// building window...
 	NewPanel /K=1 /W=(136,360,1168,907)


### PR DESCRIPTION
This is a preparation PR for an upcoming update of the unit-testing framework.

Procedure files that contain only macros require to have at least one
function for the unit-testing framework to apply instrumentation.

The additional function have no body and are not called, they just serve to
overcome the Igor Pro limitation that allows to retrieve the file system
location of procedure files through FunctionInfo. Though, FunctionInfo works
only with function names.