### PR TITLE
MIES Configuration, enhance to save/restore also notebook contents as plain text

### DIFF
--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -111,8 +111,6 @@ static StrConstant EXPCONFIG_FIELD_NOTEBOOKTEXT = "NotebookText"
 
 static StrConstant EXPCONFIG_UDATA_NICENAME = "Config_NiceName"
 static StrConstant EXPCONFIG_UDATA_JSONPATH = "Config_GroupPath"
-static StrConstant EXPCONFIG_UDATA_EXCLUDE_SAVE = "Config_DontSave"
-static StrConstant EXPCONFIG_UDATA_EXCLUDE_RESTORE = "Config_DontRestore"
 static StrConstant EXPCONFIG_UDATA_BUTTONPRESS = "Config_PushButtonOnRestore"
 // Lower means higher priority
 static StrConstant EXPCONFIG_UDATA_RESTORE_PRIORITY = "Config_RestorePriority"

--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -22,7 +22,8 @@
 /// if no other viable candidate panel was found.
 ///
 /// The GUI state is saved in a text file in json format. In the basic structure of the file the main blocks
-/// are the windows and subwindows and within are the control blocks.
+/// are the windows and subwindows and within are the control blocks. For notebook windows the content of the notebook is saved
+/// as plain text and restored as plain text.
 /// A bitmask parameter allows to configure which control information is saved. See WindowControlSavingMask
 /// Currently supported is Value, Position/Size, Userdata, Disabled state and Type of a control.
 /// Not implemented is e.g. Color/Background Color
@@ -106,6 +107,7 @@ static StrConstant EXPCONFIG_FIELD_CTRLPOSALIGN = "Align"
 static StrConstant EXPCONFIG_FIELD_CTRLUSERDATA = "Userdata"
 static StrConstant EXPCONFIG_FIELD_BASE64PREFIX = "Base64 "
 static StrConstant EXPCONFIG_FIELD_CTRLARRAYVALUES = "Values"
+static StrConstant EXPCONFIG_FIELD_NOTEBOOKTEXT = "NotebookText"
 
 static StrConstant EXPCONFIG_UDATA_NICENAME = "Config_NiceName"
 static StrConstant EXPCONFIG_UDATA_JSONPATH = "Config_GroupPath"
@@ -975,7 +977,7 @@ Function/S CONF_JSONToWindow(wName, restoreMask, jsonID)
 	string excludeList
 
 	variable i, colNiceName, colArrayName, colCtrlName, winNum, numCtrl, numWinCtrl, numGroups, numNice, offset, numWindows, numCtrlArrays, numArrayElem, isTagged
-	variable arrayNameIndex
+	variable arrayNameIndex, wType
 	string ctrlName, niceName, arrayName, ctrlList, wList, uData, winHandle, jsonCtrlGroupPath, subWinTarget, str, errMsg
 
 	AssertOnAndClearRTError()
@@ -997,7 +999,12 @@ Function/S CONF_JSONToWindow(wName, restoreMask, jsonID)
 		for(winNum = 0; winNum < numWindows; winNum += 1)
 			str = tgtWinNames[winNum]
 			subWinTarget = SelectString(IsEmpty(str), wName + "#" + str, wName)
-			ASSERT(WinType(subWinTarget), "Window " + subWinTarget + " does not exist!")
+			wType = WinType(subWinTarget)
+			ASSERT(wType, "Window " + subWinTarget + " does not exist!")
+			if(wType == WINTYPE_NOTEBOOK)
+				CONF_RestoreNotebookWindow(subWinTarget, srcWinNames[winNum], jsonID)
+				continue
+			endif
 
 			Make/FREE/T/N=(0, 4) ctrlData
 			SetDimLabel COLS, 0, NICENAME, ctrlData
@@ -1112,6 +1119,23 @@ Function/S CONF_JSONToWindow(wName, restoreMask, jsonID)
 	endtry
 
 	return wName
