### PR TITLE
README.md: Mention Igor Pro 9 instead of 8

### DIFF
--- a/Packages/doc/mies-concepts.rst
+++ b/Packages/doc/mies-concepts.rst
@@ -7,7 +7,7 @@ principles behind MIES.
 Coding Guidelines
 -----------------
 
-Can be found `here <http://www.igorexchange.com/project/CodingConventions>`_.
+Can be found `here <https://github.com/byte-physics/igor-pro-coding-conventions>`_.
 
 Documentation
 -------------

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ acquisition, and analysis.
 ## Required Software
 
 - Windows 10 x64
-- [Igor Pro 8.04 (nightly) or later](https://www.wavemetrics.com/)
+- [Igor Pro 9 (nightly) or later](https://alleninstitute.github.io/MIES/installation.html#igor-pro-update-nightly)
 - [NIDAQ MX XOP](https://www.wavemetrics.com/products/nidaqtools/nidaqtools.htm)
 
 ## Getting started


### PR DESCRIPTION
Forgotten in 3a1b477 (Packages/MIES_Include.ipf: Remove support for Igor
Pro 8, 2022-04-15).
