### PR TITLE
Bugfix/1345 same optionality for all analysis function parameters

### DIFF
--- a/Packages/MIES/MIES_AnalysisFunctionHelpers.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctionHelpers.ipf
@@ -625,9 +625,9 @@ Function AFH_GetAnalysisParamNumerical(name, params, [defValue])
 	if(WhichListItem(name, AFH_GetListOfAnalysisParamNames(params)) == -1)
 		if(ParamIsDefault(defValue))
 			return NaN
-		else
-			return defValue
 		endif
+
+		return defValue
 	endif
 
 	contents = AFH_GetAnalysisParameter(name, params, expectedType = "variable")
@@ -661,9 +661,9 @@ Function/S AFH_GetAnalysisParamTextual(name, params, [defValue, percentDecoded])
 	if(WhichListItem(name, AFH_GetListOfAnalysisParamNames(params)) == -1)
 		if(ParamIsDefault(defValue))
 			return ""
-		else
-			return defValue
 		endif
+
+		return defValue
 	endif
 
 	contents = AFH_GetAnalysisParameter(name, params, expectedType = "string")
@@ -696,9 +696,9 @@ Function/WAVE AFH_GetAnalysisParamWave(name, params, [defValue])
 	if(WhichListItem(name, AFH_GetListOfAnalysisParamNames(params)) == -1)
 		if(ParamIsDefault(defValue))
 			return $""
-		else
-			return defValue
 		endif
+
+		return defValue
 	endif
 
 	contents = AFH_GetAnalysisParameter(name, params, expectedType = "wave")
