### PR TITLE
PSQ_AccessResistanceSmoke: Make BaselineChunkLength analysis paramete…

### DIFF
--- a/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
@@ -5691,7 +5691,7 @@ static Function PSQ_CreateBaselineChunkSelectionEpochs(string device, variable h
 
 	totalOnsetDelay = GetTotalOnsetDelayFromDevice(device)
 
-	chunkLength = AFH_GetAnalysisParamNumerical("BaselineChunkLength", params) * MILLI_TO_ONE
+	chunkLength = AFH_GetAnalysisParamNumerical("BaselineChunkLength", params, defValue = PSQ_BL_EVAL_RANGE) * MILLI_TO_ONE
 	ASSERT(IsFinite(chunkLength), "BaselineChunkLength must be finite")
 
 	wbBegin = 0
@@ -6007,7 +6007,7 @@ Function/S PSQ_AccessResistanceSmoke_GetHelp(string name)
 End
 
 Function/S PSQ_AccessResistanceSmoke_GetParams()
-	return "BaselineChunkLength:variable,"                   + \
+	return "[BaselineChunkLength:variable],"                 + \
 	       "[BaselineRMSLongThreshold:variable],"            + \
 	       "[BaselineRMSShortThreshold:variable],"           + \
 	       "MaxAccessResistance:variable,"                   + \


### PR DESCRIPTION
…r optional

The two pull requests introducing optionality checking in 010771e1 (Merge
pull request #1345 from
AllenInstitute/bugfix/1345-same-optionality-for-all-analysis-function-parameters,
2022-05-17) and adding PSQ_AccessResistanceSmoke in b66d422b (Merge pull
request #1361 from AllenInstitute/feature/1358-access-resistance-check,
2022-05-17) crossed, so this is only broken now.