### PR TITLE
Remove instrumentation helper functions

### DIFF
--- a/Packages/MIES/MIES_DAEphys_Macro.ipf
+++ b/Packages/MIES/MIES_DAEphys_Macro.ipf
@@ -9,9 +9,6 @@
 /// @file MIES_DAEphys_Macro.ipf
 /// @brief __DA__ DA_Ephys panel macro
 
-static Function IUTF_InstrumentationHelper()
-End
-
 Window DA_Ephys() : Panel
 	PauseUpdate; Silent 1		// building window...
 	NewPanel /K=1 /W=(1315,92,1818,968)

--- a/Packages/MIES/MIES_DataBrowser_Macro.ipf
+++ b/Packages/MIES/MIES_DataBrowser_Macro.ipf
@@ -9,9 +9,6 @@
 /// @file MIES_DataBrowser_Macro.ipf
 /// @brief __DB__ Macro for DataBrowser
 
-static Function IUTF_InstrumentationHelper()
-End
-
 Window DataBrowser() : Graph
 	PauseUpdate; Silent 1		// building window...
 	Display /W=(487.5,83,918,420.5)/K=1  as "DataBrowser"

--- a/Packages/MIES/MIES_WaveBuilder_Macro.ipf
+++ b/Packages/MIES/MIES_WaveBuilder_Macro.ipf
@@ -9,9 +9,6 @@
 /// @file MIES_WaveBuilder_Macro.ipf
 /// @brief __WBPM__ WaveBuilder panel macro
 
-static Function IUTF_InstrumentationHelper()
-End
-
 Window WaveBuilder() : Panel
 	PauseUpdate; Silent 1		// building window...
 	NewPanel /K=1 /W=(136,360,1168,907)


### PR DESCRIPTION
This is a PR that requires the updated unit-testing-framework (soon).

With Igor Pro 9 Build 38812, two new functions MacroPath and MacroInfo are
available that allow the unit-testing-framework to instrument the code with
less limitations than before.

Whith the updated unit-testing-framework these helper functions are not
required anymore.
