### PR TITLE
tools/clean_mies_installation.sh: Install TUF XOP for release package

### DIFF
--- a/tools/clean_mies_installation.sh
+++ b/tools/clean_mies_installation.sh
@@ -150,6 +150,7 @@ do
     cp -r  "$base_folder"/XOPs-IP${i}-64bit/MIESUtils*  "$xops64"
     cp -r  "$base_folder"/XOPs-IP${i}-64bit/JSON*  "$xops64"
     cp -r  "$base_folder"/XOPs-IP${i}-64bit/ZeroMQ*  "$xops64"
+    cp -r  "$base_folder"/XOPs-IP${i}-64bit/TUF*  "$xops64"
     cp -r  "$base_folder"/XOPs-IP${i}-64bit/libzmq*  "$xops64"
   fi
 


### PR DESCRIPTION
When skipping hardware XOPs we have a list of files to install. This list
was not updated in 65994377 (Add TUFXOP for IP9-64bit, 2021-06-26).
