### PR TITLE
bugfix in IgorBeforeQuitHook ignore error on SaveExperiment

### DIFF
--- a/Packages/MIES/MIES_IgorHooks.ipf
+++ b/Packages/MIES/MIES_IgorHooks.ipf
@@ -186,6 +186,8 @@ End
 static Function IgorBeforeQuitHook(unsavedExp, unsavedNotebooks, unsavedProcedures)
 	variable unsavedExp, unsavedNotebooks, unsavedProcedures
 
+	variable err
+
 	LOG_AddEntry(PACKAGE_MIES, "start")
 
 	IH_Cleanup()
@@ -193,7 +195,7 @@ static Function IgorBeforeQuitHook(unsavedExp, unsavedNotebooks, unsavedProcedur
 	// save the experiment silently if it was saved before
 	if(unsavedExp == 0 && cmpstr(UNTITLED_EXPERIMENT, GetExperimentName()))
 		LOG_AddEntry(PACKAGE_MIES, "before save")
-		SaveExperiment
+		SaveExperiment; err = GetRTError(1)
 		LOG_AddEntry(PACKAGE_MIES, "after save")
 	endif
 


### PR DESCRIPTION
if MIES is included in Igor Pro and the user has an experiment loaded from a read-only location then the SaveExperiment call in the Hook creates a runtime-error that could pop up the Debugger.

Thus, if Igor Pro is quitting and the experiment can not be saved, we ignore the error from the save attempt.
