### PR TITLE
Make async channels work with NI hardware

### DIFF
--- a/Packages/MIES/MIES_AsynchronousData.ipf
+++ b/Packages/MIES/MIES_AsynchronousData.ipf
@@ -12,7 +12,7 @@
 /// @brief Check if the given asynchronous channel is in alarm state
 Function ASD_CheckAsynAlarmState(variable value, variable minValue, variable maxValue)
 
-	return value >= maxValue || value <= minValue
+	return IsNaN(value) || value >= maxValue || value <= minValue
 End
 
 /// @brief Read the given asynchronous channel and return the scaled value

--- a/Packages/MIES/MIES_AsynchronousData.ipf
+++ b/Packages/MIES/MIES_AsynchronousData.ipf
@@ -21,12 +21,13 @@ Function ASD_ReadChannel(device, channel)
 	variable channel
 
 	string ctrl
-	variable gain, deviceChannelOffset, rawChannelValue
+	variable gain, deviceChannelOffset, rawChannelValue, hardwareType
 
 	NVAR deviceID = $GetDAQDeviceID(device)
 	deviceChannelOffset = HW_ITC_CalculateDevChannelOff(device)
 
-	rawChannelValue = HW_ReadADC(HARDWARE_ITC_DAC, deviceID, channel + deviceChannelOffset)
+	hardwareType = GetHardwareType(device)
+	rawChannelValue = HW_ReadADC(hardwareType, deviceID, channel + deviceChannelOffset)
 
 	ctrl = GetSpecialControlLabel(CHANNEL_TYPE_ASYNC, CHANNEL_CONTROL_GAIN)
 	gain = DAG_GetNumericalValue(device, ctrl, index = channel)

--- a/Packages/MIES/MIES_DAC-Hardware.ipf
+++ b/Packages/MIES/MIES_DAC-Hardware.ipf
@@ -1297,6 +1297,11 @@ Function HW_ITC_ReadADC(deviceID, channel, [flags])
 
 	HW_ITC_HandleReturnValues(flags, V_ITCError, V_ITCXOPError)
 
+	// @todo ITCXOP: manually return NaN on error until https://github.com/AllenInstitute/ITCXOP2/issues/19 is fixed
+	if(V_ITCError != 0 || V_ITCXOPError != 0)
+		return NaN
+	endif
+
 	return V_Value
 End
 
@@ -1324,6 +1329,11 @@ Function HW_ITC_ReadDigital(deviceID, xopChannel, [flags])
 	while(V_ITCXOPError == SLOT_LOCKED_TO_OTHER_THREAD && V_ITCError == 0)
 
 	HW_ITC_HandleReturnValues(flags, V_ITCError, V_ITCXOPError)
+
+	// @todo ITCXOP: manually return NaN on error until https://github.com/AllenInstitute/ITCXOP2/issues/19 is fixed
+	if(V_ITCError != 0 || V_ITCXOPError != 0)
+		return NaN
+	endif
 
 	return V_Value
 End

--- a/Packages/MIES/MIES_DAC-Hardware.ipf
+++ b/Packages/MIES/MIES_DAC-Hardware.ipf
@@ -787,10 +787,10 @@ Function/S HW_ITC_ListDevices()
 	return list
 End
 
-/// @brief Output an informative error message for the ITC XOP2 operations (threadsafe variant)
+/// @brief Output an informative error message for the ITC XOP2 operations
 ///
 /// @return 0 on success, 1 otherwise
-threadsafe Function HW_ITC_HandleReturnValues_TS(flags, ITCError, ITCXOPError)
+threadsafe Function HW_ITC_HandleReturnValues(flags, ITCError, ITCXOPError)
 	variable flags, ITCError, ITCXOPError
 
 	// we only need the lower 32bits of the error
@@ -814,61 +814,14 @@ threadsafe Function HW_ITC_HandleReturnValues_TS(flags, ITCError, ITCXOPError)
 	elseif(ITCXOPError != 0 && !(flags & HARDWARE_PREVENT_ERROR_MESSAGE))
 		printf "The ITC XOP returned the following errors: ITCError=%#x, ITCXOPError=%d\r", ITCError, ITCXOPError
 		printf "XOP error message: %s\r", HW_ITC_GetXOPErrorMessage(ITCXOPError)
