### PR TITLE
Hardware Tests: Change default ITC1600 device

### DIFF
--- a/Packages/Testing-MIES/UTF_HardwareMain.ipf
+++ b/Packages/Testing-MIES/UTF_HardwareMain.ipf
@@ -166,7 +166,7 @@ Function/WAVE DeviceNameGeneratorMD1()
 	devList = AddListItem("ITC1600_Dev_0;ITC1600_Dev_1", devList, ":")
 	lblList = AddListItem("ITC600_YOKED", lblList)
 #else
-	devList = AddListItem("ITC1600_Dev_2", devList, ":")
+	devList = AddListItem("ITC1600_Dev_1", devList, ":")
 	lblList = AddListItem("ITC1600", lblList)
 #endif
 


### PR DESCRIPTION
Thanks for opening a PR in MIES :sparkles:!

- Code can only be merged if the continous integration tests pass
- [ ] Please ensure that the branch is named correctly. See
  [here](https://alleninstitute.github.io/MIES/developers.html#branch-naming-scheme) for all detailed explanation. In
  short: Branches targeting the release branch should have a `-backport` suffix, others targeting main must not have
  this suffix. This is done so that the correct CI plan is executed.
