### PR TITLE
Dashboard fix

### DIFF
--- a/Packages/MIES/MIES_AcquisitionStateHandling.ipf
+++ b/Packages/MIES/MIES_AcquisitionStateHandling.ipf
@@ -87,6 +87,8 @@ Function AS_HandlePossibleTransition(string device, variable newAcqState, [varia
 
 	switch(newAcqState)
 		case AS_INACTIVE:
+			AD_UpdateAllDatabrowser()
+			break
 		case AS_EARLY_CHECK:
 			// do nothing
 			break

--- a/Packages/MIES/MIES_AnalysisFunctions_Dashboard.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_Dashboard.ipf
@@ -410,7 +410,10 @@ static Function/S AD_GetSquarePulseFailMsg(numericalValues, sweepNo, headstage)
 
 	key = CreateAnaFuncLBNKey(PSQ_SQUARE_PULSE, PSQ_FMT_LBN_STEPSIZE, query = 1)
 	stepSize = GetLastSettingIndepSCI(numericalValues, sweepNo, key, headstage, UNKNOWN_MODE)
-	ASSERT(IsFinite(stepSize), "Missing DAScale stepsize LBN entry")
+	if(!IsFinite(stepSize))
+		BUG("Missing DAScale stepsize LBN entry")
+		return "Failure"
+	endif
 
 	if(stepSize != PSQ_SP_INIT_AMP_p10)
 		sprintf msg, "Failure as we did not reach the desired DAScale step size of %.0W0PA but only %.0W0PA", PSQ_SP_INIT_AMP_p10, stepSize

--- a/Packages/MIES/MIES_AnalysisFunctions_Dashboard.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_Dashboard.ipf
@@ -365,7 +365,7 @@ End
 
 static Function/S AD_FormatListKey(variable stimsetCycleID, variable headstage)
 
-	return num2str(stimsetCycleID) + "_HS" + num2str(headstage)
+	return num2strHighPrec(stimsetCycleID, shorten = 1) + "_HS" + num2str(headstage)
 End
 
 static Function AD_LabnotebookEntryExistsAndIsTrue(WAVE/Z data)

--- a/Packages/MIES/MIES_AnalysisFunctions_Dashboard.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_Dashboard.ipf
@@ -225,6 +225,8 @@ static Function AD_FillWaves(win, list, info)
 			continue
 		endif
 
+		WAVE/Z lastSweepStimsetCycleIDs = GetLastSetting(numericalValues, WaveMax(totalSweepsPresent), STIMSET_ACQ_CYCLE_ID_KEY, DATA_ACQUISITION_MODE)
+
 		key = StringFromList(GENERIC_EVENT, EVENT_NAME_LIST_LBN)
 		WAVE/Z/T anaFuncs = GetLastSetting(textualValues, sweepNo, key, DATA_ACQUISITION_MODE)
 
@@ -271,7 +273,9 @@ static Function AD_FillWaves(win, list, info)
 
 			if(anaFuncType == INVALID_ANALYSIS_FUNCTION)
 				passed = NaN
-				ongoingDAQ = 0
+				// current sweep is from the same SCI than the last acquired sweep and DAQ is not inactive
+				ASSERT(WaveExists(lastSweepStimsetCycleIDs), "Missing last sweep SCIs")
+				ongoingDAQ = (lastSweepStimsetCycleIDs[headstage] == stimsetCycleID) && (acqState != AS_INACTIVE)
 			else
 				key = CreateAnaFuncLBNKey(anaFuncType, PSQ_FMT_LBN_SET_PASS, query = 1)
 				passed = GetLastSettingIndepSCI(numericalValues, sweepNo, key, headstage, UNKNOWN_MODE)


### PR DESCRIPTION
This fixes an issue where the ongoing DAQ state was incorrectly reported for stimsets without analysis functions attached.

Minimal backport version of #1453.