### PR TITLE
Generalize checks for NextStimsetName/NextIndexingEndStimsetName

### DIFF
--- a/Packages/Testing-MIES/UTF_PatchSeqAccessResistanceSmoke.ipf
+++ b/Packages/Testing-MIES/UTF_PatchSeqAccessResistanceSmoke.ipf
@@ -215,17 +215,6 @@ static Function/WAVE GetEntries_IGNORE(string device, variable sweepNo)
 	return wv
 End
 
-static Function [string stimset, string stimsetIndexEnd] GetStimsets_IGNORE(string device)
-	variable DAC
-	string ctrl0, ctrl1
-
-	DAC   = AFH_GetDACFromHeadstage(device, PSQ_TEST_HEADSTAGE)
-	ctrl0 = GetSpecialControlLabel(CHANNEL_TYPE_DAC, CHANNEL_CONTROL_WAVE)
-	ctrl1 = GetSpecialControlLabel(CHANNEL_TYPE_DAC, CHANNEL_CONTROL_INDEX_END)
-
-	return [DAG_GetTextualValue(device, ctrl0, index = DAC), DAG_GetTextualValue(device, ctrl1, index = DAC)]
-End
-
 static Function CheckBaselineChunks(string device, WAVE chunkTimes, [variable sweepNo])
 
 	if(ParamIsDefault(sweepNo))
@@ -324,12 +313,6 @@ static Function PS_AR1_REENTRY([string str])
 	CHECK_WAVE(entries[%resistanceRatio], NULL_WAVE)
 	CHECK_EQUAL_WAVES(entries[%resistanceRatioPass], {0, 0, 0}, mode = WAVE_DATA)
 
-	[stimset, stimsetIndexEnd]  = GetStimsets_IGNORE(str)
-	expected = "PSQ_QC_stimsets_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
-	expected = NONE
-	CHECK_EQUAL_STR(stimsetIndexEnd, expected)
-
 	CHECK_WAVE(entries[%resultsSweep], NULL_WAVE)
 	CHECK_WAVE(entries[%resultsPeakResistance], NULL_WAVE)
 	CHECK_WAVE(entries[%resultsSSResistance], NULL_WAVE)
@@ -398,12 +381,6 @@ static Function PS_AR2_REENTRY([string str])
 
 	CHECK_EQUAL_WAVES(entries[%resistanceRatio], {0.83}, mode = WAVE_DATA, tol = 1e-2)
 	CHECK_EQUAL_WAVES(entries[%resistanceRatioPass], {1}, mode = WAVE_DATA)
-
-	[stimset, stimsetIndexEnd]  = GetStimsets_IGNORE(str)
-	expected = "StimulusSetA_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
-	expected = "StimulusSetB_DA_0"
-	CHECK_EQUAL_STR(stimsetIndexEnd, expected)
 
 	CHECK_WAVE(entries[%resultsSweep], TEXT_WAVE)
 	CHECK_WAVE(entries[%resultsPeakResistance], TEXT_WAVE)
@@ -474,12 +451,6 @@ static Function PS_AR3_REENTRY([string str])
 	CHECK_EQUAL_WAVES(entries[%resistanceRatio], {0.83, 0.83, 0.83}, mode = WAVE_DATA, tol = 1e-2)
 	CHECK_EQUAL_WAVES(entries[%resistanceRatioPass], {1, 1, 1}, mode = WAVE_DATA)
 
-	[stimset, stimsetIndexEnd]  = GetStimsets_IGNORE(str)
-	expected = "PSQ_QC_stimsets_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
-	expected = NONE
-	CHECK_EQUAL_STR(stimsetIndexEnd, expected)
-
 	CHECK_WAVE(entries[%resultsSweep], TEXT_WAVE)
 	CHECK_WAVE(entries[%resultsPeakResistance], TEXT_WAVE)
 	CHECK_WAVE(entries[%resultsSSResistance], TEXT_WAVE)
@@ -549,12 +520,6 @@ static Function PS_AR4_REENTRY([string str])
 	CHECK_EQUAL_WAVES(entries[%resistanceRatio], {0.83, 0.83, 0.83}, mode = WAVE_DATA, tol = 1e-2)
 	CHECK_EQUAL_WAVES(entries[%resistanceRatioPass], {0, 0, 0}, mode = WAVE_DATA)
 
-	[stimset, stimsetIndexEnd]  = GetStimsets_IGNORE(str)
-	expected = "PSQ_QC_stimsets_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
-	expected = NONE
-	CHECK_EQUAL_STR(stimsetIndexEnd, expected)
-
 	CHECK_WAVE(entries[%resultsSweep], TEXT_WAVE)
 	CHECK_WAVE(entries[%resultsPeakResistance], TEXT_WAVE)
 	CHECK_WAVE(entries[%resultsSSResistance], TEXT_WAVE)
