### PR TITLE
ShowTraceInfoTags: Call it only once per Databrowser

### DIFF
--- a/Packages/MIES/MIES_BrowserSettingsPanel.ipf
+++ b/Packages/MIES/MIES_BrowserSettingsPanel.ipf
@@ -85,6 +85,8 @@ Function BSP_InitPanel(mainPanel)
 
 	graph = LBV_GetLabNoteBookGraph(mainPanel)
 	TUD_Init(graph)
+
+	ShowTraceInfoTags()
 End
 
 /// @brief UnHides BrowserSettings side Panel
@@ -1661,9 +1663,6 @@ Function BSP_AddTracesForEpochs(string win)
 		ModifyGraph/W=$win marker($level_4_trace)=10, mode($level_4_trace)=4, rgb($level_4_trace)=(c.red, c.green, c.blue)
 
 		SetWindow $win tooltipHook(hook) = BSP_EpochGraphToolTip
-
-		DoWindow/F $win
-		Execute/P/Q/Z "ShowTraceInfoTags()"
 
 		SetAxis/W=$win/A
 	endfor

--- a/Packages/MIES/MIES_GuiUtilities.ipf
+++ b/Packages/MIES/MIES_GuiUtilities.ipf
@@ -2082,9 +2082,6 @@ Function/S GetPopupMenuList(string value, variable type)
 End
 
 /// @brief Enable show trace info tags for the current top graph
-///
-/// Callers should call that via the operation queue to avoid
-/// GUI event processing from happening.
 Function ShowTraceInfoTags()
 
 	DoIgorMenu/C "Graph", "Show Trace Info Tags"


### PR DESCRIPTION
We actually only need to call it once, as it is a global setting and not a
per-graph setting.

Doing it in BSP_InitPanel is close enough.

Close #1364.
Close #1280.
