### PR TITLE
SF: Fix RTE at check for dataUnit with no data waves in SF_GatherFormulaResults

### DIFF
--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -990,7 +990,7 @@ static Function [WAVE/WAVE formulaResults, STRUCT SF_PlotMetaData plotMetaData] 
 		endif
 	endfor
 
-	dataUnits = SelectString(addDataUnitsInAnnotation && !IsEmpty(dataUnitCheck), "", "(\\U)")
+	dataUnits = SelectString(addDataUnitsInAnnotation && !IsNull(dataUnitCheck) && !IsEmpty(dataUnitCheck), "", "(\\U)")
 
 	plotMetaData.dataType = JWN_GetStringFromWaveNote(wvYRef, SF_META_DATATYPE)
 	plotMetaData.opStack = JWN_GetStringFromWaveNote(wvYRef, SF_META_OPSTACK)

--- a/Packages/Testing-MIES/UTF_SweepFormulaHardware.ipf
+++ b/Packages/Testing-MIES/UTF_SweepFormulaHardware.ipf
@@ -174,6 +174,18 @@ static Function	TestSweepFormulaButtons(string device)
 	CHECK_EQUAL_STR(refStr, win)
 End
 
+static Function TestSweepFormulaNoDataPlotted(string device)
+
+	string plotWin, dbPanel, formula
+
+	[dbPanel, plotWin] = GetNewDBforSF_IGNORE()
+
+	formula = "data(cursors(A,B),select(channels(AD10),sweeps(),all))"
+	SF_SetFormula(dbPanel, formula)
+	PGC_SetAndActivateControl(dbPanel, "button_sweepFormula_display", val = 1)
+	PASS()
+End
+
 static Function	TestSweepFormulaAnnotations(string device)
 
 	string plotWin, dbPanel, formula,annoInfo
@@ -516,6 +528,7 @@ static Function SF_TPTest_REENTRY([str])
 	TestSweepFormulaAxisLabels(str)
 	TestSweepFormulaFittingXAxis(str)
 	TestSweepFormulaDefaultMetaDataInheritance(str)
+	TestSweepFormulaNoDataPlotted(str)
 End
 
 // UTF_TD_GENERATOR HardwareMain#DeviceNameGeneratorMD1


### PR DESCRIPTION
SF_GatherFormulaResults has a logic to determine if data units should be shown in the final formula plot or not. The string that is used to check for the presence of valid data units was not handled correctly. For the special case that no data wave are present, the IsEmpty test after the skipped loop over all data waves generated an RTE.

introduced in 74d4d3c8a5b530390e25715ca28c3609168e4a86