@@ -622,12 +587,6 @@ static Function PS_AR5_REENTRY([string str])
 
 	CHECK_WAVE(entries[%resistanceRatio], NULL_WAVE)
 	CHECK_EQUAL_WAVES(entries[%resistanceRatioPass], {0, 0, 0}, mode = WAVE_DATA)
-
-	[stimset, stimsetIndexEnd]  = GetStimsets_IGNORE(str)
-	expected = "PSQ_QC_stimsets_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
-	expected = NONE
-	CHECK_EQUAL_STR(stimsetIndexEnd, expected)
 
 	CHECK_WAVE(entries[%resultsSweep], NULL_WAVE)
 	CHECK_WAVE(entries[%resultsPeakResistance], NULL_WAVE)
@@ -717,12 +676,6 @@ static Function PS_AR6_REENTRY([string str])
 
 	CHECK_EQUAL_WAVES(entries[%resistanceRatio], {NaN, 0.83, 1.66, 0.83}, mode = WAVE_DATA, tol = 1e-2)
 	CHECK_EQUAL_WAVES(entries[%resistanceRatioPass], {0, 1, 0, 1}, mode = WAVE_DATA)
-
-	[stimset, stimsetIndexEnd]  = GetStimsets_IGNORE(str)
-	expected = "StimulusSetA_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
-	expected = NONE
-	CHECK_EQUAL_STR(stimsetIndexEnd, expected)
 
 	CHECK_WAVE(entries[%resultsSweep], TEXT_WAVE)
 	CHECK_WAVE(entries[%resultsPeakResistance], TEXT_WAVE)
@@ -827,12 +780,6 @@ static Function PS_AR8_REENTRY([string str])
 
 	CHECK_EQUAL_WAVES(entries[%resistanceRatio], {0.83}, mode = WAVE_DATA, tol = 1e-2)
 	CHECK_EQUAL_WAVES(entries[%resistanceRatioPass], {1}, mode = WAVE_DATA)
-
-	[stimset, stimsetIndexEnd]  = GetStimsets_IGNORE(str)
-	expected = "PSQ_QC_stimsets_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
-	expected = NONE
-	CHECK_EQUAL_STR(stimsetIndexEnd, expected)
 
 	CHECK_WAVE(entries[%resultsSweep], TEXT_WAVE)
 	CHECK_WAVE(entries[%resultsPeakResistance], TEXT_WAVE)

--- a/Packages/Testing-MIES/UTF_PatchSeqPipetteInBath.ipf
+++ b/Packages/Testing-MIES/UTF_PatchSeqPipetteInBath.ipf
@@ -221,13 +221,6 @@ static Function/WAVE GetEntries_IGNORE(string device, variable sweepNo)
 	return wv
 End
 
-static Function/S GetStimset_IGNORE(string device)
-	variable DAC
-
-	DAC = AFH_GetDACFromHeadstage(device, PSQ_TEST_HEADSTAGE)
-	return AFH_GetStimSetName(device, DAC, CHANNEL_TYPE_DAC)
-End
-
 static Function CheckTestPulseLikeEpochs(string device,[variable incomplete])
 
 	if(ParamIsDefault(incomplete))
@@ -306,10 +299,6 @@ static Function PS_PB1_REENTRY([str])
 	CHECK_EQUAL_WAVES(entries[%resistance], resistanceRef, mode = WAVE_DATA)
 	CHECK_EQUAL_WAVES(entries[%resistancePass], {0, 0, 0}, mode = WAVE_DATA)
 
-	stimset  = GetStimset_IGNORE(str)
-	expected = "PSQ_QC_stimsets_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
-
 	CHECK_WAVE(entries[%resultsSweep], NULL_WAVE)
 	CHECK_WAVE(entries[%resultsResistance], NULL_WAVE)
 
@@ -370,10 +359,6 @@ static Function PS_PB2_REENTRY([str])
 	Make/FREE/D resistanceRef = {12.5e6}
 	CHECK_EQUAL_WAVES(entries[%resistance], resistanceRef, mode = WAVE_DATA)
 	CHECK_EQUAL_WAVES(entries[%resistancePass], {1}, mode = WAVE_DATA)
-
-	stimset  = GetStimset_IGNORE(str)
-	expected = "StimulusSetA_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
 
 	CHECK_EQUAL_TEXTWAVES(entries[%resultsSweep], {"0;"}, mode = WAVE_DATA)
 	CHECK_WAVE(entries[%resultsResistance], TEXT_WAVE)
@@ -448,10 +433,6 @@ static Function PS_PB3_REENTRY([str])
 	CHECK_EQUAL_WAVES(entries[%resistance], resistanceRef, mode = WAVE_DATA)
 	CHECK_EQUAL_WAVES(entries[%resistancePass], {0, 1, 0}, mode = WAVE_DATA)
 