+End
+
+/// @brief Restores a notebook window content
+///
+/// @param wName  Name of notebook window in Igor
+/// @param srcWin Name of window in JSON
+/// @param jsonID Id of JSON
+static Function CONF_RestoreNotebookWindow(string wName, string srcWin, variable jsonID)
+
+	string jsonPath, nbText
+
+	if(!CmpStr(GetUserData(wName, "", EXPCONFIG_UDATA_EXCLUDE_RESTORE), "1"))
+		return NaN
+	endif
+	jsonPath = srcWin + "/" + EXPCONFIG_FIELD_NOTEBOOKTEXT
+	nbText = JSON_GetString(jsonID, jsonPath)
+	ReplaceNotebookText(wName, nbText)
 End
 
 /// @brief Returns the window with the set window handle
@@ -1395,6 +1419,12 @@ Function CONF_AllWindowsToJSON(wName, saveMask[, excCtrlTypes])
 		for(i = 0; i < numWins; i += 1)
 			curWinName = StringFromList(i, wList)
 			jsonIDWin = CONF_WindowToJSON(curWinName, saveMask, excCtrlTypes = excCtrlTypes)
+
+			if(JSON_GetType(jsonIDWin, "") == JSON_NULL)
+				JSON_Release(jsonIDWin)
+				continue
+			endif
+
 			WAVE/T ctrlList = JSON_GetKeys(jsonIDWin, "")
 			if(DimSize(ctrlList, ROWS))
 				JSON_SetJSON(jsonID, curWinName, jsonIDWin)
@@ -1433,13 +1463,18 @@ Function CONF_WindowToJSON(wName, saveMask[, excCtrlTypes])
 
 	string ctrlList, ctrlName, radioList, tmpList, wList, cbCtrlName, coupledIndexKeys = "", excUserKeys, radioFunc, str, errMsg
 	variable numCtrl, i, j, jsonID, numCoupled, setRadioPos, ctrlType, coupledCnt, numUniqueCtrlArray, numDupCheck
-	variable rbcIndex
+	variable rbcIndex, wType
 
 	AssertOnAndClearRTError()
 	try
 		excCtrlTypes = SelectString(ParamIsDefault(excCtrlTypes), excCtrlTypes, "")
-		ASSERT(WinType(wName), "Window " + wName + " does not exist!")
+		wType = WinType(wName)
+		ASSERT(wType, "Window " + wName + " does not exist!")
 		jsonID = JSON_New()
+		if(wType == WINTYPE_NOTEBOOK)
+			CONF_NotebookToJSON(wName, jsonID)
+			return jsonID
+		endif
 
 		ctrlList = ControlNameList(wName, ";", "*")
 		numCtrl = ItemsInList(ctrlList)
@@ -1584,6 +1619,21 @@ static Function/S CONF_GetCompleteJSONCtrlPath(path)
 	endfor
 
 	return completePath
+End
+
+/// @brief Adds a notebook window including content to a json
+///
+/// @param wName  Window name
+/// @param jsonID ID of existing json
+static Function CONF_NotebookToJSON(string wName, variable jsonID)
+
+	string nbText
+
+	if(!CmpStr(GetUserData(wName, "", EXPCONFIG_UDATA_EXCLUDE_SAVE), "1"))
+		return NaN
+	endif
+	nbText = GetNotebookText(wName, mode=2)
+	JSON_AddString(jsonID, EXPCONFIG_FIELD_NOTEBOOKTEXT, nbText)
 End
 
 /// @brief Adds properties of a control to a json

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -1927,3 +1927,10 @@ StrConstant SF_DATATYPE_TP = "TestPulse"
 Constant SWEEP_SKIP_USER = 0x1
 Constant SWEEP_SKIP_AUTO = 0x2
 /// @}
+
+/// @name Public constants from MIES_Configuration
+/// @anchor ExpConfigUserData
+/// @{
+StrConstant EXPCONFIG_UDATA_EXCLUDE_SAVE = "Config_DontSave"
+StrConstant EXPCONFIG_UDATA_EXCLUDE_RESTORE = "Config_DontRestore"
+/// @}

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -19,7 +19,7 @@ Constant DAQ_CONFIG_WAVE_VERSION = 2
 
 /// Used to upgrade the GuiStateWave as well as the DA Ephys panel
 Constant DA_EPHYS_PANEL_VERSION           = 57
-Constant DATA_SWEEP_BROWSER_PANEL_VERSION = 42
+Constant DATA_SWEEP_BROWSER_PANEL_VERSION = 43
 Constant WAVEBUILDER_PANEL_VERSION        = 13
 Constant ANALYSISBROWSER_PANEL_VERSION    =  1
 