@@ -735,9 +735,9 @@ Function/WAVE AFH_GetAnalysisParamTextWave(name, params, [defValue, percentDecod
 	if(WhichListItem(name, AFH_GetListOfAnalysisParamNames(params)) == -1)
 		if(ParamIsDefault(defValue))
 			return $""
-		else
-			return defValue
 		endif
+
+		return defValue
 	endif
 
 	contents = AFH_GetAnalysisParameter(name, params, expectedType = "textwave")

--- a/Packages/MIES/MIES_AnalysisFunctions_MultiPatchSeq.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_MultiPatchSeq.ipf
@@ -541,12 +541,12 @@ End
 
 /// @brief Return a list of required parameters for MSQ_FastRheoEst()
 Function/S MSQ_FastRheoEst_GetParams()
-	return "SamplingMultiplier:variable,"        + \
-		   "PostDAQDAScaleForFailedHS:variable," + \
-		   "PostDAQDAScaleMinOffset:variable,"   + \
-		   "PostDAQDAScale:variable,"            + \
-		   "PostDAQDAScaleFactor:variable,"      + \
-		   "MaximumDAScale:variable"
+	return "MaximumDAScale:variable,"            + \
+	       "PostDAQDAScale:variable,"            + \
+	       "PostDAQDAScaleFactor:variable,"      + \
+	       "PostDAQDAScaleForFailedHS:variable," + \
+	       "PostDAQDAScaleMinOffset:variable,"   + \
+	       "SamplingMultiplier:variable"
 End
 
 Function/S MSQ_FastRheoEst_GetHelp(name)

--- a/Packages/MIES/MIES_AnalysisFunctions_MultiPatchSeq_SpikeControl.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_MultiPatchSeq_SpikeControl.ipf
@@ -787,10 +787,17 @@ static Function SC_ReactToQCFailures(string device, variable sweepNo, string par
 End
 
 Function/S SC_SpikeControl_GetParams()
-	return "[FailedPulseLevel:variable],[MaxTrials:variable],DAScaleOperator:string,DAScaleModifier:variable,"           \
-			+ "DAScaleSpikePositionOperator:string,DAScaleSpikePositionModifier:variable,MinimumSpikePosition:variable," \
-			+ "IdealNumberOfSpikesPerPulse:variable,AutoBiasBaselineModifier:variable,"                                  \
-			+ "DaScaleTooManySpikesOperator:string,DaScaleTooManySpikesModifier:variable"
+	return "AutoBiasBaselineModifier:variable,"     + \
+	       "DAScaleModifier:variable,"              + \
+	       "DAScaleOperator:string,"                + \
+	       "DAScaleSpikePositionModifier:variable," + \
+	       "DAScaleSpikePositionOperator:string,"   + \
+	       "DaScaleTooManySpikesModifier:variable," + \
+	       "DaScaleTooManySpikesOperator:string,"   + \
+	       "[FailedPulseLevel:variable],"           + \
+	       "IdealNumberOfSpikesPerPulse:variable,"  + \
+	       "[MaxTrials:variable],"                  + \
+	       "MinimumSpikePosition:variable"
 End
 
 Function/S SC_SpikeControl_GetHelp(name)

--- a/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
@@ -1592,7 +1592,7 @@ static Function/S PSQ_GetHelpCommon(variable type, string name)
 
 	strswitch(name)
 		case "BaselineChunkLength":
-			return "Length of a baseline QC chunk to evaluate"
+			return "Length of a baseline QC chunk to evaluate (defaults to " + num2str(PSQ_BL_EVAL_RANGE) + ")"
 		case "BaselineRMSLongThreshold":
 			return "Threshold value in mV for the long RMS baseline QC check (defaults to " + num2str(PSQ_RMS_LONG_THRESHOLD) + ")"
 		case "BaselineRMSShortThreshold":
@@ -5256,7 +5256,7 @@ static Function PSQ_SE_CreateEpochs(string device, variable headstage, string pa
 
 	totalOnsetDelay = GetTotalOnsetDelayFromDevice(device)
 
-	chunkLength = AFH_GetAnalysisParamNumerical("BaselineChunkLength", params) * MILLI_TO_ONE
+	chunkLength = AFH_GetAnalysisParamNumerical("BaselineChunkLength", params, defValue = PSQ_BL_EVAL_RANGE ) * MILLI_TO_ONE
 
 	wbBegin = 0
 	wbEnd   = totalOnsetDelay * MILLI_TO_ONE
@@ -5398,7 +5398,7 @@ End
 
 Function/S PSQ_TrueRestingMembranePotential_GetParams()
 	return "AbsoluteVoltageDiff:variable,"         + \
-	       "BaselineChunkLength:variable,"         + \
+	       "[BaselineChunkLength:variable],"       + \
 	       "[BaselineRMSLongThreshold:variable],"  + \
 	       "[BaselineRMSShortThreshold:variable]," + \
 	       "FailedLevel:variable,"                 + \
@@ -5667,7 +5667,7 @@ static Function PSQ_CreateBaselineChunkSelectionEpochs(string device, variable h
 	totalOnsetDelay = GetTotalOnsetDelayFromDevice(device)
 
 	chunkLength = AFH_GetAnalysisParamNumerical("BaselineChunkLength", params) * MILLI_TO_ONE
-	ASSERT(IsFinite(chunkLength), "BaselineChunkLength must be present and finite")
+	ASSERT(IsFinite(chunkLength), "BaselineChunkLength must be finite")
 
 	wbBegin = 0
 	wbEnd   = totalOnsetDelay * MILLI_TO_ONE

--- a/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
@@ -3920,7 +3920,7 @@ Function/S PSQ_Chirp_GetParams()
 	       "[FailedLevel:variable],"               + \
 	       "InnerRelativeBound:variable,"          + \
 	       "[NumberOfChirpCycles:variable],"       + \
-	       "[NumberOfFailedSweeps:variable],"      + \
+	       "NumberOfFailedSweeps:variable,"        + \
 	       "OuterRelativeBound:variable,"          + \
 	       "[SamplingFrequency:variable],"         + \
 	       "SamplingMultiplier:variable,"          + \
@@ -4003,7 +4003,7 @@ Function PSQ_Chirp(device, s)
 	innerRelativeBound = AFH_GetAnalysisParamNumerical("InnerRelativeBound", s.params)
 	numberOfChirpCycles = AFH_GetAnalysisParamNumerical("NumberOfChirpCycles", s.params, defValue = 1)
 	outerRelativeBound = AFH_GetAnalysisParamNumerical("OuterRelativeBound", s.params)
-	numSweepsFailedAllowed = AFH_GetAnalysisParamNumerical("NumberOfFailedSweeps", s.params, defValue = 3)
+	numSweepsFailedAllowed = AFH_GetAnalysisParamNumerical("NumberOfFailedSweeps", s.params)
 	multiplier = AFH_GetAnalysisParamNumerical("SamplingMultiplier", s.params)
 	boundsEvaluationMode = PSQ_CR_ParseBoundsEvaluationModeString(AFH_GetAnalysisParamTextual("BoundsEvaluationMode", s.params))
 

--- a/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
@@ -3923,7 +3923,7 @@ Function/S PSQ_Chirp_GetParams()
 	       "[NumberOfFailedSweeps:variable],"      + \
 	       "OuterRelativeBound:variable,"          + \
 	       "[SamplingFrequency:variable],"         + \
-	       "[SamplingMultiplier:variable],"        + \
+	       "SamplingMultiplier:variable,"          + \
 	       "[SpikeCheck:variable]"
 End
 
@@ -4004,7 +4004,7 @@ Function PSQ_Chirp(device, s)
 	numberOfChirpCycles = AFH_GetAnalysisParamNumerical("NumberOfChirpCycles", s.params, defValue = 1)
 	outerRelativeBound = AFH_GetAnalysisParamNumerical("OuterRelativeBound", s.params)
 	numSweepsFailedAllowed = AFH_GetAnalysisParamNumerical("NumberOfFailedSweeps", s.params, defValue = 3)
-	multiplier = AFH_GetAnalysisParamNumerical("SamplingMultiplier", s.params, defValue = PSQ_DEFAULT_SAMPLING_MULTIPLIER)
+	multiplier = AFH_GetAnalysisParamNumerical("SamplingMultiplier", s.params)
 	boundsEvaluationMode = PSQ_CR_ParseBoundsEvaluationModeString(AFH_GetAnalysisParamTextual("BoundsEvaluationMode", s.params))
 
 	switch(s.eventType)
@@ -4505,7 +4505,7 @@ Function/S PSQ_PipetteInBath_GetParams()
 	       "NumberOfFailedSweeps:variable,"      + \
 	       "NumberOfTestpulses:variable,"        + \
 	       "[SamplingFrequency:variable],"       + \
-	       "[SamplingMultiplier:variable]"
+	       "SamplingMultiplier:variable"
 End
 
 /// @brief Analysis function for determining the pipette resistance while that is located in the bath
@@ -4907,7 +4907,7 @@ Function/S PSQ_SealEvaluation_GetParams()
 	       "NextStimSetName:string,"             + \
 	       "NumberOfFailedSweeps:variable,"      + \
 	       "[SamplingFrequency:variable],"       + \
-	       "[SamplingMultiplier:variable],"      + \
+	       "SamplingMultiplier:variable,"        + \
 	       "SealThreshold:variable,"             + \
 	       "[TestPulseGroupSelector:string]"
 End
@@ -5408,7 +5408,7 @@ Function/S PSQ_TrueRestingMembranePotential_GetParams()
 	       "NumberOfFailedSweeps:variable,"        + \
 	       "RelativeVoltageDiff:variable,"         + \
 	       "[SamplingFrequency:variable],"         + \
-	       "[SamplingMultiplier:variable],"        + \
+	       "SamplingMultiplier:variable,"          + \
 	       "SpikeFailureIgnoredTime:variable,"     + \
 	       "UserOffsetTargetVAutobias:variable"
 End

--- a/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
@@ -4892,7 +4892,7 @@ Function/S PSQ_SealEvaluation_GetHelp(string name)
 		case "SamplingMultiplier":
 			return PSQ_GetHelpCommon(PSQ_SEAL_EVALUATION, name)
 		case "SealThreshold":
-			return "Minimum required seal threshold, defaults to 1 [GΩ]"
+			return "Minimum required seal threshold"
 		case "TestPulseGroupSelector":
 			return "Group(s) which have their resistance evaluated: One of Both/First/Second, defaults to Both"
 		default:

--- a/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
@@ -4496,15 +4496,15 @@ Function/S PSQ_PipetteInBath_GetHelp(string name)
 End
 
 Function/S PSQ_PipetteInBath_GetParams()
-	return "BaselineRMSLongThreshold:variable,"  + \
-	       "BaselineRMSShortThreshold:variable," + \
-	       "MaxLeakCurrent:variable,"            + \
-	       "MaxPipetteResistance:variable,"      + \
-	       "MinPipetteResistance:variable,"      + \
-	       "NextStimSetName:string,"             + \
-	       "NumberOfFailedSweeps:variable,"      + \
-	       "NumberOfTestpulses:variable,"        + \
-	       "[SamplingFrequency:variable],"       + \
+	return "[BaselineRMSLongThreshold:variable],"  + \
+	       "[BaselineRMSShortThreshold:variable]," + \
+	       "MaxLeakCurrent:variable,"              + \
+	       "MaxPipetteResistance:variable,"        + \
+	       "MinPipetteResistance:variable,"        + \
+	       "NextStimSetName:string,"               + \
+	       "NumberOfFailedSweeps:variable,"        + \
+	       "NumberOfTestpulses:variable,"          + \
+	       "[SamplingFrequency:variable],"         + \
 	       "SamplingMultiplier:variable"
 End
 
@@ -4901,14 +4901,14 @@ Function/S PSQ_SealEvaluation_GetHelp(string name)
 End
 
 Function/S PSQ_SealEvaluation_GetParams()
-	return "BaselineChunkLength:variable,"       + \
-	       "BaselineRMSLongThreshold:variable,"  + \
-	       "BaselineRMSShortThreshold:variable," + \
-	       "NextStimSetName:string,"             + \
-	       "NumberOfFailedSweeps:variable,"      + \
-	       "[SamplingFrequency:variable],"       + \
-	       "SamplingMultiplier:variable,"        + \
-	       "SealThreshold:variable,"             + \
+	return "[BaselineChunkLength:variable],"       + \
+	       "[BaselineRMSLongThreshold:variable],"  + \
+	       "[BaselineRMSShortThreshold:variable]," + \
+	       "NextStimSetName:string,"               + \
+	       "NumberOfFailedSweeps:variable,"        + \
+	       "[SamplingFrequency:variable],"         + \
+	       "SamplingMultiplier:variable,"          + \
+	       "SealThreshold:variable,"               + \
 	       "[TestPulseGroupSelector:string]"
 End
 

--- a/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
@@ -4501,7 +4501,7 @@ Function/S PSQ_PipetteInBath_GetParams()
 	       "MaxLeakCurrent:variable,"              + \
 	       "MaxPipetteResistance:variable,"        + \
 	       "MinPipetteResistance:variable,"        + \
-	       "NextStimSetName:string,"               + \
+	       "[NextStimSetName:string],"             + \
 	       "NumberOfFailedSweeps:variable,"        + \
 	       "NumberOfTestpulses:variable,"          + \
 	       "[SamplingFrequency:variable],"         + \
@@ -4904,7 +4904,7 @@ Function/S PSQ_SealEvaluation_GetParams()
 	return "[BaselineChunkLength:variable],"       + \
 	       "[BaselineRMSLongThreshold:variable],"  + \
 	       "[BaselineRMSShortThreshold:variable]," + \
-	       "NextStimSetName:string,"               + \
+	       "[NextStimSetName:string],"             + \
 	       "NumberOfFailedSweeps:variable,"        + \
 	       "[SamplingFrequency:variable],"         + \
 	       "SamplingMultiplier:variable,"          + \

--- a/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
@@ -1705,9 +1705,18 @@ End
 
 /// @brief Require parameters from stimset
 Function/S PSQ_DAScale_GetParams()
-	return "DAScales:wave,OperationMode:string,SamplingMultiplier:variable,[ShowPlot:variable],[OffsetOperator:string]," +        \
-		   "[FinalSlopePercent:variable],[MinimumSpikeCount:variable],[MaximumSpikeCount:variable],[DAScaleModifier:variable]," + \
-		   "[SamplingFrequency:variable],[BaselineRMSShortThreshold:variable],[BaselineRMSLongThreshold:variable]"
+	return "[BaselineRMSLongThreshold:variable],"  + \
+	       "[BaselineRMSShortThreshold:variable]," + \
+	       "[DAScaleModifier:variable],"           + \
+	       "DAScales:wave,"                        + \
+	       "[FinalSlopePercent:variable],"         + \
+	       "[MaximumSpikeCount:variable],"         + \
+	       "[MinimumSpikeCount:variable],"         + \
+	       "[OffsetOperator:string],"              + \
+	       "OperationMode:string,"                 + \
+	       "[SamplingFrequency:variable],"         + \
+	       "SamplingMultiplier:variable,"          + \
+	       "[ShowPlot:variable]"
 End
 
 Function/S PSQ_DAScale_GetHelp(string name)
@@ -2300,7 +2309,10 @@ End
 
 /// @brief Return a list of required parameters
 Function/S PSQ_SquarePulse_GetParams()
-	return "SamplingMultiplier:variable,[SamplingFrequency:variable],[BaselineRMSShortThreshold:variable],[BaselineRMSLongThreshold:variable]"
+	return "[BaselineRMSLongThreshold:variable],"  + \
+	       "[BaselineRMSShortThreshold:variable]," + \
+	       "[SamplingFrequency:variable],"         + \
+	       "SamplingMultiplier:variable"
 End
 
 Function/S PSQ_SquarePulse_GetHelp(string name)
@@ -2544,7 +2556,10 @@ End
 
 /// @brief Return a list of required parameters
 Function/S PSQ_Rheobase_GetParams()
-	return "SamplingMultiplier:variable,[SamplingFrequency:variable],[BaselineRMSShortThreshold:variable],[BaselineRMSLongThreshold:variable]"
+	return "[BaselineRMSLongThreshold:variable],"  + \
+	       "[BaselineRMSShortThreshold:variable]," + \
+	       "[SamplingFrequency:variable],"         + \
+	       "SamplingMultiplier:variable"
 End
 
 Function/S PSQ_Rheobase_GetHelp(string name)
@@ -2957,7 +2972,11 @@ End
 
 /// @brief Return a list of required parameters
 Function/S PSQ_Ramp_GetParams()
-	return "NumberOfSpikes:variable,SamplingMultiplier:variable,[SamplingFrequency:variable],[BaselineRMSShortThreshold:variable],[BaselineRMSLongThreshold:variable]"
+	return "[BaselineRMSLongThreshold:variable],"  + \
+	       "[BaselineRMSShortThreshold:variable]," + \
+	       "NumberOfSpikes:variable,"              + \
+	       "[SamplingFrequency:variable],"         + \
+	       "SamplingMultiplier:variable"
 End
 
 Function/S PSQ_Ramp_GetHelp(string name)
@@ -3891,12 +3910,21 @@ End
 
 /// @brief Return a list of required analysis functions for PSQ_Chirp()
 Function/S PSQ_Chirp_GetParams()
-	return "InnerRelativeBound:variable,OuterRelativeBound:variable," +                            \
-		   "[NumberOfChirpCycles:variable],[SpikeCheck:variable],[FailedLevel:variable]," +         \
-		   "[DAScaleOperator:string],[DAScaleModifier:variable],[NumberOfFailedSweeps:variable]," + \
-		   "[SamplingMultiplier:variable],[SamplingFrequency:variable]," +                          \
-		   "[BaselineRMSShortThreshold:variable],[BaselineRMSLongThreshold:variable]," +            \
-		   "BoundsEvaluationMode:string,[AutobiasTargetV:variable],[AutobiasTargetVAtSetEnd:variable]"
+	return "[AutobiasTargetV:variable],"           + \
+	       "[AutobiasTargetVAtSetEnd:variable],"   + \
+	       "[BaselineRMSLongThreshold:variable],"  + \
+	       "[BaselineRMSShortThreshold:variable]," + \
+	       "BoundsEvaluationMode:string,"          + \
+	       "[DAScaleModifier:variable],"           + \
+	       "[DAScaleOperator:string],"             + \
+	       "[FailedLevel:variable],"               + \
+	       "InnerRelativeBound:variable,"          + \
+	       "[NumberOfChirpCycles:variable],"       + \
+	       "[NumberOfFailedSweeps:variable],"      + \
+	       "OuterRelativeBound:variable,"          + \
+	       "[SamplingFrequency:variable],"         + \
+	       "[SamplingMultiplier:variable],"        + \
+	       "[SpikeCheck:variable]"
 End
 
 /// @brief Analysis function for determining the impedance of the cell using a sine chirp stim set
@@ -4468,9 +4496,16 @@ Function/S PSQ_PipetteInBath_GetHelp(string name)
 End
 
 Function/S PSQ_PipetteInBath_GetParams()
-	return "[SamplingFrequency:variable],[SamplingMultiplier:variable],BaselineRMSShortThreshold:variable," +                         \
-	       "BaselineRMSLongThreshold:variable,MaxLeakCurrent:variable,MinPipetteResistance:variable,MaxPipetteResistance:variable," + \
-	       "NumberOfFailedSweeps:variable,NextStimSetName:string,NumberOfTestpulses:variable"
+	return "BaselineRMSLongThreshold:variable,"  + \
+	       "BaselineRMSShortThreshold:variable," + \
+	       "MaxLeakCurrent:variable,"            + \
+	       "MaxPipetteResistance:variable,"      + \
+	       "MinPipetteResistance:variable,"      + \
+	       "NextStimSetName:string,"             + \
+	       "NumberOfFailedSweeps:variable,"      + \
+	       "NumberOfTestpulses:variable,"        + \
+	       "[SamplingFrequency:variable],"       + \
+	       "[SamplingMultiplier:variable]"
 End
 
 /// @brief Analysis function for determining the pipette resistance while that is located in the bath
@@ -4866,9 +4901,15 @@ Function/S PSQ_SealEvaluation_GetHelp(string name)
 End
 
 Function/S PSQ_SealEvaluation_GetParams()
-	return "[SamplingFrequency:variable],[SamplingMultiplier:variable],BaselineRMSShortThreshold:variable," +                 \
-		   "BaselineRMSLongThreshold:variable,SealThreshold:variable,NumberOfFailedSweeps:variable,NextStimSetName:string," + \
-		   "BaselineChunkLength:variable,[TestPulseGroupSelector:string]"
+	return "BaselineChunkLength:variable,"       + \
+	       "BaselineRMSLongThreshold:variable,"  + \
+	       "BaselineRMSShortThreshold:variable," + \
+	       "NextStimSetName:string,"             + \
+	       "NumberOfFailedSweeps:variable,"      + \
+	       "[SamplingFrequency:variable],"       + \
+	       "[SamplingMultiplier:variable],"      + \
+	       "SealThreshold:variable,"             + \
+	       "[TestPulseGroupSelector:string]"
 End
 
 /// @brief Analysis function for checking the seal resistance
@@ -5356,15 +5397,20 @@ Function/S PSQ_TrueRestingMembranePotential_GetHelp(string name)
 End
 
 Function/S PSQ_TrueRestingMembranePotential_GetParams()
-	return "AbsoluteVoltageDiff:variable,RelativeVoltageDiff:variable,"                + \
-	       "NumberOfFailedSweeps:variable,"                                            + \
-	       "BaselineChunkLength:variable,"                                             + \
-	       "UserOffsetTargetVAutobias:variable,"                                       + \
-	       "FailedLevel:variable,SpikeFailureIgnoredTime:variable,"                    + \
-	       "[NextStimSetName:string],[NextIndexingEndStimSetName:string],"             + \
-	       "[BaselineRMSShortThreshold:variable],[BaselineRMSLongThreshold:variable]," + \
-	       "[SamplingFrequency:variable],[SamplingMultiplier:variable],"               + \
-	       "[InterTrialInterval:variable]"
+	return "AbsoluteVoltageDiff:variable,"         + \
+	       "BaselineChunkLength:variable,"         + \
+	       "[BaselineRMSLongThreshold:variable],"  + \
+	       "[BaselineRMSShortThreshold:variable]," + \
+	       "FailedLevel:variable,"                 + \
+	       "[InterTrialInterval:variable],"        + \
+	       "[NextIndexingEndStimSetName:string],"  + \
+	       "[NextStimSetName:string],"             + \
+	       "NumberOfFailedSweeps:variable,"        + \
+	       "RelativeVoltageDiff:variable,"         + \
+	       "[SamplingFrequency:variable],"         + \
+	       "[SamplingMultiplier:variable],"        + \
+	       "SpikeFailureIgnoredTime:variable,"     + \
+	       "UserOffsetTargetVAutobias:variable"
 End
 
 /// @brief Analysis function for determining the mean potential of a stimset

--- a/Packages/Testing-MIES/UTF_AnalysisFunctionManagement.ipf
+++ b/Packages/Testing-MIES/UTF_AnalysisFunctionManagement.ipf
@@ -291,6 +291,31 @@ Function CheckHelpStringsOfAllAnalysisFunctions()
 	endfor
 End
 
+static Function AnalysisParamsMustHaveSameOptionality()
+	variable numFuncs
+	WAVE/T funcs = GetAnalysisFunctions()
+
+	numFuncs = DimSize(funcs, ROWS)
+
+	Make/N=(numFuncs)/WAVE requiredParams = ListToTextWave(AFH_GetListOfAnalysisParamNames(AFH_GetListOfAnalysisParams(funcs[p], REQUIRED_PARAMS)), ";")
+	Make/N=(numFuncs)/WAVE optParams      = ListToTextWave(AFH_GetListOfAnalysisParamNames(AFH_GetListOfAnalysisParams(funcs[p], OPTIONAL_PARAMS)), ";")
+
+	Concatenate/NP/FREE {requiredParams}, allRequiredParams
+	Concatenate/NP/FREE {optParams}, allOptParams
+
+	WAVE/Z allRequiredParamsUnique = GetUniqueEntries(allRequiredParams)
+	WAVE/Z allOptParamsUnique      = GetUniqueEntries(allOptParams)
+
+	WAVE/Z duplicates = GetSetIntersection(allRequiredParamsUnique, allOptParamsUnique)
+
+	// these parameters are expected to have different optionality
+	CHECK(!RemoveTextWaveEntry1D(duplicates, "DAScaleModifier"))
+	CHECK(!RemoveTextWaveEntry1D(duplicates, "DAScaleOperator"))
+	CHECK(!RemoveTextWaveEntry1D(duplicates, "FailedLevel"))
+
+	CHECK_EQUAL_VAR(DimSize(duplicates, ROWS), 0)
+End
+
 // invalid analysis functions
 // UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
 static Function AFT1([str])

--- a/Packages/Testing-MIES/UTF_AnalysisFunctionManagement.ipf
+++ b/Packages/Testing-MIES/UTF_AnalysisFunctionManagement.ipf
@@ -263,17 +263,22 @@ static Function EnsureCorrectUserAnalysis()
 	REQUIRE_EQUAL_VAR(ItemsInList(FunctionList("InvalidSignature", ";", "WIN:UserAnalysisFunctions.ipf")), 1)
 End
 
-Function CheckHelpStringsOfAllAnalysisFunctions()
-	string funcs, genericFunc, params, names, name, help
-	variable i, j, numFuncs, numParams
+static Function/WAVE GetAnalysisFunctions()
+	string funcs
 
 	funcs = WBP_GetAnalysisFunctions(ANALYSIS_FUNCTION_VERSION_V3)
+
 	// remove our test help functions which do nasty things
 	funcs = GrepList(funcs, "Params[[:digit:]]*_V3", 1)
 
-	numFuncs = ItemsInList(funcs)
-	for(i = 0; i < numFuncs; i += 1)
-		genericFunc = StringFromList(i, funcs)
+	return ListToTextWave(funcs, ";")
+End
+
+Function CheckHelpStringsOfAllAnalysisFunctions()
+	string genericFunc, params, names, name, help
+	variable j, numParams
+
+	for(genericFunc : GetAnalysisFunctions())
 		params = AFH_GetListOfAnalysisParams(genericFunc, REQUIRED_PARAMS | OPTIONAL_PARAMS)
 
 		names = AFH_GetListOfAnalysisParamNames(params)

--- a/Packages/Testing-MIES/UTF_PatchSeqChirp.ipf
+++ b/Packages/Testing-MIES/UTF_PatchSeqChirp.ipf
@@ -166,6 +166,7 @@ static Function PS_CR1_IGNORE(string device)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfChirpCycles", var=1)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "SpikeCheck", var=0)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "BoundsEvaluationMode", str="Symmetric")
+	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfFailedSweeps", var=3)
 End
 
 // BBAA but with zero value which results in PSQ_CR_RERUN
@@ -226,6 +227,7 @@ static Function PS_CR2_IGNORE(string device)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfChirpCycles", var=1)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "SpikeCheck", var=0)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "BoundsEvaluationMode", str="Symmetric")
+	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfFailedSweeps", var=3)
 End
 
 // UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
@@ -286,6 +288,7 @@ static Function PS_CR2a_IGNORE(string device)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfChirpCycles", var=1)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "SpikeCheck", var=0)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "BoundsEvaluationMode", str="Depolarized")
+	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfFailedSweeps", var=3)
 End
 
 // UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
@@ -346,6 +349,7 @@ static Function PS_CR2b_IGNORE(string device)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfChirpCycles", var=1)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "SpikeCheck", var=0)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "BoundsEvaluationMode", str="Hyperpolarized")
+	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfFailedSweeps", var=3)
 End
 
 // UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
@@ -406,6 +410,7 @@ static Function PS_CR3_IGNORE(string device)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfChirpCycles", var=1)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "SpikeCheck", var=0)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "BoundsEvaluationMode", str="Symmetric")
+	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfFailedSweeps", var=3)
 End
 
 // UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
@@ -468,6 +473,7 @@ static Function PS_CR4_IGNORE(string device)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfChirpCycles", var=2)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "SpikeCheck", var=0)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "BoundsEvaluationMode", str="Symmetric")
+	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfFailedSweeps", var=3)
 End
 
 // UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
@@ -558,6 +564,7 @@ static Function PS_CR4a_IGNORE(string device)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfChirpCycles", var=2)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "SpikeCheck", var=0)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "BoundsEvaluationMode", str="Depolarized")
+	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfFailedSweeps", var=3)
 End
 
 // UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
@@ -648,6 +655,7 @@ static Function PS_CR4b_IGNORE(string device)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfChirpCycles", var=2)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "SpikeCheck", var=0)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "BoundsEvaluationMode", str="Hyperpolarized")
+	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfFailedSweeps", var=3)
 End
 
 // UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
@@ -738,6 +746,7 @@ static Function PS_CR5_IGNORE(string device)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfChirpCycles", var=2)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "SpikeCheck", var=0)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "BoundsEvaluationMode", str="Symmetric")
+	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfFailedSweeps", var=3)
 End
 
 // UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
@@ -829,6 +838,7 @@ static Function PS_CR6_IGNORE(string device)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfChirpCycles", var=2)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "SpikeCheck", var=0)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "BoundsEvaluationMode", str="Symmetric")
+	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfFailedSweeps", var=3)
 End
 
 // UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
@@ -920,6 +930,7 @@ static Function PS_CR7_IGNORE(string device)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfChirpCycles", var=2)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "SpikeCheck", var=0)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "BoundsEvaluationMode", str="Symmetric")
+	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfFailedSweeps", var=3)
 End
 
 // UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
@@ -1007,6 +1018,7 @@ static Function PS_CR8_IGNORE(string device)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfChirpCycles", var=2)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "SpikeCheck", var=0)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "BoundsEvaluationMode", str="Symmetric")
+	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfFailedSweeps", var=3)
 End
 
 // UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
@@ -1094,6 +1106,7 @@ static Function PS_CR9_IGNORE(string device)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfChirpCycles", var=2)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "SpikeCheck", var=0)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "BoundsEvaluationMode", str="Symmetric")
+	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfFailedSweeps", var=3)
 End
 
 // Enough passing sweeps but not enough with the same DAScale
@@ -1186,6 +1199,7 @@ static Function PS_CR9a_IGNORE(string device)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfChirpCycles", var=2)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "SpikeCheck", var=0)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "BoundsEvaluationMode", str="Depolarized")
+	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfFailedSweeps", var=3)
 End
 
 // Enough passing sweeps but not enough with the same DAScale
@@ -1278,6 +1292,7 @@ static Function PS_CR9b_IGNORE(string device)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfChirpCycles", var=2)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "SpikeCheck", var=0)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "BoundsEvaluationMode", str="Hyperpolarized")
+	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfFailedSweeps", var=3)
 End
 
 // Enough passing sweeps but not enough with the same DAScale
@@ -1370,6 +1385,7 @@ static Function PS_CR10_IGNORE(string device)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfChirpCycles", var=2)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "SpikeCheck", var=0)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "BoundsEvaluationMode", str="Symmetric")
+	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfFailedSweeps", var=3)
 End
 
 // Early abort as not enough sweeps with the same DASCale value pass
@@ -1462,6 +1478,7 @@ static Function PS_CR11_IGNORE(string device)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "DAScaleOperator", str="+")
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "DAScaleModifier", var=1.2)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "BoundsEvaluationMode", str="Symmetric")
+	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfFailedSweeps", var=3)
 End
 
 // UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
@@ -1530,6 +1547,7 @@ static Function PS_CR12_IGNORE(string device)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "DAScaleOperator", str="+")
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "DAScaleModifier", var=1.2)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "BoundsEvaluationMode", str="Symmetric")
+	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfFailedSweeps", var=3)
 End
 
 // UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