-	stimset  = GetStimset_IGNORE(str)
-	expected = "PSQ_QC_stimsets_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
-
 	CHECK_EQUAL_TEXTWAVES(entries[%resultsSweep], {"0;", "1;", "2;"}, mode = WAVE_DATA)
 	CHECK_WAVE(entries[%resultsResistance], TEXT_WAVE)
 	CHECK_EQUAL_VAR(DimSize(entries[%resultsResistance], Rows), 3)
@@ -514,10 +495,6 @@ static Function PS_PB4_REENTRY([str])
 	Make/FREE/D resistanceRef = {5e6, 5e6}
 	CHECK_EQUAL_WAVES(entries[%resistance], resistanceRef, mode = WAVE_DATA)
 	CHECK_EQUAL_WAVES(entries[%resistancePass], {0, 0}, mode = WAVE_DATA)
-
-	stimset  = GetStimset_IGNORE(str)
-	expected = "PSQ_QC_stimsets_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
 
 	CHECK_WAVE(entries[%resultsSweep], NULL_WAVE)
 	CHECK_WAVE(entries[%resultsResistance], NULL_WAVE)
@@ -584,10 +561,6 @@ static Function PS_PB5_REENTRY([str])
 	CHECK_EQUAL_WAVES(entries[%resistance], resistanceRef, mode = WAVE_DATA)
 	CHECK_EQUAL_WAVES(entries[%resistancePass], {1, 1, 1}, mode = WAVE_DATA)
 
-	stimset  = GetStimset_IGNORE(str)
-	expected = "PSQ_QC_stimsets_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
-
 	CHECK_WAVE(entries[%resultsSweep], NULL_WAVE)
 	CHECK_WAVE(entries[%resultsResistance], NULL_WAVE)
 
@@ -653,10 +626,6 @@ static Function PS_PB6_REENTRY([str])
 	CHECK_EQUAL_WAVES(entries[%resistance], resistanceRef, mode = WAVE_DATA)
 	CHECK_EQUAL_WAVES(entries[%resistancePass], {1, 1, 1}, mode = WAVE_DATA)
 
-	stimset  = GetStimset_IGNORE(str)
-	expected = "PSQ_QC_stimsets_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
-
 	CHECK_WAVE(entries[%resultsSweep], NULL_WAVE)
 	CHECK_WAVE(entries[%resultsResistance], NULL_WAVE)
 
@@ -721,10 +690,6 @@ static Function PS_PB7_REENTRY([str])
 	Make/FREE/D resistanceRef = {12.5e6}
 	CHECK_EQUAL_WAVES(entries[%resistance], resistanceRef, mode = WAVE_DATA)
 	CHECK_EQUAL_WAVES(entries[%resistancePass], {1}, mode = WAVE_DATA)
-
-	stimset  = GetStimset_IGNORE(str)
-	expected = "PSQ_QC_stimsets_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
 
 	CHECK_EQUAL_TEXTWAVES(entries[%resultsSweep], {"0;"}, mode = WAVE_DATA)
 	CHECK_WAVE(entries[%resultsResistance], TEXT_WAVE)

--- a/Packages/Testing-MIES/UTF_PatchSeqSealEvaluation.ipf
+++ b/Packages/Testing-MIES/UTF_PatchSeqSealEvaluation.ipf
@@ -210,13 +210,6 @@ static Function/WAVE GetEntries_IGNORE(string device, variable sweepNo)
 	return wv
 End
 
-static Function/S GetStimset_IGNORE(string device)
-	variable DAC
-
-	DAC = AFH_GetDACFromHeadstage(device, PSQ_TEST_HEADSTAGE)
-	return AFH_GetStimSetName(device, DAC, CHANNEL_TYPE_DAC)
-End
-
 static Function CheckTestPulseLikeEpochs(string device, variable testpulseGroupSel)
 
 	switch(testpulseGroupSel)
@@ -304,7 +297,7 @@ static Function PS_SE1_REENTRY([str])
 	string str
 
 	variable sweepNo, autobiasV
-	string lbl, failedPulses, spikeCounts, stimset, expected
+	string lbl, failedPulses, spikeCounts
 
 	sweepNo = 2
 
@@ -331,10 +324,6 @@ static Function PS_SE1_REENTRY([str])
 	CHECK_EQUAL_WAVES(entries[%resistanceMax], resistanceMaxRef, mode = WAVE_DATA)
 
 	CHECK_EQUAL_WAVES(entries[%resistancePass], {0, 0, 0}, mode = WAVE_DATA)
-
-	stimset  = GetStimset_IGNORE(str)
-	expected = "PatchSeqSealChec_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
 
 	CHECK_EQUAL_TEXTWAVES(entries[%resultsSweep], {"0;", "1;", "2;"}, mode = WAVE_DATA)
 	CHECK_WAVE(entries[%resultsResistanceA], TEXT_WAVE)
