### PR TITLE
MIES_Include.ipf: Raise required IP9 version [Backport]

### DIFF
--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -2239,7 +2239,7 @@ Function CONF_Position_MCC_Win(serialNum, winTitle, winPosition)
 		return 0
 	endif
 
-	cmdPath = GetWindowsPath(GetFolder(FunctionPath("")) + "..:..:tools:nircmd:nircmd.exe")
+	cmdPath = GetWindowsPath(GetFolder(FunctionPath("")) + "::tools:nircmd:nircmd.exe")
 	if(!FileExists(cmdPath))
 		printf "nircmd.exe is not installed, please download it here: %s", "http://www.nirsoft.net/utils/nircmd.html"
 		return NaN

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -5046,7 +5046,7 @@ static Function DAP_LoadBuiltinStimsets()
 	variable i, numEntries
 
 	symbPath = GetUniqueSymbolicPath()
-	NewPath/Q $symbPath, GetFolder(FunctionPath("")) + "..:Stimsets"
+	NewPath/Q $symbPath, GetFolder(FunctionPath("")) + ":Stimsets"
 
 	PathInfo $symbPath
 	if(!V_flag)

--- a/Packages/MIES/MIES_DebugPanel.ipf
+++ b/Packages/MIES/MIES_DebugPanel.ipf
@@ -113,11 +113,11 @@ static Function DP_FillDebugPanelWaves()
 
 	symbPath = GetUniqueSymbolicPath()
 
-	path = FunctionPath("") + ":..:"
+	path = FunctionPath("") + "::"
 	NewPath/Q/O $symbPath, path
 	allProcFiles = GetAllFilesRecursivelyFromPath(symbPath, extension=".ipf")
 
-	path += "..:IPNWB"
+	path += ":IPNWB"
 	NewPath/Q/O $symbPath, path
 	allProcFiles = AddListItem(allProcFiles, GetAllFilesRecursivelyFromPath(symbPath, extension=".ipf"), "|")
 

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -7183,10 +7183,10 @@ Function UploadCrashDumps()
 	diagPath = S_path
 
 	basePath = GetUniqueSymbolicPath()
-	NewPath/Q/O/Z $basePath diagPath + "..:"
+	NewPath/Q/O/Z $basePath diagPath + ":"
 
 #ifdef DEBUGGING_ENABLED
-	SaveTextFile(JSON_dump(jsonID, indent=4), diagPath + "..:" + UniqueFileOrFolder(basePath, "crash-dumps", suffix = ".json"))
+	SaveTextFile(JSON_dump(jsonID, indent=4), diagPath + ":" + UniqueFileOrFolder(basePath, "crash-dumps", suffix = ".json"))
 #endif // DEBUGGING_ENABLED
 
 	UploadJSONPayload(jsonID)

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -4680,7 +4680,7 @@ End
 Function TurnOffASLR()
 	string cmd, path
 
-	path = GetFolder(FunctionPath("")) + "..:ITCXOP2:tools:Disable-ASLR-for-IP7-and-8.ps1"
+	path = GetFolder(FunctionPath("")) + ":ITCXOP2:tools:Disable-ASLR-for-IP7-and-8.ps1"
 	ASSERT(FileExists(path), "Could not locate powershell script")
 	sprintf cmd, "powershell.exe -ExecutionPolicy Bypass \"%s\"", GetWindowsPath(path)
 	ExecuteScriptText/B/Z cmd

--- a/Packages/MIES_Include.ipf
+++ b/Packages/MIES_Include.ipf
@@ -16,12 +16,12 @@
 // They are defined here so that we can parse them from within IP.
 //
 // .. |IgorPro8Nightly| replace:: `Igor Pro 8 <https://www.byte-physics.de/Downloads/WinIgor8_12MAY2021.zip>`__
-// .. |IgorPro9Nightly| replace:: `Igor Pro 9 <https://www.byte-physics.de/Downloads/WinIgor9_31MAR2022.zip>`__
+// .. |IgorPro9Nightly| replace:: `Igor Pro 9 <https://www.byte-physics.de/Downloads/WinIgor9_30APR2022.zip>`__
 
 #pragma IgorVersion=8.04
 
 #if IgorVersion() >= 9.0
-#if (NumberByKey("BUILD", IgorInfo(0)) < 38847)
+#if (NumberByKey("BUILD", IgorInfo(0)) < 38961)
 #define TOO_OLD_IGOR
 #endif
 #else

--- a/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
+++ b/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
@@ -3968,7 +3968,7 @@ Function RestoreDAEphysPanel([str])
 	jPath = MIES_CONF#CONF_FindControl(jsonID, "popup_MoreSettings_Devices")
 	JSON_SetString(jsonID, jPath + "/StrValue", str)
 	JSON_SetString(jsonID, "/Common configuration data/Save data to", S_path)
-	stimSetPath = S_path + "..:..:Packages:Testing-MIES:_2017_09_01_192934-compressed.nwb"
+	stimSetPath = S_path + "::Packages:Testing-MIES:_2017_09_01_192934-compressed.nwb"
 	JSON_SetString(jsonID, "/Common configuration data/Stim set file name", stimSetPath)
 
 	// replace stored serial number with present serial number


### PR DESCRIPTION
This has a fix which is supposed to be responsible for at least 1/3 of
the crashes between 8/2021 and 4/2022.