### PR TITLE
DA_Ephys: Remove thumbColor keyword

### DIFF
--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -18,7 +18,7 @@
 Constant DAQ_CONFIG_WAVE_VERSION = 2
 
 /// Used to upgrade the GuiStateWave as well as the DA Ephys panel
-Constant DA_EPHYS_PANEL_VERSION           = 55
+Constant DA_EPHYS_PANEL_VERSION           = 56
 Constant DATA_SWEEP_BROWSER_PANEL_VERSION = 41
 Constant WAVEBUILDER_PANEL_VERSION        = 13
 Constant ANALYSISBROWSER_PANEL_VERSION    =  1

--- a/Packages/MIES/MIES_DAEphys_Macro.ipf
+++ b/Packages/MIES/MIES_DAEphys_Macro.ipf
@@ -2960,7 +2960,7 @@ Window DA_Ephys() : Panel
 	Slider slider_DataAcq_ActiveHeadstage,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	Slider slider_DataAcq_ActiveHeadstage,userdata(ResizeControlsInfo)+=A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
 	Slider slider_DataAcq_ActiveHeadstage,labelBack=(60928,60928,60928)
-	Slider slider_DataAcq_ActiveHeadstage,limits={0,7,1},value=0,live=0,side=2,vert=0,ticks=0,thumbColor=(43520,43520,43520)
+	Slider slider_DataAcq_ActiveHeadstage,limits={0,7,1},value=0,live=0,side=2,vert=0,ticks=0
 	SetVariable setvar_DataAcq_AutoBiasV,pos={278.00,216.00},size={96.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVarProc_AmpCntrls
 	SetVariable setvar_DataAcq_AutoBiasV,title="\\[0Vm \\Z10(mV)\\]0"
 	SetVariable setvar_DataAcq_AutoBiasV,userdata(tabnum)="1"


### PR DESCRIPTION
This was not respected on Windows until r39013, but we actually just want
the default color.

The fix in IP as it is today also changes the style of the thumb on color
change.

Merge once CI passes.