@@ -381,7 +370,7 @@ static Function PS_SE2_REENTRY([str])
 	string str
 
 	variable sweepNo, autobiasV
-	string lbl, failedPulses, spikeCounts, stimset, expected
+	string lbl, failedPulses, spikeCounts
 
 	sweepNo = 0
 
@@ -408,10 +397,6 @@ static Function PS_SE2_REENTRY([str])
 	CHECK_EQUAL_WAVES(entries[%resistanceMax], resistanceMaxRef, mode = WAVE_DATA)
 
 	CHECK_EQUAL_WAVES(entries[%resistancePass], {1}, mode = WAVE_DATA)
-
-	stimset  = GetStimset_IGNORE(str)
-	expected = "StimulusSetA_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
 
 	CHECK_EQUAL_TEXTWAVES(entries[%resultsSweep], {"0;"}, mode = WAVE_DATA)
 	CHECK_WAVE(entries[%resultsResistanceA], TEXT_WAVE)
@@ -458,7 +443,7 @@ static Function PS_SE3_REENTRY([str])
 	string str
 
 	variable sweepNo, autobiasV
-	string lbl, failedPulses, spikeCounts, stimset, expected
+	string lbl, failedPulses, spikeCounts
 
 	sweepNo = 0
 
@@ -484,10 +469,6 @@ static Function PS_SE3_REENTRY([str])
 	CHECK_EQUAL_WAVES(entries[%resistanceMax], resistanceMaxRef, mode = WAVE_DATA)
 
 	CHECK_EQUAL_WAVES(entries[%resistancePass], {1}, mode = WAVE_DATA)
-
-	stimset  = GetStimset_IGNORE(str)
-	expected = "StimulusSetA_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
 
 	CHECK_EQUAL_TEXTWAVES(entries[%resultsSweep], {"0;"}, mode = WAVE_DATA)
 	CHECK_WAVE(entries[%resultsResistanceA], TEXT_WAVE)
@@ -534,7 +515,7 @@ static Function PS_SE4_REENTRY([str])
 	string str
 
 	variable sweepNo, autobiasV
-	string lbl, failedPulses, spikeCounts, stimset, expected
+	string lbl, failedPulses, spikeCounts
 
 	sweepNo = 0
 
@@ -560,10 +541,6 @@ static Function PS_SE4_REENTRY([str])
 	CHECK_EQUAL_WAVES(entries[%resistanceMax], resistanceMaxRef, mode = WAVE_DATA)
 
 	CHECK_EQUAL_WAVES(entries[%resistancePass], {1}, mode = WAVE_DATA)
-
-	stimset  = GetStimset_IGNORE(str)
-	expected = "StimulusSetA_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
 
 	CHECK_EQUAL_TEXTWAVES(entries[%resultsSweep], {"0;"}, mode = WAVE_DATA)
 	CHECK_WAVE(entries[%resultsResistanceA], NULL_WAVE)
@@ -611,7 +588,7 @@ static Function PS_SE5_REENTRY([str])
 	string str
 
 	variable sweepNo, autobiasV
-	string lbl, failedPulses, spikeCounts, stimset, expected
+	string lbl, failedPulses, spikeCounts
 
 	sweepNo = 2
 
@@ -638,10 +615,6 @@ static Function PS_SE5_REENTRY([str])
 	CHECK_EQUAL_WAVES(entries[%resistanceMax], resistanceMaxRef, mode = WAVE_DATA)
 
 	CHECK_EQUAL_WAVES(entries[%resistancePass], {1, 1, 1}, mode = WAVE_DATA)
-
-	stimset  = GetStimset_IGNORE(str)
-	expected = "PatchSeqSealChec_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
 
 	CHECK_EQUAL_TEXTWAVES(entries[%resultsSweep], {"0;", "1;", "2;"}, mode = WAVE_DATA)
 	CHECK_WAVE(entries[%resultsResistanceA], TEXT_WAVE)
@@ -689,7 +662,7 @@ static Function PS_SE6_REENTRY([str])
 	string str
 
 	variable sweepNo, autobiasV
-	string lbl, failedPulses, spikeCounts, stimset, expected
+	string lbl, failedPulses, spikeCounts
 
 	sweepNo = 2
 
@@ -716,10 +689,6 @@ static Function PS_SE6_REENTRY([str])
 	CHECK_EQUAL_WAVES(entries[%resistanceMax], resistanceMaxRef, mode = WAVE_DATA)
 
 	CHECK_EQUAL_WAVES(entries[%resistancePass], {1, 1, 1}, mode = WAVE_DATA)
-
-	stimset  = GetStimset_IGNORE(str)
-	expected = "PatchSeqSealChec_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
 
 	CHECK_EQUAL_TEXTWAVES(entries[%resultsSweep], {"0;", "1;", "2;"}, mode = WAVE_DATA)
 	CHECK_WAVE(entries[%resultsResistanceA], TEXT_WAVE)