--- a/Packages/MIES/MIES_DataBrowser.ipf
+++ b/Packages/MIES/MIES_DataBrowser.ipf
@@ -42,7 +42,7 @@ End
 ///        after GUI editor adapted controls in development process
 Function DB_ResetAndStoreCurrentDBPanel()
 	string device, bsPanel, scPanel, shPanel, recreationCode
-	string sfJSON, descNB
+	string sfJSON, descNB, helpNBWin
 
 	device = GetMainWindow(GetCurrentWindow())
 	if(!windowExists(device))
@@ -225,11 +225,19 @@ Function DB_ResetAndStoreCurrentDBPanel()
 
 	SF_SetFormula(device, "data(\rcursors(A,B),\rselect(channels(AD),sweeps())\r)")
 
+	helpNBWin = BSP_GetSFHELP(device)
+	SetWindow $helpNBWin, userdata($EXPCONFIG_UDATA_EXCLUDE_RESTORE)="1"
+	SetWindow $helpNBWin, userdata($EXPCONFIG_UDATA_EXCLUDE_SAVE)="1"
+
 	sfJSON = BSP_GetSFJSON(device)
 	ReplaceNotebookText(sfJSON, "")
+	SetWindow $sfJSON, userdata($EXPCONFIG_UDATA_EXCLUDE_RESTORE)="1"
+	SetWindow $sfJSON, userdata($EXPCONFIG_UDATA_EXCLUDE_SAVE)="1"
 
 	descNB = LBV_GetDescriptionNotebook(shPanel)
 	ReplaceNotebookText(descNB, "")
+	SetWindow $descNB, userdata($EXPCONFIG_UDATA_EXCLUDE_RESTORE)="1"
+	SetWindow $descNB, userdata($EXPCONFIG_UDATA_EXCLUDE_SAVE)="1"
 
 	SetVariable setvar_sweepFormula_parseResult WIN = $bsPanel, value=_STR:""
 	ValDisplay status_sweepFormula_parser, WIN = $bsPanel, value=1

--- a/Packages/MIES/MIES_DataBrowser_Macro.ipf
+++ b/Packages/MIES/MIES_DataBrowser_Macro.ipf
@@ -11,7 +11,7 @@
 
 Window DataBrowser() : Graph
 	PauseUpdate; Silent 1		// building window...
-	Display /W=(372,523.25,804,860)/K=1  as "DataBrowser"
+	Display /W=(739.5,170,1279.5,715.25)/K=1  as "DataBrowser"
 	Button button_BSP_open,pos={3.00,3.00},size={24.00,24.00},disable=1,proc=DB_ButtonProc_Panel
 	Button button_BSP_open,title="<<",help={"Open Side Panel"}
 	Button button_BSP_open,userdata(ResizeControlsInfo)=A"!!,>M!!#8L!!#=#!!#=#z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
@@ -82,11 +82,11 @@ Window DataBrowser() : Graph
 	GroupBox group_dDAQ,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	GroupBox group_dDAQ,userdata(ResizeControlsInfo)+=A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
 	GroupBox group_dDAQ,userdata(tabnum)="0",userdata(tabcontrol)="Settings"
-	Slider slider_BrowserSettings_dDAQ,pos={348.00,59.00},size={56.00,278.00},disable=2,proc=BSP_SliderProc_ChangedSetting
+	Slider slider_BrowserSettings_dDAQ,pos={348.00,59.00},size={53.00,278.00},disable=2,proc=BSP_SliderProc_ChangedSetting
 	Slider slider_BrowserSettings_dDAQ,help={"Allows to view only regions from the selected headstage (oodDAQ) resp. the selected headstage (dDAQ). Choose -1 to display all."}
 	Slider slider_BrowserSettings_dDAQ,userdata(tabnum)="0"
 	Slider slider_BrowserSettings_dDAQ,userdata(tabcontrol)="Settings"
