### PR TITLE
ShowTraceInfoTags: Call it always

### DIFF
--- a/Packages/MIES/MIES_BrowserSettingsPanel.ipf
+++ b/Packages/MIES/MIES_BrowserSettingsPanel.ipf
@@ -85,8 +85,6 @@ Function BSP_InitPanel(mainPanel)
 
 	graph = LBV_GetLabNoteBookGraph(mainPanel)
 	TUD_Init(graph)
-
-	ShowTraceInfoTags()
 End
 
 /// @brief UnHides BrowserSettings side Panel

--- a/Packages/MIES/MIES_GuiUtilities.ipf
+++ b/Packages/MIES/MIES_GuiUtilities.ipf
@@ -2081,7 +2081,7 @@ Function/S GetPopupMenuList(string value, variable type)
 	endswitch
 End
 
-/// @brief Enable show trace info tags for the current top graph
+/// @brief Enable show trace info tags globally
 Function ShowTraceInfoTags()
 
 	DoIgorMenu/C "Graph", "Show Trace Info Tags"

--- a/Packages/MIES/MIES_IgorHooks.ipf
+++ b/Packages/MIES/MIES_IgorHooks.ipf
@@ -310,6 +310,8 @@ static Function AfterCompiledHook()
 		ExperimentModified 0
 	endif
 
+	ShowTraceInfoTags()
+
 	LOG_AddEntry(PACKAGE_MIES, "end")
 End
 


### PR DESCRIPTION
When opening a saved experiment we don't re-execute the BSP_InitPanel code.
And the only place which we know is always executed are the Igor hooks.

The hooks IgorStartOrNewHook/IgorBeforeNewHook don't work, so we use
AfterCompiledHook.

This complements the fix from da7cc293 (ShowTraceInfoTags: Call it only
once per Databrowser, 2022-05-10).

Will merge once CI passes.