@@ -1596,6 +1614,7 @@ static Function PS_CR13_IGNORE(string device)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "DAScaleOperator", str="+")
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "DAScaleModifier", var=1.2)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "BoundsEvaluationMode", str="Symmetric")
+	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfFailedSweeps", var=3)
 End
 
 // Early abort as not enough sweeps with the same DASCale value pass
@@ -1672,6 +1691,7 @@ static Function PS_CR14_IGNORE(string device)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "SpikeCheck", var=0)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "SamplingFrequency", var=10)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "BoundsEvaluationMode", str="Symmetric")
+	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfFailedSweeps", var=3)
 End
 
 // Same as PS_CR1 but with failing sampling interval check
@@ -1734,6 +1754,7 @@ static Function PS_CR15_IGNORE(string device)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfChirpCycles", var=1)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "SpikeCheck", var=0)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "BoundsEvaluationMode", str="Symmetric")
+	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "NumberOfFailedSweeps", var=3)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "AutobiasTargetV", var=45)
 	AFH_AddAnalysisParameter("PatchSeqChirp_DA_0", "AutobiasTargetVAtSetEnd", var=55)
 End

--- a/Packages/doc/dot/patch-seq-chirp.dot
+++ b/Packages/doc/dot/patch-seq-chirp.dot
@@ -105,8 +105,8 @@ digraph G {
 	n69 -> n67;
 	n72	 [label="Add Spike QC passed labnotebook entry"];
 	n71 -> n72	 [label=Yes];
-	"Read analysis parameter \"NumberOfFailedSweeps\",\n if not present use 3.\n Have that many sweeps failed?" -> "Skip to end of DAQ"	 [label=Yes];
-	"Read analysis parameter \"NumberOfFailedSweeps\",\n if not present use 3.\n Have that many sweeps failed?" -> "Set can still pass?"	 [label=No];
+	"Read analysis parameter \"NumberOfFailedSweeps\".\n Have that many sweeps failed?" -> "Skip to end of DAQ"	 [label=Yes];
+	"Read analysis parameter \"NumberOfFailedSweeps\".\n Have that many sweeps failed?" -> "Set can still pass?"	 [label=No];
 	"Mark sweep as passed\n in labnotebook" -> "Has three passing sweeps in set\n with the same DAScale value? [2]";
 	"Enable \"Repeated Acquisition\"" -> "Enable \"Insert TP\"";
 	"Check if only one headstage is active" -> "All checks passed";


### PR DESCRIPTION
So I've written a test to check that all parameters have the same optionality.

In the following I've listed the differences:

```
"DAScaleModifier":
  - Optional: PSQ_DaScale, PSQ_Chirp
  - Required: SC_SpikeControl

"DAScaleOperator":
  - Optional: PSQ_Chirp
  - Required: SC_SpikeControl

BaselineRMSShortThreshold:
BaselineRMSLongThreshold:
  - Required: PSQ_PipetteInBath, PSQ_SealEvaluation
  - Optional: PSQ_DaScale, PSQ_SquarePulse, PSQ_Rheobase, PSQ_Ramp, PSQ_Chirp

NumberOfFailedSweeps:
- Optional: PSQ_Chirp
- Required: PSQ_PipetteInBath, PSQ_SealEvaluation


SamplingMultiplier:
- Optional: PSQ_PipetteInBath, PSQ_SealEvaluation, PSQ_Chirp
- Required: MSQ_FastRheoEst, PSQ_DaScale, PSQ_SquarePulse, PSQ_Rheobase, PSQ_Ramp
```

@timjarsky How should I unify them? All required, all optional?