### PR TITLE
SF_OperationTP: Fix TP property calculation

### DIFF
--- a/Packages/MIES/MIES_Structures.ipf
+++ b/Packages/MIES/MIES_Structures.ipf
@@ -295,7 +295,7 @@ Structure TPAnalysisInput
 	WAVE data
 	variable clampAmp
 	variable clampMode
-	variable duration
+	variable duration // [points]
 	variable baselineFrac
 	variable tpLengthPoints
 	variable readTimeStamp

--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -1885,7 +1885,7 @@ static Function/WAVE SF_OperationTP(variable jsonId, string jsonPath, string gra
 
 	variable numArgs, sweepCnt, activeChannelCnt, i, j, channelNr, channelType, dacChannelNr
 	variable sweep, index, numTPEpochs
-	variable tpBaseLineT, emptyOutput, headstage, outType
+	variable tpBaseLinePoints, emptyOutput, headstage, outType
 	string epShortName, tmpStr, unit, unitKey
 	string epochTPRegExp = "^(U_)?TP[[:digit:]]*$"
 	string baselineUnit = ""
@@ -2016,13 +2016,13 @@ static Function/WAVE SF_OperationTP(variable jsonId, string jsonPath, string gra
 			SF_ASSERT(WaveExists(epochTPPulse) && DimSize(epochTPPulse, ROWS) == 1, "No TP Pulse epoch found for TP epoch")
 			WAVE/Z/T epochTPBaseline = EP_GetEpochs(numericalValues, textualValues, sweep, XOP_CHANNEL_TYPE_DAC, dacChannelNr, epShortName + "_B0")
 			SF_ASSERT(WaveExists(epochTPBaseline) && DimSize(epochTPBaseline, ROWS) == 1, "No TP Baseline epoch found for TP epoch")
-			tpBaseLineT = (str2num(epochTPBaseline[0][EPOCH_COL_ENDTIME]) - str2num(epochTPBaseline[0][EPOCH_COL_STARTTIME])) * ONE_TO_MILLI
+			tpBaseLinePoints = (str2num(epochTPBaseline[0][EPOCH_COL_ENDTIME]) - str2num(epochTPBaseline[0][EPOCH_COL_STARTTIME])) * ONE_TO_MILLI / DimDelta(sweepData, ROWS)
 
 			// Assemble TP data
 			WAVE tpInput.data = SF_AverageTPFromSweep(epochMatches, sweepData)
 			tpInput.tpLengthPoints = DimSize(tpInput.data, ROWS)
-			tpInput.duration = (str2num(epochTPPulse[0][EPOCH_COL_ENDTIME]) - str2num(epochTPPulse[0][EPOCH_COL_STARTTIME])) * ONE_TO_MILLI
-			tpInput.baselineFrac =  TP_CalculateBaselineFraction(tpInput.duration, tpInput.duration + 2 * tpBaseLineT)
+			tpInput.duration = (str2num(epochTPPulse[0][EPOCH_COL_ENDTIME]) - str2num(epochTPPulse[0][EPOCH_COL_STARTTIME])) * ONE_TO_MILLI / DimDelta(sweepData, ROWS)
+			tpInput.baselineFrac =  TP_CalculateBaselineFraction(tpInput.duration, tpInput.duration + 2 * tpBaseLinePoints)
 
 			[WAVE settings, index] = GetLastSettingChannel(numericalValues, textualValues, sweep, CLAMPMODE_ENTRY_KEY, dacChannelNr, XOP_CHANNEL_TYPE_DAC, DATA_ACQUISITION_MODE)
 			SF_ASSERT(WaveExists(settings), "Failed to retrieve TP Clamp Mode from LBN")

--- a/Packages/Testing-MIES/UTF_SweepFormula.ipf
+++ b/Packages/Testing-MIES/UTF_SweepFormula.ipf
@@ -2105,3 +2105,33 @@ static Function TestHelpNotebook([string str])
 	DB_OpenDataBrowser()
 	CHECK_EQUAL_VAR(DB_SFHelpJumpToLine("operation - " + str), 0)
 End
+
+// data acquired with model cell, 45% baseline
+// the data is the inserted TP plus 10ms flat stimset
+static Function TPWithModelCell()
+	string win, device, bsPanel, results, ref
+
+	device = HW_ITC_BuildDeviceString("ITC18USB", "0")
+
+	DFREF dfr = GetDevicePath(device)
+	DuplicateDataFolder root:SF_TP:Data, dfr
+
+	DFREF dfr = GetMIESPath()
+	DuplicateDataFolder root:SF_TP:LabNoteBook, dfr
+
+	GetDAQDeviceID(device)
+
+	win = DB_GetBoundDataBrowser(device)
+
+	CHECK(ExecuteSweepFormulaInDB("store(\"inst\",tp(inst))\n and \nstore(\"ss\",tp(ss))", win))
+
+	WAVE textualResultsValues = GetLogbookWaves(LBT_RESULTS, LBN_TEXTUAL_VALUES)
+
+	results = GetLastSettingTextIndep(textualResultsValues, NaN, "Sweep Formula store [ss]", SWEEP_FORMULA_RESULT)
+	ref = "183.03771820448884;"
+	CHECK_EQUAL_STR(ref, results)
+
+	results = GetLastSettingTextIndep(textualResultsValues, NaN, "Sweep Formula store [inst]", SWEEP_FORMULA_RESULT)
+	ref = "17.158406068163004;"
+	CHECK_EQUAL_STR(ref, results)
+End

--- a/Packages/Testing-MIES/UserAnalysisFunctions.ipf
+++ b/Packages/Testing-MIES/UserAnalysisFunctions.ipf
@@ -1050,3 +1050,15 @@ Function EnableIndexing(string device, STRUCT AnalysisFunction_V3& s)
 			// do nothing
 	endswitch
 End
+
+Function AddUserEpochsForTPLike(string device, STRUCT AnalysisFunction_V3& s)
+	variable ret
+
+	switch(s.eventType)
+		case PRE_SWEEP_CONFIG_EVENT:
+			ret = MIES_PSQ#PSQ_CreateTestpulseEpochs(device, s.headstage, 3)
+			if(ret)
+				return 1
+			endif
+	endswitch
+End


### PR DESCRIPTION
The duration is in points and not in ms as the code assumed.

Bug introduced in the initial version in 044d386 (SweepFormula add tp
operation, 2021-12-09).

Close #1273
Close #1444