### PR TITLE
LBV_UpdateLBGraphLegend: Tweak legend

### DIFF
--- a/Packages/MIES/MIES_LogbookViewer.ipf
+++ b/Packages/MIES/MIES_LogbookViewer.ipf
@@ -431,7 +431,7 @@ static Function LBV_UpdateLBGraphLegend(string graph, [string traceList])
 			str += prefix + num2str(headstage)
 		else
 			if(!hasAllEntry)
-				str += prefix + "all"
+				str += prefix + "indep"
 				hasAllEntry = 1
 			endif
 		endif


### PR DESCRIPTION
At the very beginning of the labnotebook in MIES we treated the last
layer as the "all" entry for all headstages. This was very quickly
abandoned in favour of the concept of having headstage independent
entries stored there instead.

We therefore now rename the legend in the logboook viewer from all to indep.
