### PR TITLE
tools/nwb-read-tests/run.sh: Update pynwb version

### DIFF
--- a/tools/nwb-read-tests/run.sh
+++ b/tools/nwb-read-tests/run.sh
@@ -25,7 +25,7 @@ echo "Start building Docker container \"$tag\""
 
 docker build --build-arg USERID=$(id -u)                     \
              --build-arg GROUPID=$(id -g)                    \
-             --build-arg PACKAGE_WITH_VERSION="pynwb==2.0.0" \
+             --build-arg PACKAGE_WITH_VERSION="pynwb==2.0.1" \
              -t $tag $top_level/tools/nwb-read-tests
 
 # use 'docker run -it ..' for interactive debugging


### PR DESCRIPTION
Released in March 16 2022, see
https://github.com/NeurodataWithoutBorders/pynwb/releases/tag/2.0.1.

Merge once CI passes.
