### PR TITLE
Require newer IP9 version

### DIFF
--- a/Packages/MIES_Include.ipf
+++ b/Packages/MIES_Include.ipf
@@ -16,12 +16,14 @@
 // They are defined here so that we can parse them from within IP.
 //
 // .. |IgorPro8Nightly| replace:: `Igor Pro 8 <https://www.byte-physics.de/Downloads/WinIgor8_12MAY2021.zip>`__
-// .. |IgorPro9Nightly| replace:: `Igor Pro 9 <https://www.byte-physics.de/Downloads/WinIgor9_14AUG2021.zip>`__
+// .. |IgorPro9Nightly| replace:: `Igor Pro 9 <https://www.byte-physics.de/Downloads/WinIgor9_31MAR2022.zip>`__
 
 #pragma IgorVersion=8.04
 
 #if IgorVersion() >= 9.0
-// 37840 is the released version of IP9
+#if (NumberByKey("BUILD", IgorInfo(0)) < 38847)
+#define TOO_OLD_IGOR
+#endif
 #else
 #if (NumberByKey("BUILD", IgorInfo(0)) < 37456)
 #define TOO_OLD_IGOR


### PR DESCRIPTION
Due to repeated crashes on the ITC CI box [1], the author of this commit
chatted with WM support about potential remedies.

And it turns out some quick fixes should already make it less likely
crashing and also avoids the billion explorer windows on bug messages.

So let's require the IP9 nightly from today.

Let's see what CI says.

Close #1311.