-	Slider slider_BrowserSettings_dDAQ,userdata(ResizeControlsInfo)=A"!!,Hi!!#?%!!#>n!!#BEz!!#`-A7TLfzzzzzzzzzzzzzz!!#r+D.OhkBk2=!z"
+	Slider slider_BrowserSettings_dDAQ,userdata(ResizeControlsInfo)=A"!!,Hi!!#?%!!#>b!!#BEz!!#`-A7TLfzzzzzzzzzzzzzz!!#r+D.OhkBk2=!z"
 	Slider slider_BrowserSettings_dDAQ,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	Slider slider_BrowserSettings_dDAQ,userdata(ResizeControlsInfo)+=A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
 	Slider slider_BrowserSettings_dDAQ,limits={-1,7,1},value=-1
@@ -947,7 +947,7 @@ Window DataBrowser() : Graph
 	PopupMenu popup_DB_lockedDevices,userdata(ResizeControlsInfo)=A"!!,Dg!!#BPJ,hr2!!#<Pz!!#`-A7TLfzzzzzzzzzzzzzz!!#r+D.OhkBk2=!z"
 	PopupMenu popup_DB_lockedDevices,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	PopupMenu popup_DB_lockedDevices,userdata(ResizeControlsInfo)+=A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	PopupMenu popup_DB_lockedDevices,mode=2,popvalue="- none -",value=#"DB_GetAllDevicesWithData()"
+	PopupMenu popup_DB_lockedDevices,mode=1,popvalue="- none -",value=#"DB_GetAllDevicesWithData()"
 	GroupBox group_enable_sweepFormula,pos={5.00,25.00},size={434.00,50.00},disable=1
 	GroupBox group_enable_sweepFormula,title="SweepFormula",userdata(tabnum)="5"
 	GroupBox group_enable_sweepFormula,userdata(tabcontrol)="Settings"
@@ -1263,12 +1263,14 @@ Window DataBrowser() : Graph
 	SetWindow kwTopWin,userdata(ResizeControlsInfo)=A"!!,@C!!#>F!!#C#!!#B[J,fQL!!#](Aon#azzzzzzzzzzzzzz!!#o2B4uAeBk2=!z"
 	SetWindow kwTopWin,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetWindow kwTopWin,userdata(ResizeControlsInfo)+=A"zzz!!#?(FEDG<zzzzzzzzzzzzzz!!!"
+	SetWindow kwTopWin,userdata(Config_DontRestore)="1"
+	SetWindow kwTopWin,userdata(Config_DontSave)="1"
 	RenameWindow #,sweepFormula_json
 	SetActiveSubwindow ##
 	NewNotebook /F=1 /N=sweepFormula_formula /W=(12,71,378,529)/FG=(UGVL,UGVT,UGVR,UGVB) /HOST=# /V=0
-	Notebook kwTopWin, defaultTab=20, autoSave= 1, magnification=100, showRuler=0, rulerUnits=2
+	Notebook kwTopWin, defaultTab=10, autoSave= 1, magnification=100, showRuler=0, rulerUnits=2
 	Notebook kwTopWin newRuler=Normal, justification=0, margins={0,0,286}, spacing={0,0,0}, tabs={}, rulerDefaults={"Arial",11,0,(0,0,0)}
-	Notebook kwTopWin, zdata= "GaqDU%ejN7!Z)uNa2l$r6juaSr.@(O3s1Uq&W)/A(*I2niY!B*!lQ'Dkpdh3KVT$I/Ich)!tpS$YV?Caacs`,6k*H,LAsL=dd[9$7$\\?7Rp9,rS6o6siMbe4WImX)**?3\\C//MaM+2MT@U<AU%T'QkVG;,VC2-&>L8H:5?&W/sRLGQ=$k.U\\7Ce78\\6TQl!OeDHmk=c$b_1:YZ:k\\;$kjKuM_]jLqiiF?VBdWNkN<TCkG0kd!!)\\i68n"
+	Notebook kwTopWin, zdata= "GaqDU%ejN7!Z)uNa2l$r6juaS]NAgm*X3eh,8(:b/3qDf`$IZ2\"c,0hdT&QD#tZ!q>8lc2\"sb*'?t0`LOsu56M&O#8%0(kYUuD?'Lb'WM2S$2n35;Co_bnHG;[8413O#OCe=>%L&rkt2`4Wb4*2%$_9qC;7eC9(Z%8BPJ\\er8p1`7uY(`<2AMfKJPE4[$a\")KaohdHS(QjNH<A=49T(a^pr(1dP!pF/h^9M&3&cHe#dcUh\\e\"9;;O6<4"
 	Notebook kwTopWin, zdataEnd= 1
 	SetWindow kwTopWin,hook(ResizeControls)=ResizeControls#ResizeControlsHook
 	SetWindow kwTopWin,userdata(tabnum)="0"
