### PR TITLE
Tests: Allow tweaking test execution more fine-grained

### DIFF
--- a/Packages/doc/developers.rst
+++ b/Packages/doc/developers.rst
@@ -170,6 +170,11 @@ For executing the tests manually perform the followings steps:
 - Call ``RunWithOpts()``
 - Watch the output
 
+The environment variables ``BAMBOO_INSTRUMENT_TESTS``/``BAMBOO_EXPENSIVE_CHECKS``
+allow to tweak test execution. By default we do expensive tests in CI and
+instrumentation in CI for the main branch. Accepted are all numbers but the
+values ``0``/``1`` are suggested.
+
 Documentation building
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/Packages/tests/UTF_HardwareHelperFunctions.ipf
+++ b/Packages/tests/UTF_HardwareHelperFunctions.ipf
@@ -96,11 +96,19 @@ End
 
 Function DoExpensiveChecks()
 
+	variable expensive
+
 #ifdef AUTOMATED_TESTING_EXPENSIVE
 	return 1
 #endif
 
-	return IsRunningInCI()
+	expensive = GetEnvironmentVariableAsBoolean("BAMBOO_EXPENSIVE_CHECKS")
+
+	if(IsFinite(expensive))
+		return expensive
+	endif
+
+	return 0
 End
 
 Function TEST_CASE_END_OVERRIDE(name)


### PR DESCRIPTION
The environment variables BAMBOO_EXPENSIVE_CHECKS and BAMBOO_INSTRUMENT_TESTS can now also be used to turn the feature off.

This allows to execute some tests faster in CI.

We also introduce GetEnvironmentVariableAsBoolean as helper function.

Will merge once CI passes.