### PR TITLE
tools/clean_mies_installation.sh: Remove old MIES installations

### DIFF
--- a/tools/clean_mies_installation.sh
+++ b/tools/clean_mies_installation.sh
@@ -96,6 +96,9 @@ elif [ "$sourceLoc" = "installer" ]
 then
   base_folder=$top_level
 
+  # remove old installations
+  rm -rf "$USERPROFILE/Documents/MIES/"
+
   # requires an installer which does not trigger UAC
   # installer always installs for all available and supported IP versions
   if [ "$skipHardwareXOPs" = "1" ]


### PR DESCRIPTION
Since forever we are just installing the new MIES version on top of the
old one. This can create problems if two XOPs from different branches
export the same operations/functions. And this is the case since 69a22f1b
(XOPs: Update TUF XOP to the released version, 2022-07-25) got merged.

The '/CIS' installation mode does not uninstall the already existing
version, so we need to do that ourselves here.

Will merge once CI passes.
