### PR TITLE
WBP_ClearFolders: Factor out helper function

### DIFF
--- a/Packages/MIES/MIES_WaveBuilderPanel.ipf
+++ b/Packages/MIES/MIES_WaveBuilderPanel.ipf
@@ -1482,6 +1482,10 @@ static Function/S WBP_TranslateControlContents(control, direction, data)
 	endswitch
 End
 
+static Function WBP_ClearFolders()
+	KillOrMoveToTrash(dfr = GetWaveBuilderDataPath())
+End
+
 /// @brief Wavebuilder panel window hook
 ///
 /// The epoch selection is done on the mouseup event if there exists no marquee.
@@ -1496,7 +1500,7 @@ Function WBP_MainWindowHook(s)
 
 	switch(s.eventCode)
 		case EVENT_WINDOW_HOOK_KILL:
-			KillOrMoveToTrash(dfr = GetWaveBuilderDataPath())
+			WBP_ClearFolders()
 			break
 #ifdef DEBUGGING_ENABLED
 		case EVENT_WINDOW_HOOK_MOUSEMOVED:

--- a/Packages/MIES/MIES_WaveBuilderPanel.ipf
+++ b/Packages/MIES/MIES_WaveBuilderPanel.ipf
@@ -112,9 +112,7 @@ Function/S WBP_CreateWaveBuilderPanel()
 	GetWBSvdStimSetDAPath()
 	GetWBSvdStimSetTTLPath()
 
-	KillOrMoveToTrash(wv=GetSegmentTypeWave())
-	KillOrMoveToTrash(wv=GetWaveBuilderWaveParam())
-	KillOrMoveToTrash(wv=GetWaveBuilderWaveTextParam())
+	WBP_ClearFolders()
 
 	Execute "WaveBuilder()"
 	ListBox listbox_combineEpochMap, listWave=GetWBEpochCombineList()


### PR DESCRIPTION
Igor Pro currently does not store dimension labels for non-existing
dimensions. This means that column labels don't survive experiment saving
and loading if the row count is zero.

For the Wavebuilder this affects WBP_GetAnalysisParamGUIListWave and
friends.

The easiest solution is to throw away any existing waves on panel creation.