### PR TITLE
WIP: Test adaptations for upcoming IUTF update

### DIFF
--- a/Packages/Testing-MIES/UTF_Labnotebook.ipf
+++ b/Packages/Testing-MIES/UTF_Labnotebook.ipf
@@ -1006,7 +1006,11 @@ End
 Function/WAVE AllDescriptionWaves()
 	Make/FREE/WAVE/N=1 wvs
 
-	wvs[0] = GetLBNumericalDescription()
+	// GetLBNumericalDescription creates a wave within the MIES datafolder, but that is killed at Test Begin
+	// Thus, we use a copy of that wave here
+	WAVE wDesc = GetLBNumericalDescription()
+	Duplicate/FREE wDesc, wT
+	wvs[0] = wT
 
 	return wvs
 End


### PR DESCRIPTION
In the upcoming IUTF update the data generator waves are retrieved once at the start of the testrun. Thus, the test must make sure that the wave is actually constant and not killed in between the retrieval and the test case execution.

