### PR TITLE
Tests: Fix that hardwaretest testsuites were not properly sorted

### DIFF
--- a/Packages/Testing-MIES/UTF_HardwareMain.ipf
+++ b/Packages/Testing-MIES/UTF_HardwareMain.ipf
@@ -101,7 +101,7 @@ Function RunWithOpts([string testcase, string testsuite, variable allowdebug, va
 	// analysis functions
 	list = AddListItem("UTF_SetControls.ipf", list, ";", inf)
 	list = AddListItem("UTF_PatchSeqAccessResistanceSmoke.ipf", list, ";", inf)
-	list = AddListItem("UTF_PatchSeqChirp.ipf", list)
+	list = AddListItem("UTF_PatchSeqChirp.ipf", list, ";", inf)
 	list = AddListItem("UTF_PatchSeqDAScale.ipf", list, ";", inf)
 	list = AddListItem("UTF_PatchSeqSealEvaluation.ipf", list, ";", inf)
 	list = AddListItem("UTF_PatchSeqSquarePulse.ipf", list, ";", inf)
@@ -113,7 +113,7 @@ Function RunWithOpts([string testcase, string testsuite, variable allowdebug, va
 	list = AddListItem("UTF_MultiPatchSeqFastRheoEstimate.ipf", list, ";", inf)
 	list = AddListItem("UTF_MultiPatchSeqDAScale.ipf", list, ";", inf)
 	list = AddListItem("UTF_MultiPatchSeqSpikeControl.ipf", list, ";", inf)
-	list = AddListItem("UTF_AutoTestpulse.ipf", list)
+	list = AddListItem("UTF_AutoTestpulse.ipf", list, ";", inf)
 	list = AddListItem("UTF_VeryLastTestSuite.ipf", list, ";", inf)
 
 	// tests which BUG out must come after the test-all tests in UTF_VeryLastTestSuite.ipf


### PR DESCRIPTION
When assembling the procedure file list for RunTest two procedure files
were added at the beginning of the list instead of the end.
This resulted in an unwanted execution order of the test suites.

Now they are properly added at the end of the list.

