### PR TITLE
SF_OperationTP: Fix TP property calculation [backport]

### DIFF
--- a/Packages/MIES/MIES_Structures.ipf
+++ b/Packages/MIES/MIES_Structures.ipf
@@ -295,7 +295,7 @@ Structure TPAnalysisInput
 	WAVE data
 	variable clampAmp
 	variable clampMode
-	variable duration
+	variable duration // [points]
 	variable baselineFrac
 	variable tpLengthPoints
 	variable readTimeStamp

--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -1873,7 +1873,7 @@ static Function/WAVE SF_OperationTP(variable jsonId, string jsonPath, string gra
 
 	variable numArgs, sweepCnt, activeChannelCnt, i, j, channelNr, channelType, dacChannelNr
 	variable sweep, index, numTPEpochs
-	variable tpBaseLineT, emptyOutput, headstage, outType
+	variable tpBaseLinePoints, emptyOutput, headstage, outType
 	string epShortName, tmpStr, unit, unitKey
 	string epochTPRegExp = "^(U_)?TP[[:digit:]]*$"
 	string baselineUnit = ""
@@ -2004,13 +2004,13 @@ static Function/WAVE SF_OperationTP(variable jsonId, string jsonPath, string gra
 			SF_ASSERT(WaveExists(epochTPPulse) && DimSize(epochTPPulse, ROWS) == 1, "No TP Pulse epoch found for TP epoch")
 			WAVE/Z/T epochTPBaseline = EP_GetEpochs(numericalValues, textualValues, sweep, XOP_CHANNEL_TYPE_DAC, dacChannelNr, epShortName + "_B0")
 			SF_ASSERT(WaveExists(epochTPBaseline) && DimSize(epochTPBaseline, ROWS) == 1, "No TP Baseline epoch found for TP epoch")
-			tpBaseLineT = (str2num(epochTPBaseline[0][EPOCH_COL_ENDTIME]) - str2num(epochTPBaseline[0][EPOCH_COL_STARTTIME])) * ONE_TO_MILLI
+			tpBaseLinePoints = (str2num(epochTPBaseline[0][EPOCH_COL_ENDTIME]) - str2num(epochTPBaseline[0][EPOCH_COL_STARTTIME])) * ONE_TO_MILLI / DimDelta(sweepData, ROWS)
 
 			// Assemble TP data
 			WAVE tpInput.data = SF_AverageTPFromSweep(epochMatches, sweepData)
 			tpInput.tpLengthPoints = DimSize(tpInput.data, ROWS)
-			tpInput.duration = (str2num(epochTPPulse[0][EPOCH_COL_ENDTIME]) - str2num(epochTPPulse[0][EPOCH_COL_STARTTIME])) * ONE_TO_MILLI
-			tpInput.baselineFrac =  TP_CalculateBaselineFraction(tpInput.duration, tpInput.duration + 2 * tpBaseLineT)
+			tpInput.duration = (str2num(epochTPPulse[0][EPOCH_COL_ENDTIME]) - str2num(epochTPPulse[0][EPOCH_COL_STARTTIME])) * ONE_TO_MILLI / DimDelta(sweepData, ROWS)
+			tpInput.baselineFrac =  TP_CalculateBaselineFraction(tpInput.duration, tpInput.duration + 2 * tpBaseLinePoints)
 
 			[WAVE settings, index] = GetLastSettingChannel(numericalValues, textualValues, sweep, CLAMPMODE_ENTRY_KEY, dacChannelNr, XOP_CHANNEL_TYPE_DAC, DATA_ACQUISITION_MODE)
 			SF_ASSERT(WaveExists(settings), "Failed to retrieve TP Clamp Mode from LBN")

--- a/Packages/Testing-MIES/UTF_SweepFormulaHardware.ipf
+++ b/Packages/Testing-MIES/UTF_SweepFormulaHardware.ipf
@@ -416,3 +416,112 @@ static Function TestSweepFormulaCodeResults_REENTRY([string str])
 	content = GetLastSettingTextIndep(textualResultsValues, NaN, "Sweep Formula cursor J", UNKNOWN_MODE)
 	CHECK_PROPER_STR(content)
 End
+
+Function SF_InsertedTPVersusTP_IGNORE(string device)
+
+	ST_SetStimsetParameter("PSQ_QC_Stimsets_DA_0", "Analysis function (generic)", str = "AddUserEpochsForTPLike")
+	PGC_SetAndActivateControl(device, GetPanelControl(0, CHANNEL_TYPE_DAC, CHANNEL_CONTROL_WAVE), str = "PSQ_QC_Stimsets_DA_0")
+	PGC_SetAndActivateControl(device, GetPanelControl(1, CHANNEL_TYPE_DAC, CHANNEL_CONTROL_WAVE), str = "PSQ_QC_Stimsets_DA_0")
+
+	PGC_SetAndActivateControl(device, "Check_DataAcq_Get_Set_ITI", val = CHECKBOX_UNSELECTED)
+	PGC_SetAndActivateControl(device, "SetVar_DataAcq_ITI", val = 10)
+
+	// HS0: IC
+	PGC_SetAndActivateControl(device, DAP_GetClampModeControl(I_CLAMP_MODE, 0), val=CHECKBOX_SELECTED)
+
+	// HS1: VC
+	PGC_SetAndActivateControl(device, DAP_GetClampModeControl(V_CLAMP_MODE, 1), val=CHECKBOX_SELECTED)
+
+	// make IC less noisy
+	PGC_SetAndActivateControl(device, "SetVar_DataAcq_TPAmplitudeIC", val=-150)
+
+	CtrlNamedBackGround StopTPAfterSomeTime, start=(ticks + 420), period=60, proc=StartAcq_IGNORE
+End
+
+// UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1
+static Function SF_InsertedTPVersusTP([str])
+	string str
+
+	STRUCT DAQSettings s
+	InitDAQSettingsFromString(s, "MD1_RA0_I0_L0_BKG_1_RES_0")
+	BasicHardwareTests#AcquireData(s, str, preAcquireFunc = SF_InsertedTPVersusTP_IGNORE, startTPinstead = 1)
+End
+
+static Function SF_InsertedTPVersusTP_REENTRY([str])
+	string str
+
+	string graph, formula
+	variable index
+
+	graph = DB_OpenDataBrowser()
+
+	// check that the inserted TP is roughly the same as the other TPs in the stimset
+
+	// HS0
+	formula = "tp(ss, select(channels(AD0), sweeps()), [1, 2, 3])"
+	WAVE/Z steadyStateInsertedHS0 = SF_FormulaExecutor(DirectToFormulaParser(formula), graph=graph)
+	CHECK_WAVE(steadyStateInsertedHS0, NUMERIC_WAVE)
+
+	formula = "tp(inst, select(channels(AD0), sweeps()), [1, 2, 3])"
+	WAVE/Z instInsertedHS0 = SF_FormulaExecutor(DirectToFormulaParser(formula), graph=graph)
+	CHECK_WAVE(instInsertedHS0, NUMERIC_WAVE)
+
+	formula = "tp(ss, select(channels(AD0), sweeps()), [0])"
+	WAVE/Z steadyStateOthersHS0 = SF_FormulaExecutor(DirectToFormulaParser(formula), graph=graph)
+	CHECK_WAVE(steadyStateOthersHS0, NUMERIC_WAVE)
+
+	formula = "tp(inst, select(channels(AD0), sweeps()), [0])"
+	WAVE/Z instOthersHS0 = SF_FormulaExecutor(DirectToFormulaParser(formula), graph=graph)
+	CHECK_WAVE(instOthersHS0, NUMERIC_WAVE)
+
+	CHECK_EQUAL_WAVES(steadyStateInsertedHS0, steadyStateOthersHS0, mode = WAVE_DATA, tol = 50^2)
+	CHECK_EQUAL_WAVES(instInsertedHS0, instOthersHS0, mode = WAVE_DATA,tol = 50^2)
+
+	// HS1
+	formula = "tp(ss, select(channels(AD1), sweeps()), [1, 2, 3])"
+	WAVE/Z steadyStateInsertedHS1 = SF_FormulaExecutor(DirectToFormulaParser(formula), graph=graph)
+	CHECK_WAVE(steadyStateInsertedHS1, NUMERIC_WAVE)
+
+	formula = "tp(inst, select(channels(AD1), sweeps()), [1, 2, 3])"
+	WAVE/Z instInsertedHS1 = SF_FormulaExecutor(DirectToFormulaParser(formula), graph=graph)
+	CHECK_WAVE(instInsertedHS1, NUMERIC_WAVE)
+
+	formula = "tp(ss, select(channels(AD1), sweeps()), [0])"
+	WAVE/Z steadyStateOthersHS1 = SF_FormulaExecutor(DirectToFormulaParser(formula), graph=graph)
+	CHECK_WAVE(steadyStateOthersHS1, NUMERIC_WAVE)
+
+	formula = "tp(inst, select(channels(AD1), sweeps()), [0])"
+	WAVE/Z instOthersHS1 = SF_FormulaExecutor(DirectToFormulaParser(formula), graph=graph)
+	CHECK_WAVE(instOthersHS1, NUMERIC_WAVE)
+
+	CHECK_EQUAL_WAVES(steadyStateInsertedHS1, steadyStateOthersHS1, mode = WAVE_DATA, tol = 0.1)
+	CHECK_EQUAL_WAVES(instInsertedHS1, instOthersHS1, mode = WAVE_DATA, tol = 0.1)
+
+	// `tp` gives the same results as TP from TPStorage
+
+	WAVE TPStorage = GetTPstorage(str)
+	index = GetNumberFromWaveNote(TPstorage, NOTE_INDEX)
+	CHECK_GT_VAR(index, 0)
+
+	Duplicate/FREE/RMD=[0, index - 1][0][FindDimlabel(TPStorage, LAYERS, "PeakResistance")] TPStorage, instTPStorageLayer_HS0
+	Duplicate/FREE/RMD=[0, index - 1][0][FindDimlabel(TPStorage, LAYERS, "SteadyStateResistance")] TPStorage, steadyStateTPStorageLayer_HS0
+
+	Duplicate/FREE/RMD=[0, index - 1][1][FindDimlabel(TPStorage, LAYERS, "PeakResistance")] TPStorage, instTPStorageLayer_HS1
+	Duplicate/FREE/RMD=[0, index - 1][1][FindDimlabel(TPStorage, LAYERS, "SteadyStateResistance")] TPStorage, steadyStateTPStorageLayer_HS1
+
+	Redimension/N=(-1) instTPStorageLayer_HS0, steadyStateTPStorageLayer_HS0, steadyStateInsertedHS0, instInsertedHS0
+
+	matrixOP/FREE instTPStorage_HS0 = mean(instTPStorageLayer_HS0)
+	matrixOP/FREE steadyStateTPStorage_HS0 = mean(steadyStateTPStorageLayer_HS0)
+
+	CHECK_EQUAL_WAVES(steadyStateInsertedHS0, SteadyStateTPStorage_HS0, mode = WAVE_DATA, tol = 0.1)
+	CHECK_EQUAL_WAVES(instInsertedHS0, InstTPStorage_HS0, mode = WAVE_DATA, tol = 0.1)
+
+	Redimension/N=(-1) instTPStorageLayer_HS1, steadyStateTPStorageLayer_HS1, steadyStateInsertedHS1, instInsertedHS1
+
+	matrixOP/FREE instTPStorage_HS1 = mean(instTPStorageLayer_HS1)
+	matrixOP/FREE steadyStateTPStorage_HS1 = mean(steadyStateTPStorageLayer_HS1)
+
+	CHECK_EQUAL_WAVES(steadyStateInsertedHS1, steadyStateTPStorage_HS1, mode = WAVE_DATA, tol = 0.1)
+	CHECK_EQUAL_WAVES(instInsertedHS1, instTPStorage_HS1, mode = WAVE_DATA, tol = 0.1)
+End

--- a/Packages/Testing-MIES/UserAnalysisFunctions.ipf
+++ b/Packages/Testing-MIES/UserAnalysisFunctions.ipf
@@ -1050,3 +1050,15 @@ Function EnableIndexing(string device, STRUCT AnalysisFunction_V3& s)
 			// do nothing
 	endswitch
 End
+
+Function AddUserEpochsForTPLike(string device, STRUCT AnalysisFunction_V3& s)
+	variable ret
+
+	switch(s.eventType)
+		case PRE_SWEEP_CONFIG_EVENT:
+			ret = MIES_PSQ#PSQ_CreateTestpulseEpochs(device, s.headstage, 3)
+			if(ret)
+				return 1
+			endif
+	endswitch
+End


### PR DESCRIPTION
The duration is in points and not in ms as the code assumed.

Bug introduced in the initial version in 044d386 (SweepFormula add tp
operation, 2021-12-09).