@@ -766,7 +735,7 @@ static Function PS_SE7_REENTRY([str])
 	string str
 
 	variable sweepNo, autobiasV
-	string lbl, failedPulses, spikeCounts, stimset, expected
+	string lbl, failedPulses, spikeCounts
 
 	sweepNo = 0
 
@@ -793,10 +762,6 @@ static Function PS_SE7_REENTRY([str])
 	CHECK_EQUAL_WAVES(entries[%resistanceMax], resistanceMaxRef, mode = WAVE_DATA)
 
 	CHECK_EQUAL_WAVES(entries[%resistancePass], {0}, mode = WAVE_DATA)
-
-	stimset  = GetStimset_IGNORE(str)
-	expected = "PatchSeqSealChec_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
 
 	CHECK_EQUAL_TEXTWAVES(entries[%resultsSweep], {"0;"}, mode = WAVE_DATA)
 	CHECK_WAVE(entries[%resultsResistanceA], TEXT_WAVE)
@@ -875,7 +840,7 @@ static Function PS_SE9_REENTRY([str])
 	string str
 
 	variable sweepNo, autobiasV
-	string lbl, failedPulses, spikeCounts, stimset, expected
+	string lbl, failedPulses, spikeCounts
 
 	sweepNo = 0
 
@@ -902,10 +867,6 @@ static Function PS_SE9_REENTRY([str])
 	CHECK_EQUAL_WAVES(entries[%resistanceMax], resistanceMaxRef, mode = WAVE_DATA)
 
 	CHECK_EQUAL_WAVES(entries[%resistancePass], {1}, mode = WAVE_DATA)
-
-	stimset  = GetStimset_IGNORE(str)
-	expected = "PatchSeqSealChec_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
 
 	CHECK_EQUAL_TEXTWAVES(entries[%resultsSweep], {"0;"}, mode = WAVE_DATA)
 	CHECK_WAVE(entries[%resultsResistanceA], TEXT_WAVE)

--- a/Packages/Testing-MIES/UTF_PatchSeqTrueRestingMembranePotential.ipf
+++ b/Packages/Testing-MIES/UTF_PatchSeqTrueRestingMembranePotential.ipf
@@ -219,17 +219,6 @@ static Function/WAVE GetEntries_IGNORE(string device, variable sweepNo)
 	return wv
 End
 
-static Function [string stimset, string stimsetIndexEnd] GetStimsets_IGNORE(string device)
-	variable DAC
-	string ctrl0, ctrl1
-
-	DAC   = AFH_GetDACFromHeadstage(device, PSQ_TEST_HEADSTAGE)
-	ctrl0 = GetSpecialControlLabel(CHANNEL_TYPE_DAC, CHANNEL_CONTROL_WAVE)
-	ctrl1 = GetSpecialControlLabel(CHANNEL_TYPE_DAC, CHANNEL_CONTROL_INDEX_END)
-
-	return [DAG_GetTextualValue(device, ctrl0, index = DAC), DAG_GetTextualValue(device, ctrl1, index = DAC)]
-End
-
 Function CheckBaselineChunks(string device, WAVE chunkTimes)
 
 	CheckUserEpochs(device, {20, 520, 625, 1125}, EPOCH_SHORTNAME_USER_PREFIX + "BLS%d", sweep = 0)
@@ -287,7 +276,6 @@ End
 
 static Function PS_VM1_REENTRY([string str])
 	variable sweepNo
-	string stimset, stimsetIndexEnd, expected
 
 	sweepNo = 2
 
@@ -317,8 +305,6 @@ static Function PS_VM1_REENTRY([string str])
 
 	CHECK_EQUAL_TEXTWAVES(entries[%spikePositions], {"1;", "2;2;", "3;3;3;"}, mode = WAVE_DATA)
 
-	CHECK_EQUAL_VAR(DAG_GetNumericalValue(str, "Check_DataAcq_Indexing"), 0)
-
 	// first sweep does not have autobias enabled
 	// and the last sweep's setting is only available in the GUI
 	CHECK_EQUAL_WAVES(entries[%autobiasVcom], {0, 11, 12}, mode = WAVE_DATA)
@@ -332,12 +318,6 @@ static Function PS_VM1_REENTRY([string str])
 
 	CHECK_EQUAL_WAVES(entries[%getsetiti], {1, 0, 0}, mode = WAVE_DATA)
 	CHECK_EQUAL_VAR(DAG_GetNumericalValue(str, "Check_DataAcq_Get_Set_ITI"), 1)
-
-	[stimset, stimsetIndexEnd]  = GetStimsets_IGNORE(str)
-	expected = "PSQ_TrueRest_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
-	expected = NONE
-	CHECK_EQUAL_STR(stimsetIndexEnd, expected)
 
 	CommonAnalysisFunctionChecks(str, sweepNo, entries[%setPass])
 	CheckBaselineChunks(str, {20, 520})