-
 		printf "Responsible function: %s\r", GetRTStackInfo(2)
 		printf "Complete call stack: %s\r", GetRTStackInfo(3)
-
 		BUG_TS("The ITC XOP was called incorrectly!")
 	endif
 
 #ifndef EVIL_KITTEN_EATING_MODE
 	if(ITCXOPError != 0 || ITCError != 0)
 		ASSERT_TS(!(flags & HARDWARE_ABORT_ON_ERROR), "DAC error")
-	endif
-
-	return ITCXOPError != 0 || ITCError != 0
-#else
-	ClearRTError()
-	return 0
-#endif
-End
-
-/// @brief Output an informative error message for the ITC XOP2 operations
-///
-/// @return 0 on success, 1 otherwise
-Function HW_ITC_HandleReturnValues(flags, ITCError, ITCXOPError)
-	variable flags, ITCError, ITCXOPError
-
-	// we only need the lower 32bits of the error
-	ITCError = ITCError & 0x00000000ffffffff
-	ITCXOPError = ConvertXOPErrorCode(ITCXOPError)
-
-	if(ITCError != 0 && !(flags & HARDWARE_PREVENT_ERROR_MESSAGE))
-		printf "The ITC XOP returned the following errors: ITCError=%#x, ITCXOPError=%d\r", ITCError, ITCXOPError
-
-		do
-			ITCGetErrorString2/X itcError
-		while(V_ITCXOPError == SLOT_LOCKED_TO_OTHER_THREAD && V_ITCError == 0)
-
-		print S_errorMEssage
-		print "Some hints you might want to try!"
-		print "- Is the correct ITC device type selected?"
-		print "- Is your ITC Device connected to a power socket?"
-		print "- Is your ITC Device connected to your computer?"
-		print "- Have you tried unlocking/locking the device already?"
-		print "- Reseating all connections between the DAC and the computer has also helped in the past."
-	elseif(ITCXOPError != 0 && !(flags & HARDWARE_PREVENT_ERROR_MESSAGE))
-		printf "The ITC XOP returned the following errors: ITCError=%#x, ITCXOPError=%d\r", ITCError, ITCXOPError
-		printf "XOP error message: %s\r", HW_ITC_GetXOPErrorMessage(ITCXOPError)
-		printf "Responsible function: %s\r", GetRTStackInfo(2)
-		printf "Complete call stack: %s\r", GetRTStackInfo(3)
-		BUG("The ITC XOP was called incorrectly!")
-	endif
-
-#ifndef EVIL_KITTEN_EATING_MODE
-	if(ITCXOPError != 0 || ITCError != 0)
-		ControlWindowToFront()
-		ASSERT(!(flags & HARDWARE_ABORT_ON_ERROR), "DAC error")
 	endif
 
 	return ITCXOPError != 0 || ITCError != 0
@@ -1089,14 +1042,14 @@ threadsafe Function HW_ITC_StopAcq_TS(deviceID, [prepareForDAQ, flags])
 		ITCStopAcq2/DEV=(deviceID)/Z=(HW_ITC_GetZValue(flags))
 	while(V_ITCXOPError == SLOT_LOCKED_TO_OTHER_THREAD && V_ITCError == 0)
 
-	HW_ITC_HandleReturnValues_TS(flags, V_ITCError, V_ITCXOPError)
+	HW_ITC_HandleReturnValues(flags, V_ITCError, V_ITCXOPError)
 
 	if(prepareForDAQ)
 		do
 			ITCConfigChannelUpload2/DEV=(deviceID)/Z=(HW_ITC_GetZValue(flags))
 		while(V_ITCXOPError == SLOT_LOCKED_TO_OTHER_THREAD && V_ITCError == 0)
 
-		HW_ITC_HandleReturnValues_TS(flags, V_ITCError, V_ITCXOPError)
+		HW_ITC_HandleReturnValues(flags, V_ITCError, V_ITCXOPError)
 	endif
 End
 
@@ -1197,7 +1150,7 @@ threadsafe Function HW_ITC_ResetFifo_TS(deviceID, config, [flags])
 		ITCUpdateFIFOPositionAll2/DEV=(deviceID)/Z=(HW_ITC_GetZValue(flags)) fifoPos_t
 	while(V_ITCXOPError == SLOT_LOCKED_TO_OTHER_THREAD && V_ITCError == 0)
 