@@ -1287,6 +1289,8 @@ Window DataBrowser() : Graph
 	SetWindow kwTopWin,userdata(ResizeControlsInfo)=A"!!,@C!!#>F!!#C#!!#B[J,fQL!!#](Aon#azzzzzzzzzzzzzz!!#o2B4uAeBk2=!z"
 	SetWindow kwTopWin,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetWindow kwTopWin,userdata(ResizeControlsInfo)+=A"zzz!!#?(FEDG<zzzzzzzzzzzzzz!!!"
+	SetWindow kwTopWin,userdata(Config_DontRestore)="1"
+	SetWindow kwTopWin,userdata(Config_DontSave)="1"
 	RenameWindow #,sweepFormula_help
 	SetActiveSubwindow ##
 	NewNotebook /F=0 /N=WaveNoteDisplay /W=(200,24,600,561)/FG=(FL,$"",FR,FB) /HOST=# /V=0 /OPTS=10
@@ -1391,6 +1395,8 @@ Window DataBrowser() : Graph
 	NewNotebook /F=1 /N=Description /W=(145,49,436,148)/FG=(FL,FT,UGVL,FB) /HOST=# /OPTS=11
 	Notebook kwTopWin, defaultTab=10, autoSave= 0, magnification=1, showRuler=0, rulerUnits=0
 	Notebook kwTopWin newRuler=Normal, justification=0, margins={0,0,86}, spacing={0,0,0}, tabs={}, rulerDefaults={"Arial",11,0,(0,0,0)}
+	SetWindow kwTopWin,userdata(Config_DontRestore)="1"
+	SetWindow kwTopWin,userdata(Config_DontSave)="1"
 	RenameWindow #,Description
 	SetActiveSubwindow ##
 	RenameWindow #,SettingsHistoryPanel

--- a/Packages/tests/Basic/UTF_Configuration.ipf
+++ b/Packages/tests/Basic/UTF_Configuration.ipf
@@ -324,3 +324,31 @@ static Function TCONF_DupCtrlArrayNameRestore()
 		PASS()
 	endtry
 End
+
+/// @brief Check for notebook window saving
+static Function TCONF_SaveNotebookAndRestore()
+
+	string wName = "nbText"
+	string fName = "NotebookTest.json"
+	string nbTextRef = "This is fine."
+	string nbTextRef2 = "This is not fine."
+	string nbText
+
+	DoWindow/K $wName
+	NewNotebook/N=$wName/F=0
+	ReplaceNotebookText(wName, nbTextRef)
+	CONF_SaveWindow(PrependExperimentFolder_IGNORE(fName))
+	ReplaceNotebookText(wName, nbTextRef2)
+	CONF_RestoreWindow(PrependExperimentFolder_IGNORE(fName))
+	nbText = GetNotebookText(wName, mode=2)
+	CHECK_EQUAL_STR(nbTextRef, nbText)
+
+	ReplaceNotebookText(wName, nbTextRef)
+	SetWindow $wName, userdata($EXPCONFIG_UDATA_EXCLUDE_RESTORE)="1"
+	SetWindow $wName, userdata($EXPCONFIG_UDATA_EXCLUDE_SAVE)="1"
+	CONF_SaveWindow(PrependExperimentFolder_IGNORE(fName))
+	ReplaceNotebookText(wName, nbTextRef2)
+	CONF_RestoreWindow(PrependExperimentFolder_IGNORE(fName))
+	nbText = GetNotebookText(wName, mode=2)
+	CHECK_EQUAL_STR(nbTextRef2, nbText)
+End


### PR DESCRIPTION
This enhances the MIES Configuration module to be aware of notebook windows.
For notebook windows the content gets saved as plain text and restored as plain text.
The SweepFormula help notebook was excluded from saving/restore as it contains formatted text.

close https://github.com/AllenInstitute/MIES/issues/646