@@ -394,7 +374,6 @@ End
 
 static Function PS_VM2_REENTRY([string str])
 	variable sweepNo
-	string stimset, stimsetIndexEnd, expected
 
 	sweepNo = 0
 
@@ -429,8 +408,6 @@ static Function PS_VM2_REENTRY([string str])
 
 	CHECK_WAVE(entries[%spikePositions], NULL_WAVE)
 
-	CHECK_EQUAL_VAR(DAG_GetNumericalValue(str, "Check_DataAcq_Indexing"), 1)
-
 	// first sweep does not have autobias enabled
 	// and the last sweep's setting is only available in the GUI
 	CHECK_EQUAL_WAVES(entries[%autobiasVcom], {0}, mode = WAVE_DATA)
@@ -444,12 +421,6 @@ static Function PS_VM2_REENTRY([string str])
 
 	CHECK_EQUAL_WAVES(entries[%getsetiti], {1}, mode = WAVE_DATA)
 	CHECK_EQUAL_VAR(DAG_GetNumericalValue(str, "Check_DataAcq_Get_Set_ITI"), 1)
-
-	[stimset, stimsetIndexEnd] = GetStimsets_IGNORE(str)
-	expected = "StimulusSetA_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
-	expected = "StimulusSetB_DA_0"
-	CHECK_EQUAL_STR(stimsetIndexEnd, expected)
 
 	CommonAnalysisFunctionChecks(str, sweepNo, entries[%setPass])
 	CheckBaselineChunks(str, {20, 520})
@@ -507,7 +478,6 @@ End
 
 static Function PS_VM3_REENTRY([string str])
 	variable sweepNo
-	string stimset, stimsetIndexEnd, expected
 
 	sweepNo = 2
 
@@ -537,8 +507,6 @@ static Function PS_VM3_REENTRY([string str])
 
 	CHECK_WAVE(entries[%spikePositions], NULL_WAVE)
 
-	CHECK_EQUAL_VAR(DAG_GetNumericalValue(str, "Check_DataAcq_Indexing"), 0)
-
 	// first sweep does not have autobias enabled
 	// and the last sweep's setting is only available in the GUI
 	CHECK_EQUAL_WAVES(entries[%autobiasVcom], {0, 0, 0}, mode = WAVE_DATA)
@@ -552,12 +520,6 @@ static Function PS_VM3_REENTRY([string str])
 
 	CHECK_EQUAL_WAVES(entries[%getsetiti], {1, 1, 1}, mode = WAVE_DATA)
 	CHECK_EQUAL_VAR(DAG_GetNumericalValue(str, "Check_DataAcq_Get_Set_ITI"), 1)
-
-	[stimset, stimsetIndexEnd]  = GetStimsets_IGNORE(str)
-	expected = "PSQ_TrueRest_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
-	expected = NONE
-	CHECK_EQUAL_STR(stimsetIndexEnd, expected)
 
 	CommonAnalysisFunctionChecks(str, sweepNo, entries[%setPass])
 	CheckBaselineChunks(str, {20, 520})
@@ -614,7 +576,6 @@ End
 
 static Function PS_VM4_REENTRY([string str])
 	variable sweepNo
-	string stimset, stimsetIndexEnd, expected
 
 	sweepNo = 2
 
@@ -649,8 +610,6 @@ static Function PS_VM4_REENTRY([string str])
 
 	CHECK_WAVE(entries[%spikePositions], NULL_WAVE)
 
-	CHECK_EQUAL_VAR(DAG_GetNumericalValue(str, "Check_DataAcq_Indexing"), 0)
-
 	// first sweep does not have autobias enabled
 	// and the last sweep's setting is only available in the GUI
 	CHECK_EQUAL_WAVES(entries[%autobiasVcom], {0, 0, 0}, mode = WAVE_DATA)
@@ -664,12 +623,6 @@ static Function PS_VM4_REENTRY([string str])
 
 	CHECK_EQUAL_WAVES(entries[%getsetiti], {1, 1, 1}, mode = WAVE_DATA)
 	CHECK_EQUAL_VAR(DAG_GetNumericalValue(str, "Check_DataAcq_Get_Set_ITI"), 1)
-
-	[stimset, stimsetIndexEnd]  = GetStimsets_IGNORE(str)
-	expected = "PSQ_TrueRest_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
-	expected = NONE
-	CHECK_EQUAL_STR(stimsetIndexEnd, expected)
 
 	CommonAnalysisFunctionChecks(str, sweepNo, entries[%setPass])
 	CheckBaselineChunks(str, {20, 520})
@@ -726,7 +679,6 @@ End
 
 static Function PS_VM5_REENTRY([string str])
 	variable sweepNo
