### PR TITLE
Track analysis function calls

### DIFF
--- a/Packages/MIES/MIES_AcquisitionStateHandling.ipf
+++ b/Packages/MIES/MIES_AcquisitionStateHandling.ipf
@@ -70,6 +70,8 @@ Function AS_HandlePossibleTransition(string device, variable newAcqState, [varia
 
 	if(oldAcqState == AS_PRE_SWEEP && newAcqState == AS_MID_SWEEP)
 		ED_MarkSweepStart(device)
+	elseif(newAcqState == AS_PRE_SWEEP_CONFIG)
+		DC_ClearWaves(device)
 	endif
 
 #ifdef AUTOMATED_TESTING

--- a/Packages/MIES/MIES_AcquisitionStateHandling.ipf
+++ b/Packages/MIES/MIES_AcquisitionStateHandling.ipf
@@ -74,6 +74,14 @@ Function AS_HandlePossibleTransition(string device, variable newAcqState, [varia
 		DC_ClearWaves(device)
 	endif
 
+	if(newAcqState == AS_PRE_DAQ)
+		AFM_ClearCallCount(device)
+	elseif(oldAcqState == AS_ITI && newAcqState == AS_PRE_SWEEP_CONFIG \
+		   || oldAcqState == AS_POST_DAQ && newAcqState == AS_INACTIVE)
+		ED_WriteAnalysisFunctionCallCount(device)
+		AFM_ClearCallCount(device)
+	endif
+
 #ifdef AUTOMATED_TESTING
 	AS_RecordStateTransition(oldAcqState, newAcqState)
 #endif

--- a/Packages/MIES/MIES_AcquisitionStateHandling.ipf
+++ b/Packages/MIES/MIES_AcquisitionStateHandling.ipf
@@ -76,8 +76,8 @@ Function AS_HandlePossibleTransition(string device, variable newAcqState, [varia
 
 	if(newAcqState == AS_PRE_DAQ)
 		AFM_ClearCallCount(device)
-	elseif(oldAcqState == AS_ITI && newAcqState == AS_PRE_SWEEP_CONFIG \
-		   || oldAcqState == AS_POST_DAQ && newAcqState == AS_INACTIVE)
+	elseif((oldAcqState == AS_ITI && newAcqState == AS_PRE_SWEEP_CONFIG) \
+		   || (oldAcqState == AS_POST_DAQ && newAcqState == AS_INACTIVE))
 		ED_WriteAnalysisFunctionCallCount(device)
 		AFM_ClearCallCount(device)
 	endif

--- a/Packages/MIES/MIES_AnalysisFunctionManagement.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctionManagement.ipf
@@ -225,15 +225,12 @@ End
 
 Function AFM_ClearCallCount(string device)
 	WAVE callCount = GetAnalysisFunctionCallCount(device)
-	callCount[][] = NaN
+
+	callCount[][] = 0
 End
 
 static Function AFM_IncreaseCallCount(string device, variable headstage, variable event)
 	WAVE callCount = GetAnalysisFunctionCallCount(device)
 
-	if(IsNaN(callCount[headstage][event]))
-		callCount[headstage][event] = 1
-	else
-		callCount[headstage][event] +=1
-	endif
+	callCount[headstage][event] +=1
 End

--- a/Packages/MIES/MIES_AnalysisFunctionManagement.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctionManagement.ipf
@@ -133,6 +133,7 @@ Function AFM_CallAnalysisFunctions(device, eventType)
 				s.sweepsInSet        = sweepsInSet
 				s.params             = analysisFunctions[i][ANALYSIS_FUNCTION_PARAMS]
 
+				AFM_IncreaseCallCount(device, i, eventType)
 				ret = f3(device, s); AbortOnRTE
 			else
 				ASSERT(0, "impossible case")
@@ -220,4 +221,19 @@ Function AFM_UpdateAnalysisFunctionWave(device)
 
 		analysisFunctions[i][ANALYSIS_FUNCTION_PARAMS] = ExtractAnalysisFunctionParams(stimSet)
 	endfor
+End
+
+Function AFM_ClearCallCount(string device)
+	WAVE callCount = GetAnalysisFunctionCallCount(device)
+	callCount[][] = NaN
+End
+
+static Function AFM_IncreaseCallCount(string device, variable headstage, variable event)
+	WAVE callCount = GetAnalysisFunctionCallCount(device)
+
+	if(IsNaN(callCount[headstage][event]))
+		callCount[headstage][event] = 1
+	else
+		callCount[headstage][event] +=1
+	endif
 End

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -38,7 +38,7 @@ Constant SWEEP_EPOCH_VERSION = 5
 /// - New/Changed layers of entries
 ///
 /// @{
-Constant LABNOTEBOOK_VERSION = 63
+Constant LABNOTEBOOK_VERSION = 64
 Constant RESULTS_VERSION     = 2
 /// @}
 

--- a/Packages/MIES/MIES_DataConfigurator.ipf
+++ b/Packages/MIES/MIES_DataConfigurator.ipf
@@ -20,9 +20,6 @@ static Function DC_UpdateGlobals(string device, variable dataAcqOrTP)
 
 	TP_UpdateTPSettingsCalculated(device)
 
-	KillOrMoveToTrash(wv=GetTPSettingsLabnotebook(device))
-	KillOrMoveToTrash(wv=GetTPSettingsLabnotebookKeyWave(device))
-
 	if(dataAcqOrTP == DATA_ACQUISITION_MODE)
 		TP_UpdateTPLBNSettings(device)
 	endif
@@ -32,6 +29,21 @@ static Function DC_UpdateGlobals(string device, variable dataAcqOrTP)
 
 	NVAR fifoPosition = $GetFifoPosition(device)
 	fifoPosition = 0
+End
+
+Function DC_ClearWaves(string device)
+
+	KillOrMoveToTrash(wv=GetTPSettingsLabnotebook(device))
+	KillOrMoveToTrash(wv=GetTPSettingsLabnotebookKeyWave(device))
+
+	KillOrMoveToTrash(wv = GetTPResultsBuffer(device))
+
+	KillOrMoveToTrash(wv=GetSweepSettingsWave(device))
+	KillOrMoveToTrash(wv=GetSweepSettingsTextWave(device))
+	KillOrMoveToTrash(wv=GetSweepSettingsKeyWave(device))
+	KillOrMoveToTrash(wv=GetSweepSettingsTextKeyWave(device))
+
+	EP_ClearEpochs(device)
 End
 
 /// @brief Prepare test pulse/data acquisition
@@ -67,12 +79,9 @@ Function DC_Configure(device, dataAcqOrTP, [multiDevice])
 	variable hardwareType = GetHardwareType(device)
 	ASSERT(!HW_IsRunning(hardwareType, deviceID, flags=HARDWARE_ABORT_ON_ERROR | HARDWARE_PREVENT_ERROR_POPUP), "Hardware is still running and it shouldn't. Please report that as a bug.")
 
-	KillOrMoveToTrash(wv=GetSweepSettingsWave(device))
-	KillOrMoveToTrash(wv=GetSweepSettingsTextWave(device))
-	KillOrMoveToTrash(wv=GetSweepSettingsKeyWave(device))
-	KillOrMoveToTrash(wv=GetSweepSettingsTextKeyWave(device))
-
-	EP_ClearEpochs(device)
+	if(dataAcqOrTP == TEST_PULSE_MODE)
+		DC_ClearWaves(device)
+	endif
 
 	if(dataAcqOrTP == DATA_ACQUISITION_MODE)
 		if(AFM_CallAnalysisFunctions(device, PRE_SET_EVENT))
@@ -101,8 +110,6 @@ Function DC_Configure(device, dataAcqOrTP, [multiDevice])
 
 	NVAR ADChannelToMonitor = $GetADChannelToMonitor(device)
 	ADChannelToMonitor = DimSize(GetDACListFromConfig(DAQConfigWave), ROWS)
-
-	KillOrMoveToTrash(wv = GetTPResultsBuffer(device))
 
 	DC_MakeHelperWaves(device, dataAcqOrTP)
 	SCOPE_CreateGraph(device, dataAcqOrTP)

--- a/Packages/MIES/MIES_ExperimentDocumentation.ipf
+++ b/Packages/MIES/MIES_ExperimentDocumentation.ipf
@@ -697,7 +697,7 @@ Function ED_WriteAnalysisFunctionCallCount(string device)
 			str += entry
 		endfor
 
-		values[i] = str
+		values[0][0][i] = str
 	endfor
 
 	ED_AddEntriesToLabnotebook(values, keys, sweepNo, device, DATA_ACQUISITION_MODE)

--- a/Packages/MIES/MIES_ExperimentDocumentation.ipf
+++ b/Packages/MIES/MIES_ExperimentDocumentation.ipf
@@ -642,6 +642,67 @@ Function ED_MarkSweepStart(device)
 	sweepSettingsTxtWave[0][%$HIGH_PREC_SWEEP_START_KEY][INDEP_HEADSTAGE] = GetISO8601TimeStamp(numFracSecondsDigits = 3)
 End
 
+/// @brief Add the analysis function call count labnotebook entry
+///
+/// Name: Analysis function call count
+/// Format: `$analysisFunctionName:$eventName=$callCount;...`
+Function ED_WriteAnalysisFunctionCallCount(string device)
+	variable i, j, callCount, sweepNo
+	string str, entry, func
+
+	WAVE analysisFunctionCallCount = GetAnalysisFunctionCallCount(device)
+
+	sweepNo = AFH_GetLastSweepAcquired(device)
+	ASSERT(IsValidSweepNumber(sweepNo), "Unexpected sweep number")
+
+	WAVE/T textualValues = GetLBTextualValues(device)
+
+	WAVE/T/Z funcs = GetLastSetting(textualValues, sweepNo, "Generic function", DATA_ACQUISITION_MODE)
+
+	if(!WaveExists(funcs))
+		// nothing to do
+		return NaN
+	endif
+
+	if(!HasOneValidEntry(analysisFunctionCallCount))
+		// nothing to do
+		return NaN
+	endif
+
+	Make/T/FREE/N=(1, 1, LABNOTEBOOK_LAYER_COUNT) values
+	Make/T/FREE/N=(1, 1) keys = "Analysis function call count"
+
+	for(i = 0; i < NUM_HEADSTAGES; i += 1)
+		func = funcs[i]
+
+		if(IsEmpty(func))
+			continue
+		endif
+
+		str = ""
+		for(j = 0; j < TOTAL_NUM_EVENTS; j += 1)
+			if(j == GENERIC_EVENT)
+				// generic events are never send to analysis functions
+				continue
+			endif
+
+			callCount = analysisFunctionCallCount[i][j]
+
+			if(IsNaN(callCount))
+				callCount = 0
+			endif
+
+			ASSERT(IsInteger(callCount), "Expected integer value")
+			sprintf entry, "%s:%s=%d;", func, StringFromList(j, EVENT_NAME_LIST), callCount
+			str += entry
+		endfor
+
+		values[i] = str
+	endfor
+
+	ED_AddEntriesToLabnotebook(values, keys, sweepNo, device, DATA_ACQUISITION_MODE)
+End
+
 /// @brief Add sweep specific information to the labnotebook
 Function ED_createWaveNoteTags(device, sweepCount)
 	string device

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -6496,7 +6496,8 @@ End
 /// - Head stage number
 ///
 /// Columns:
-/// - 0-#TOTAL_NUM_EVENTS - 1: Counts how often the analysis function was called during a complete sweep
+/// - 0-#TOTAL_NUM_EVENTS - 1: Counts how often the analysis function was
+///   called during a complete sweep for the given event.
 Function/WAVE GetAnalysisFunctionCallCount(string device)
 	variable versionOfWave = 1
 	DFREF dfr = GetDevicePath(device)
@@ -6511,7 +6512,7 @@ Function/WAVE GetAnalysisFunctionCallCount(string device)
 		Make/D/N=(NUM_HEADSTAGES, TOTAL_NUM_EVENTS) dfr:analysisFunctionCallCount/WAVE=wv
 	endif
 
-	wv = NaN
+	wv = 0
 
 	SetWaveVersion(wv, versionOfWave)
 

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -6490,6 +6490,34 @@ Function/WAVE GetAnalysisFunctionStorage(device)
 	return wv
 End
 
+/// @brief Return the call count wave for the analysis functions
+///
+/// Rows:
+/// - Head stage number
+///
+/// Columns:
+/// - 0-#TOTAL_NUM_EVENTS - 1: Counts how often the analysis function was called during a complete sweep
+Function/WAVE GetAnalysisFunctionCallCount(string device)
+	variable versionOfWave = 1
+	DFREF dfr = GetDevicePath(device)
+	WAVE/D/Z/SDFR=dfr wv = analysisFunctionCallCount
+
+	if(ExistsWithCorrectLayoutVersion(wv, versionOfWave))
+		return wv
+	elseif(WaveExists(wv))
+		 // handle upgrade
+		Redimension/N=(NUM_HEADSTAGES, TOTAL_NUM_EVENTS) wv
+	else
+		Make/D/N=(NUM_HEADSTAGES, TOTAL_NUM_EVENTS) dfr:analysisFunctionCallCount/WAVE=wv
+	endif
+
+	wv = NaN
+
+	SetWaveVersion(wv, versionOfWave)
+
+	return wv
+End
+
 /// @brief Used for storing a true/false state that the pre and/or post set event
 /// should be fired *after* the sweep which is currently prepared in DC_PlaceDataInDAQDataWave().
 ///

--- a/Packages/Testing-MIES/UTF_AnalysisFunctionManagement.ipf
+++ b/Packages/Testing-MIES/UTF_AnalysisFunctionManagement.ipf
@@ -178,6 +178,47 @@ Function RewriteAnalysisFunctions_IGNORE()
 	SaveStimsets()
 End
 
+/// Return the analysis function calls
+Function/WAVE GetAnalysisFunctionCallCountsFromLBN(string device, [variable sweepTotals])
+	variable i, j, numSweeps
+
+	if(ParamIsDefault(sweepTotals))
+		sweepTotals = 1
+	else
+		sweepTotals = !!sweepTotals
+	endif
+
+	WAVE/T textualValues = GetLBTextualValues(device)
+
+	WAVE/Z sweeps = GetSweepsWithSetting(textualValues, "Analysis Function call count")
+	CHECK_WAVE(sweeps, NUMERIC_WAVE)
+
+	numSweeps = DimSize(sweeps, ROWS)
+	Make/FREE/D/N=(NUM_HEADSTAGES, TOTAL_NUM_EVENTS, numSweeps) results = NaN
+
+	for(i = 0; i < numSweeps; i += 1)
+		WAVE/T/Z entries = GetLastSetting(textualValues, sweeps[i], "Analysis Function call count", DATA_ACQUISITION_MODE)
+		CHECK_WAVE(entries, TEXT_WAVE)
+		WAVE/T/Z funcs = GetLastSetting(textualValues, sweeps[i], "Generic function", DATA_ACQUISITION_MODE)
+		CHECK_WAVE(funcs, TEXT_WAVE)
+
+		for(j = 0; j < TOTAL_NUM_EVENTS; j += 1)
+			if(j == GENERIC_EVENT)
+				continue
+			endif
+
+			results[][j][i] = NumberByKey(funcs[p] + ":" + StringFromList(j, EVENT_NAME_LIST), entries[p], "=", ";")
+		endfor
+	endfor
+
+	if(sweepTotals)
+		MatrixOp/FREE summedUp = sumBeams(results)
+		return summedUp
+	endif
+
+	return results
+End
+
 /// @brief Acquire data with the given DAQSettings
 static Function AcquireData(s, stimset, device, [numHeadstages, TTLStimset, postInitializeFunc, preAcquireFunc])
 	STRUCT DAQSettings& s
@@ -755,15 +796,15 @@ static Function AFT6a_REENTRY([str])
 	sweepNo = AFH_GetLastSweepAcquired(str)
 	CHECK_EQUAL_VAR(sweepNo, 19)
 
-	WAVE anaFuncTracker = TrackAnalysisFunctionCalls()
-	CHECK_EQUAL_VAR(anaFuncTracker[PRE_DAQ_EVENT], 1)
-	CHECK_EQUAL_VAR(anaFuncTracker[PRE_SET_EVENT], 1)
-	CHECK_EQUAL_VAR(anaFuncTracker[PRE_SWEEP_CONFIG_EVENT], 20)
-	CHECK_GE_VAR(anaFuncTracker[MID_SWEEP_EVENT], 1)
-	CHECK_EQUAL_VAR(anaFuncTracker[POST_SWEEP_EVENT], 20)
-	CHECK_EQUAL_VAR(anaFuncTracker[POST_SET_EVENT], 1)
-	CHECK_EQUAL_VAR(anaFuncTracker[POST_DAQ_EVENT], 1)
-	CHECK_EQUAL_VAR(anaFuncTracker[GENERIC_EVENT], 0)
+	WAVE anaFuncTracker = GetAnalysisFunctionCallCountsFromLBN(str)
+	CHECK_EQUAL_VAR(anaFuncTracker[0][PRE_DAQ_EVENT], 1)
+	CHECK_EQUAL_VAR(anaFuncTracker[0][PRE_SET_EVENT], 1)
+	CHECK_EQUAL_VAR(anaFuncTracker[0][PRE_SWEEP_CONFIG_EVENT], 20)
+	CHECK_GE_VAR(anaFuncTracker[0][MID_SWEEP_EVENT], 1)
+	CHECK_EQUAL_VAR(anaFuncTracker[0][POST_SWEEP_EVENT], 20)
+	CHECK_EQUAL_VAR(anaFuncTracker[0][POST_SET_EVENT], 1)
+	CHECK_EQUAL_VAR(anaFuncTracker[0][POST_DAQ_EVENT], 1)
+	CHECK_EQUAL_VAR(anaFuncTracker[0][GENERIC_EVENT], NaN)
 
 	WAVE/T textualValues = GetLBTextualValues(str)
 	key = StringFromList(PRE_DAQ_EVENT, EVENT_NAME_LIST_LBN)

--- a/Packages/Testing-MIES/UTF_AnalysisFunctionManagement.ipf
+++ b/Packages/Testing-MIES/UTF_AnalysisFunctionManagement.ipf
@@ -188,26 +188,25 @@ Function/WAVE GetAnalysisFunctionCallCountsFromLBN(string device, [variable swee
 		sweepTotals = !!sweepTotals
 	endif
 
+	WAVE numericalValues = GetLBNumericalValues(device)
 	WAVE/T textualValues = GetLBTextualValues(device)
 
-	WAVE/Z sweeps = GetSweepsWithSetting(textualValues, "Analysis Function call count")
+	WAVE/Z sweeps = GetSweepsWithSetting(textualValues, "Generic Function")
 	CHECK_WAVE(sweeps, NUMERIC_WAVE)
 
 	numSweeps = DimSize(sweeps, ROWS)
 	Make/FREE/D/N=(NUM_HEADSTAGES, TOTAL_NUM_EVENTS, numSweeps) results = NaN
 
 	for(i = 0; i < numSweeps; i += 1)
-		WAVE/T/Z entries = GetLastSetting(textualValues, sweeps[i], "Analysis Function call count", DATA_ACQUISITION_MODE)
-		CHECK_WAVE(entries, TEXT_WAVE)
-		WAVE/T/Z funcs = GetLastSetting(textualValues, sweeps[i], "Generic function", DATA_ACQUISITION_MODE)
-		CHECK_WAVE(funcs, TEXT_WAVE)
-
 		for(j = 0; j < TOTAL_NUM_EVENTS; j += 1)
 			if(j == GENERIC_EVENT)
 				continue
 			endif
 
-			results[][j][i] = NumberByKey(funcs[p] + ":" + StringFromList(j, EVENT_NAME_LIST), entries[p], "=", ";")
+			WAVE/Z entries = GetLastSetting(numericalValues, sweeps[i], ED_GetCallCountEntry(j), DATA_ACQUISITION_MODE)
+			CHECK_WAVE(entries, NUMERIC_WAVE)
+
+			results[][j][i] = entries[p]
 		endfor
 	endfor
 

--- a/Packages/Testing-MIES/UTF_HardwareMain.ipf
+++ b/Packages/Testing-MIES/UTF_HardwareMain.ipf
@@ -1400,7 +1400,7 @@ Function AddLabnotebookEntries_IGNORE(s)
 	return 0
 End
 
-static Function TestSweepReconstruction_IGNORE(string device)
+Function TestSweepReconstruction_IGNORE(string device)
 	variable i, numEntries, sweepNo
 	string list, nameRecon, nameOrig
 


### PR DESCRIPTION
(Recreated from #1203)

- [ ] Finalize
- [ ] Commit cleanup
- [ ] Tests: Ditch TrackAnalysisFunctionCalls for V3 and translate the tests to GetAnalysisFunctionCallCountsFromLBN
- [ ] One entry per event in LBN with `count`


Revise after chat:

~~- [ ] Change UNKNOWN_MODE for writing to 2, introduce new variable for "not-caring-about-entry-source" on reading, adapt cache for these changes~~
~~- [ ] Use this new entry source type for call count to avoid LBN querying issues with UNKNOWN_MODE entries being between DATA_ACQUISITION_MODE entries.~~
~~- [ ] The code in 96519036de080d84e78c6f310bcee70e3c25cadc seems odd. With calling DC_ClearWaves from AS_PRE_SWEEP_CONFIG we are now actually calling it later than before.~~

Close #1081.