-	HW_ITC_HandleReturnValues_TS(flags, V_ITCError, V_ITCXOPError)
+	HW_ITC_HandleReturnValues(flags, V_ITCError, V_ITCXOPError)
 End
 
 /// @brief Reset the AD/DA channel FIFOs
@@ -1258,7 +1211,7 @@ threadsafe Function HW_ITC_StartAcq_TS(deviceID, triggerMode, [flags])
 			break
 	endswitch
 
-	HW_ITC_HandleReturnValues_TS(flags, V_ITCError, V_ITCXOPError)
+	HW_ITC_HandleReturnValues(flags, V_ITCError, V_ITCXOPError)
 End
 
 /// @see HW_StartAcq
@@ -1505,7 +1458,7 @@ threadsafe Function HW_ITC_MoreData_TS(deviceID, ADChannelToMonitor, stopCollect
 		ITCFIFOAvailableALL2/DEV=(deviceID)/FREE/Z=(HW_ITC_GetZValue(flags)) config_t, fifoAvail_t
 	while(V_ITCXOPError == SLOT_LOCKED_TO_OTHER_THREAD && V_ITCError == 0)
 
-	HW_ITC_HandleReturnValues_TS(flags, V_ITCError, V_ITCXOPError)
+	HW_ITC_HandleReturnValues(flags, V_ITCError, V_ITCXOPError)
 
 	fifoPosValue = fifoAvail_t[2][ADChannelToMonitor]
 
@@ -1588,12 +1541,6 @@ End
 Function/S HW_ITC_ListDevices()
 
 	DEBUGPRINT("Unimplemented")
-End
-
-threadsafe Function HW_ITC_HandleReturnValues_TS(flags, ITCError, ITCXOPError)
-	variable flags, ITCError, ITCXOPError
-
-	DEBUGPRINT_TS("Unimplemented")
 End
 
 Function HW_ITC_HandleReturnValues(flags, ITCError, ITCXOPError)

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -6468,12 +6468,10 @@ End
 /// @brief Remove the volatile part of the XOP error code
 ///
 /// The result is constant and can therefore be compared with constants.
-///
-///	 From http://www.igorexchange.com/node/7286
 threadsafe Function ConvertXOPErrorCode(xopError)
 	variable xopError
 
-	return xopError == 0 ? 0 : ((xopError & 0xFFFF) + 10000)
+	return xopError == 0 ? 0 : (mod(xopError, 10000) + 10000)
 End
 
 /// @brief Extended version of `FindValue`


### PR DESCRIPTION
That is a bummer!

We actually did not support NI hardware for async channels. I found that by accident when I looked at some other CI failure. What put me off was that we had some ITC errors in the NI hardware tests, see [1].

The test case AsyncAcquisitionLBN works with NI hardware but had this output.

```
<testcase name="AsyncAcquisitionLBN:NI in UTF_BasicHardwareTests.ipf (4)" classname="AsyncAcquisitionLBN:NI" time="15.161">
<system-out>
Entering test case "AsyncAcquisitionLBN:NI" The ITC XOP returned the following errors: ITCError=0x82503001, ITCXOPError=0 System is not initialized (0x82503001);Place: User Layer; Connection: DSP; Error Type: Ready; Sequence Number: 0x0; Device Type: ITC1600; OS: Any; Application: Regular; Local Sequence Number: 0x1 Some hints you might want to try! - Is the correct ITC device type selected? - Is your ITC Device connected to a power socket? - Is your ITC Device connected to your computer? - Have you tried unlocking/locking the device already? - Reseating all connections between the DAC and the computer has also helped in the past. Entering reentry "AsyncAcquisitionLBN_REENTRY" Trying to resurrect missing sweeps from device Dev1 Sweep 0 is missing its sweep wave Sweep 0 is missing its config wave Trying to recontruct sweep 0 Reconstructed successfully. Leaving test case "AsyncAcquisitionLBN:NI"
</system-out>
</testcase>
```

So turns out the test case actually does not work but failed to complain. I've now added a couple of safety nets so that we are getting complained at in the future if something similiar would happen.

[1]: http://bamboo.corp.alleninstitute.org/browse/MIES-PLAYIN-698/artifact/shared/JUNIT-logfile-%5B5%5D/JU_2022_05_23_102810_2022-05-23_11-56-30.xml.