-	string stimset, stimsetIndexEnd, expected
 
 	sweepNo = 2
 
@@ -761,8 +713,6 @@ static Function PS_VM5_REENTRY([string str])
 
 	CHECK_WAVE(entries[%spikePositions], NULL_WAVE)
 
-	CHECK_EQUAL_VAR(DAG_GetNumericalValue(str, "Check_DataAcq_Indexing"), 0)
-
 	// first sweep does not have autobias enabled
 	// and the last sweep's setting is only available in the GUI
 	CHECK_EQUAL_WAVES(entries[%autobiasVcom], {0, 0, 0}, mode = WAVE_DATA)
@@ -776,12 +726,6 @@ static Function PS_VM5_REENTRY([string str])
 
 	CHECK_EQUAL_WAVES(entries[%getsetiti], {1, 1, 1}, mode = WAVE_DATA)
 	CHECK_EQUAL_VAR(DAG_GetNumericalValue(str, "Check_DataAcq_Get_Set_ITI"), 1)
-
-	[stimset, stimsetIndexEnd]  = GetStimsets_IGNORE(str)
-	expected = "PSQ_TrueRest_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
-	expected = NONE
-	CHECK_EQUAL_STR(stimsetIndexEnd, expected)
 
 	CommonAnalysisFunctionChecks(str, sweepNo, entries[%setPass])
 	CheckBaselineChunks(str, {20, 520})
@@ -844,7 +788,6 @@ End
 
 static Function PS_VM5a_REENTRY([string str])
 	variable sweepNo
-	string stimset, stimsetIndexEnd, expected
 
 	sweepNo = 2
 
@@ -879,8 +822,6 @@ static Function PS_VM5a_REENTRY([string str])
 
 	CHECK_WAVE(entries[%spikePositions], NULL_WAVE)
 
-	CHECK_EQUAL_VAR(DAG_GetNumericalValue(str, "Check_DataAcq_Indexing"), 1)
-
 	// first sweep does not have autobias enabled
 	// and the last sweep's setting is only available in the GUI
 	CHECK_EQUAL_WAVES(entries[%autobiasVcom], {0, 0, 0}, mode = WAVE_DATA)
@@ -894,12 +835,6 @@ static Function PS_VM5a_REENTRY([string str])
 
 	CHECK_EQUAL_WAVES(entries[%getsetiti], {1, 1, 1}, mode = WAVE_DATA)
 	CHECK_EQUAL_VAR(DAG_GetNumericalValue(str, "Check_DataAcq_Get_Set_ITI"), 1)
-
-	[stimset, stimsetIndexEnd] = GetStimsets_IGNORE(str)
-	expected = "StimulusSetA_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
-	expected = "StimulusSetB_DA_0"
-	CHECK_EQUAL_STR(stimsetIndexEnd, expected)
 
 	CommonAnalysisFunctionChecks(str, sweepNo, entries[%setPass])
 	CheckBaselineChunks(str, {20, 520})
@@ -956,7 +891,6 @@ End
 
 static Function PS_VM5b_REENTRY([string str])
 	variable sweepNo
-	string stimset, stimsetIndexEnd, expected
 
 	sweepNo = 0
 
@@ -991,8 +925,6 @@ static Function PS_VM5b_REENTRY([string str])
 
 	CHECK_WAVE(entries[%spikePositions], NULL_WAVE)
 
-	CHECK_EQUAL_VAR(DAG_GetNumericalValue(str, "Check_DataAcq_Indexing"), 0)
-
 	// first sweep does not have autobias enabled
 	// and the last sweep's setting is only available in the GUI
 	CHECK_EQUAL_WAVES(entries[%autobiasVcom], {0}, mode = WAVE_DATA)
@@ -1006,12 +938,6 @@ static Function PS_VM5b_REENTRY([string str])
 
 	CHECK_EQUAL_WAVES(entries[%getsetiti], {1}, mode = WAVE_DATA)
 	CHECK_EQUAL_VAR(DAG_GetNumericalValue(str, "Check_DataAcq_Get_Set_ITI"), 1)
-
-	[stimset, stimsetIndexEnd] = GetStimsets_IGNORE(str)
-	expected = "StimulusSetA_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
-	expected = NONE
-	CHECK_EQUAL_STR(stimsetIndexEnd, expected)
 
 	CommonAnalysisFunctionChecks(str, sweepNo, entries[%setPass])
 	CheckBaselineChunks(str, {20, 520})
@@ -1121,7 +1047,6 @@ End
 
 static Function PS_VM7_REENTRY([string str])
 	variable sweepNo
-	string stimset, stimsetIndexEnd, expected
 
 	sweepNo = 0
 
@@ -1156,8 +1081,6 @@ static Function PS_VM7_REENTRY([string str])
 
 	CHECK_EQUAL_TEXTWAVES(entries[%spikePositions], {"1;"}, mode = WAVE_DATA)
 
