### PR TITLE
DAP_ButtonProc_ClearChanCon: Also clear the channel clamp mode wave

### DIFF
--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -2037,7 +2037,7 @@ Function DAP_ButtonProc_ClearChanCon(ba) : ButtonControl
 	STRUCT WMButtonAction &ba
 
 	string device
-	variable headStage
+	variable headStage, daVC, daIC, adVC, adIC
 
 	switch(ba.eventCode)
 		case 2: // mouse up
@@ -2047,6 +2047,30 @@ Function DAP_ButtonProc_ClearChanCon(ba) : ButtonControl
 			WAVE ChanAmpAssign = GetChanAmpAssign(device)
 
 			headStage = str2num(GetPopupMenuString(device,"Popup_Settings_HeadStage"))
+
+			daVC = ChanAmpAssign[%VC_DA][headStage]
+			daIC = ChanAmpAssign[%IC_DA][headStage]
+
+			adVC = ChanAmpAssign[%VC_AD][headStage]
+			adIC = ChanAmpAssign[%IC_AD][headStage]
+
+			WAVE channelClampMode = GetChannelClampMode(device)
+
+			if(IsFinite(daVC))
+				channelClampMode[daVC][%DAC][%Headstage] = NaN
+			endif
+
+			if(IsFinite(daIC))
+				channelClampMode[daIC][%DAC][%Headstage] = NaN
+			endif
+
+			if(IsFinite(adVC))
+				channelClampMode[adVC][%ADC][%Headstage] = NaN
+			endif
+
+			if(IsFinite(adIC))
+				channelClampMode[adIC][%ADC][%Headstage] = NaN
+			endif
 
 			// set all DA/AD channels for both clamp modes to an invalid channel number
 			ChanAmpAssign[0, 6;2][headStage] = NaN


### PR DESCRIPTION
Since 9293eac6 (DA_Ephys: Add a button to the hardware tab allowing to
clear the channel/amplifier connections, 2015-12-16) we allow to clear the
headstage/channel association.

But in cb206d3c (GetChannelClampMode: Extend to also hold headstage
information, 2019-03-08) we introduced the channel clamp mode wave which
also holds the headstage/channel association.

This needs to be cleared as well.