### PR TITLE
Tests/EnsureUnityGain: Set the gain

### DIFF
--- a/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
+++ b/Packages/Testing-MIES/UTF_BasicHardwareTests.ipf
@@ -5456,9 +5456,15 @@ static Function CheckTPStorage(string device)
 End
 
 static Function EnsureUnityGain(string device, variable headstage)
-	variable gain, mode
+	variable gain, mode, ret
 
 	mode = DAG_GetHeadstageMode(device, headstage)
+
+	ret = AI_SendToAmp(device, headstage, mode, MCC_SETPRIMARYSIGNALGAIN_FUNC, 1)
+	CHECK(!ret)
+
+	ret = AI_SendToAmp(device, headstage, mode, MCC_SETSECONDARYSIGNALGAIN_FUNC, 1)
+	CHECK(!ret)
 
 	gain = AI_SendToAmp(device, headstage, mode, MCC_GETPRIMARYSIGNALGAIN_FUNC, NaN)
 	REQUIRE_EQUAL_VAR(gain, 1)


### PR DESCRIPTION
We currently only check if the primary and secondary gains are unity. But
since daddd566 (AI_SendToAmp: Add some more MCC functions, 2022-04-05) we
can actually set them as well.

So let's do that. This fixes CI errors when the gain was changed by other
tests.

Will merge once CI passes.