-	CHECK_EQUAL_VAR(DAG_GetNumericalValue(str, "Check_DataAcq_Indexing"), 0)
-
 	// first sweep does not have autobias enabled
 	// and the last sweep's setting is only available in the GUI
 	CHECK_EQUAL_WAVES(entries[%autobiasVcom], {0}, mode = WAVE_DATA)
@@ -1171,12 +1094,6 @@ static Function PS_VM7_REENTRY([string str])
 
 	CHECK_EQUAL_WAVES(entries[%getsetiti], {1}, mode = WAVE_DATA)
 	CHECK_EQUAL_VAR(DAG_GetNumericalValue(str, "Check_DataAcq_Get_Set_ITI"), 1)
-
-	[stimset, stimsetIndexEnd]  = GetStimsets_IGNORE(str)
-	expected = "PSQ_TrueRest_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
-	expected = NONE
-	CHECK_EQUAL_STR(stimsetIndexEnd, expected)
 
 	CommonAnalysisFunctionChecks(str, sweepNo, entries[%setPass])
 	CheckBaselineChunks(str, {20, 520})
@@ -1234,7 +1151,6 @@ End
 
 static Function PS_VM7a_REENTRY([string str])
 	variable sweepNo
-	string stimset, stimsetIndexEnd, expected
 
 	sweepNo = 1
 
@@ -1269,8 +1185,6 @@ static Function PS_VM7a_REENTRY([string str])
 
 	CHECK_EQUAL_TEXTWAVES(entries[%spikePositions], {"1;", ""}, mode = WAVE_DATA)
 
-	CHECK_EQUAL_VAR(DAG_GetNumericalValue(str, "Check_DataAcq_Indexing"), 1)
-
 	// first sweep does not have autobias enabled
 	CHECK_EQUAL_WAVES(entries[%autobiasVcom], {0, 6 + 3}, mode = WAVE_DATA)
 	CHECK_CLOSE_VAR(DAG_GetNumericalValue(str, "setvar_DataAcq_AutoBiasV"), 13, tol = 1e-12)
@@ -1283,12 +1197,6 @@ static Function PS_VM7a_REENTRY([string str])
 
 	CHECK_EQUAL_WAVES(entries[%getsetiti], {1, 0}, mode = WAVE_DATA)
 	CHECK_EQUAL_VAR(DAG_GetNumericalValue(str, "Check_DataAcq_Get_Set_ITI"), 1)
-
-	[stimset, stimsetIndexEnd] = GetStimsets_IGNORE(str)
-	expected = "StimulusSetA_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
-	expected = "StimulusSetB_DA_0"
-	CHECK_EQUAL_STR(stimsetIndexEnd, expected)
 
 	CommonAnalysisFunctionChecks(str, sweepNo, entries[%setPass])
 	CheckBaselineChunks(str, {20, 520})
@@ -1346,7 +1254,6 @@ End
 
 static Function PS_VM8_REENTRY([string str])
 	variable sweepNo
-	string stimset, stimsetIndexEnd, expected
 
 	sweepNo = 0
 
@@ -1381,8 +1288,6 @@ static Function PS_VM8_REENTRY([string str])
 
 	CHECK_WAVE(entries[%spikePositions], NULL_WAVE)
 
-	CHECK_EQUAL_VAR(DAG_GetNumericalValue(str, "Check_DataAcq_Indexing"), 0)
-
 	// first sweep does not have autobias enabled
 	// and the last sweep's setting is only available in the GUI
 	CHECK_EQUAL_WAVES(entries[%autobiasVcom], {0}, mode = WAVE_DATA)
@@ -1396,12 +1301,6 @@ static Function PS_VM8_REENTRY([string str])
 
 	CHECK_EQUAL_WAVES(entries[%getsetiti], {1}, mode = WAVE_DATA)
 	CHECK_EQUAL_VAR(DAG_GetNumericalValue(str, "Check_DataAcq_Get_Set_ITI"), 1)
-
-	[stimset, stimsetIndexEnd]  = GetStimsets_IGNORE(str)
-	expected = "PSQ_TrueRest_DA_0"
-	CHECK_EQUAL_STR(stimset, expected)
-	expected = NONE
-	CHECK_EQUAL_STR(stimsetIndexEnd, expected)
 
 	CommonAnalysisFunctionChecks(str, sweepNo, entries[%setPass])
 	CheckBaselineChunks(str, {20, 520})


### PR DESCRIPTION
Up to now we had in each test case a check for the set stimulus set names
in the POST_SET_EVENT, see PSQ_SetStimulusSets.

We now generalize the tests so that in the future we can also
automatically reuse these tests for analysis functions supporting these
analysis parameters.

The uncontroversial parts of #1362.

Will merge once CI passes.
