### PR TITLE
Fix labnotebook description wave not being refetched if changed

### DIFF
--- a/Packages/MIES/MIES_ExperimentDocumentation.ipf
+++ b/Packages/MIES/MIES_ExperimentDocumentation.ipf
@@ -489,7 +489,7 @@ static Function [WAVE colIndizes, variable rowIndex] ED_FindIndizesAndRedimensio
 	numKeyCols = DimSize(key, COLS)
 	lastValidIncomingKeyRow = DimSize(incomingKey, ROWS) - 1
 
-	Make/FREE/U/I/N=(DimSize(incomingKey, COLS)) indizes = NaN
+	Make/FREE/D/N=(DimSize(incomingKey, COLS)) indizes = NaN
 
 	WAVE/T/Z desc
 	if(logbookType == LBT_LABNOTEBOOK)

--- a/Packages/MIES/MIES_ExperimentDocumentation.ipf
+++ b/Packages/MIES/MIES_ExperimentDocumentation.ipf
@@ -491,7 +491,7 @@ static Function [WAVE colIndizes, variable rowIndex] ED_FindIndizesAndRedimensio
 
 	Make/FREE/D/N=(DimSize(incomingKey, COLS)) indizes = NaN
 
-	WAVE/T/Z desc
+	WAVE/T/ZZ desc
 
 	numCols = DimSize(incomingKey, COLS)
 	for(i = 0; i < numCols; i += 1)

--- a/Packages/MIES/MIES_ExperimentDocumentation.ipf
+++ b/Packages/MIES/MIES_ExperimentDocumentation.ipf
@@ -513,6 +513,12 @@ static Function [WAVE colIndizes, variable rowIndex] ED_FindIndizesAndRedimensio
 		indizes[i] = idx
 		numAdditions += 1
 
+		isUserEntry = (strsearch(searchStr, LABNOTEBOOK_USER_PREFIX, 0) == 0)
+
+		if(isUserEntry)
+			continue
+		endif
+
 		if(logbookType == LBT_LABNOTEBOOK)
 			if(!WaveExists(desc) && IsNumericWave(values))
 				WAVE/T desc = GetLBNumericalDescription()
@@ -523,12 +529,6 @@ static Function [WAVE colIndizes, variable rowIndex] ED_FindIndizesAndRedimensio
 
 		// check description wave if available
 		if(!WaveExists(desc))
-			continue
-		endif
-
-		isUserEntry = (strsearch(searchStr, LABNOTEBOOK_USER_PREFIX, 0) == 0)
-
-		if(isUserEntry)
 			continue
 		endif
 

--- a/Packages/MIES/MIES_ExperimentDocumentation.ipf
+++ b/Packages/MIES/MIES_ExperimentDocumentation.ipf
@@ -481,7 +481,7 @@ End
 /// @retval colIndizes column indizes of the entries from incomingKey
 /// @retval rowIndex   returns the row index into values at which the new values should be written
 static Function [WAVE colIndizes, variable rowIndex] ED_FindIndizesAndRedimension(WAVE/T incomingKey, WAVE incomingValues, WAVE/T key, WAVE values, variable logbookType)
-	variable numCols, col, row, numKeyRows, numKeyCols, i, j, numAdditions, idx
+	variable numCols, numKeyRows, numKeyCols, i, j, numAdditions, idx
 	variable lastValidIncomingKeyRow, descIndex, isUserEntry, headstageCont, headstageContDesc, isUnAssoc
 	string msg, searchStr
 
@@ -504,13 +504,10 @@ static Function [WAVE colIndizes, variable rowIndex] ED_FindIndizesAndRedimensio
 	for(i = 0; i < numCols; i += 1)
 		searchStr = incomingKey[0][i]
 
-		FindValue/TXOP=4/TEXT=(searchStr) key
-		col = floor(V_value / numKeyRows)
+		FindValue/TXOP=4/TEXT=(searchStr)/RMD=[0][] key
 
-		if(col >= 0)
-			row = V_value - col * numKeyRows
-			ASSERT(row == 0, "Unexpected match in a row not being zero")
-			indizes[i] = col
+		if(V_col >= 0)
+			indizes[i] = V_col
 			continue
 		endif
 

--- a/Packages/MIES/MIES_ExperimentDocumentation.ipf
+++ b/Packages/MIES/MIES_ExperimentDocumentation.ipf
@@ -492,13 +492,6 @@ static Function [WAVE colIndizes, variable rowIndex] ED_FindIndizesAndRedimensio
 	Make/FREE/D/N=(DimSize(incomingKey, COLS)) indizes = NaN
 
 	WAVE/T/Z desc
-	if(logbookType == LBT_LABNOTEBOOK)
-		if(IsNumericWave(values))
-			WAVE/T desc = GetLBNumericalDescription()
-		else
-			// @todo not yet done for text waves
-		endif
-	endif
 
 	numCols = DimSize(incomingKey, COLS)
 	for(i = 0; i < numCols; i += 1)
@@ -519,6 +512,14 @@ static Function [WAVE colIndizes, variable rowIndex] ED_FindIndizesAndRedimensio
 		key[0, lastValidIncomingKeyRow][idx] = incomingKey[p][i]
 		indizes[i] = idx
 		numAdditions += 1
+
+		if(logbookType == LBT_LABNOTEBOOK)
+			if(!WaveExists(desc) && IsNumericWave(values))
+				WAVE/T desc = GetLBNumericalDescription()
+			else
+				// @todo not yet done for text waves
+			endif
+		endif
 
 		// check description wave if available
 		if(!WaveExists(desc))

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -1572,16 +1572,15 @@ End
 
 static Function/WAVE GetLBDescription_Impl(string name, variable forceReload)
 
+	variable versionOfNewWave = LABNOTEBOOK_VERSION
 	DFREF dfr = GetStaticDataFolder()
 	WAVE/T/Z/SDFR=dfr wv = $name
 
-	if(WaveExists(wv))
-		if(forceReload)
-			KillOrMoveToTrash(wv = wv)
-		else
-			return wv
-		endif
+	if(ExistsWithCorrectLayoutVersion(wv, versionOfNewWave) && !forceReload)
+		return wv
 	endif
+
+	KillOrMoveToTrash(wv = wv)
 
 	WAVE/T/Z wv = LoadWaveFromDisk(name)
 	ASSERT(WaveExists(wv), "Missing wave")
@@ -1594,6 +1593,7 @@ static Function/WAVE GetLBDescription_Impl(string name, variable forceReload)
 	Duplicate/FREE/RMD=[0][] wv, labels
 	Redimension/N=(numpnts(labels)) labels
 	SetDimensionLabels(wv, TextWaveToList(labels, ";"), COLS)
+	SetWaveVersion(wv, versionOfNewWave)
 
 	return wv
 End


### PR DESCRIPTION
This was found as part of testing #1380. This fixes the "BUG: ED_FindIndizesAndRedimension" messages. This bug should not influence normal users as you have to acquire data with one MIES version and then acquire data with a newer MIES version again into the same file. Nevertheless worth fixing.