### PR TITLE
EP_GetEpochs: Add support for old epoch tag formats

### DIFF
--- a/Packages/MIES/MIES_Epochs.ipf
+++ b/Packages/MIES/MIES_Epochs.ipf
@@ -698,7 +698,8 @@ End
 /// @param sweepNo         Number of sweep
 /// @param channelType     type of channel @sa XopChannelConstants
 /// @param channelNumber   number of channel
-/// @param shortname       short name filter, can be a regular expression which is matched caseless
+/// @param shortname       short name filter, can be a regular expression which is matched caseless. For older tag formats
+///                        it can be a simple tag entry (or regexp).
 /// @param treelevel       [optional: default = not set] tree level of epochs, if not set then treelevel is ignored
 /// @param epochsWave      [optional: defaults to $""] when passed, gathers epoch information from this wave directly.
 ///                        This is required for callers who want to read epochs during MID_SWEEP_EVENT in analysis functions.
@@ -742,7 +743,18 @@ Function/WAVE EP_GetEpochs(WAVE numericalValues, WAVE textualValues, variable sw
 	WAVE/Z indizesName = FindIndizes(shortnames, col = 0, str = regexp, prop = PROP_GREP)
 
 	if(!WaveExists(indizesName))
-		return $""
+		if(HasOneValidEntry(shortnames))
+			// we got short names but no hit
+			return $""
+		endif
+
+		// fallback to previous tag name formats without shortname
+		regexp = "(?i)(^|;)" + shortname + "($|;)"
+		WAVE/Z indizesName = FindIndizes(epochInfo, col = EPOCH_COL_TAGS, str = regexp, prop = PROP_GREP)
+
+		if(!WaveExists(indizesName))
+			return $""
+		endif
 	endif
 
 	if(IsNaN(treelevel))

--- a/Packages/Testing-MIES/UTF_EpochswoHardware.ipf
+++ b/Packages/Testing-MIES/UTF_EpochswoHardware.ipf
@@ -153,3 +153,43 @@ static Function EP_GetEpochsWorks()
 
 	CHECK_EQUAL_TEXTWAVES(result, resultFromWave)
 End
+
+static Function EP_GetEpochsDoesNotFallbackWithShortNames()
+
+	[WAVE numericalValues, WAVE/T textualValues, WAVE/T epochsWave] = PrepareEpochsTable_IGNORE()
+
+	WAVE/T/Z resultEmpty = EP_GetEpochs(numericalValues, textualValues, 0, XOP_CHANNEL_TYPE_DAC, 2, "someDesc")
+	CHECK_WAVE(resultEmpty, NULL_WAVE)
+
+	WAVE/T/Z resultEmpty = EP_GetEpochs(numericalValues, textualValues, 0, XOP_CHANNEL_TYPE_DAC, 2, "otherDesc")
+	CHECK_WAVE(resultEmpty, NULL_WAVE)
+End
+
+static Function/WAVE OldEpochsFormats()
+
+	Make/WAVE/N=2/FREE oldFormats = {root:EpochsWave:EpochsWave_4e534e298, root:EpochsWave:EpochsWave_d150d896e}
+
+	SetDimensionLabels(oldFormats, "EpochsWave_4e534e298;EpochsWave_d150d896e", ROWS)
+
+	return oldFormats
+End
+
+// UTF_TD_GENERATOR OldEpochsFormats
+static Function EP_GetEpochsWorksWithoutShortNames([WAVE wv])
+
+	WAVE/T/Z result = EP_GetEpochs($"", $"", NaN, XOP_CHANNEL_TYPE_DAC, 0, "Inserted TP", epochsWave = wv)
+	CHECK_WAVE(result, TEXT_WAVE)
+	CHECK_EQUAL_VAR(DimSize(result, ROWS), 2)
+
+	WAVE/T/Z result = EP_GetEpochs($"", $"", NaN, XOP_CHANNEL_TYPE_DAC, 0, "Test Pulse", epochsWave = wv)
+	CHECK_WAVE(result, TEXT_WAVE)
+	CHECK_EQUAL_VAR(DimSize(result, ROWS), 2)
+
+	WAVE/T/Z result = EP_GetEpochs($"", $"", NaN, XOP_CHANNEL_TYPE_DAC, 0, "Inserted TP;Test Pulse", epochsWave = wv)
+	CHECK_WAVE(result, TEXT_WAVE)
+	CHECK_EQUAL_VAR(DimSize(result, ROWS), 2)
+
+	WAVE/T/Z result = EP_GetEpochs($"", $"", NaN, XOP_CHANNEL_TYPE_DAC, 0, "STIM.*", epochsWave = wv)
+	CHECK_WAVE(result, TEXT_WAVE)
+	CHECK_EQUAL_VAR(DimSize(result, ROWS), 1)
+End


### PR DESCRIPTION
The shortnames in epoch tags are not present for all epochs wave versions. Older
formats, see the comment in GetEpochsWave, which don't have shortnames
can currently not be used for querying epoch information.

This is now fixed. We don't require for the full tag to be present, but
only one entry from the semicolon list is enough. Also supports regexps.

Close #1419.
