### PR TITLE
Unify pragma usage and add checks

### DIFF
--- a/Packages/Conversion/MIES_MassExperimentProcessing.ipf
+++ b/Packages/Conversion/MIES_MassExperimentProcessing.ipf
@@ -1,4 +1,10 @@
+#pragma TextEncoding = "UTF-8"
 #pragma rtGlobals=3 // Use modern global access method.
+#pragma rtFunctionErrors=1
+
+#ifdef AUTOMATED_TESTING
+#pragma ModuleName=MIES_MEP
+#endif
 
 /// @file MIES_MassExperimentProcessing.ipf
 /// @brief __MEP__ Process multiple MIES pxps to convert data into NWBv2

--- a/Packages/MIES/MIES_ThreadedFIFOHandling.ipf
+++ b/Packages/MIES/MIES_ThreadedFIFOHandling.ipf
@@ -1,3 +1,4 @@
+#pragma TextEncoding = "UTF-8"
 #pragma rtGlobals=3 // Use modern global access method and strict wave access.
 #pragma rtFunctionErrors=1
 

--- a/Packages/MIES/MIES_ThreadsafeUtilities.ipf
+++ b/Packages/MIES/MIES_ThreadsafeUtilities.ipf
@@ -1,3 +1,4 @@
+#pragma TextEncoding = "UTF-8"
 #pragma rtGlobals=3 // Use modern global access method and strict wave access.
 #pragma rtFunctionErrors=1
 

--- a/Packages/doc/MIES_Regenerate-Screenshots.ipf
+++ b/Packages/doc/MIES_Regenerate-Screenshots.ipf
@@ -1,7 +1,6 @@
 #pragma TextEncoding = "UTF-8"
 #pragma rtGlobals=3 // Use modern global access method and strict wave access
 #pragma rtFunctionErrors=1
-#pragma DefaultTab={3,20,4}		// Set default tab width in Igor Pro 9 and later
 
 #ifdef AUTOMATED_TESTING
 #pragma ModuleName=MIES_RS

--- a/Packages/doc/MIES_Regenerate-Screenshots.ipf
+++ b/Packages/doc/MIES_Regenerate-Screenshots.ipf
@@ -1,6 +1,11 @@
 #pragma TextEncoding = "UTF-8"
 #pragma rtGlobals=3				// Use modern global access method and strict wave access
+#pragma rtFunctionErrors=1
 #pragma DefaultTab={3,20,4}		// Set default tab width in Igor Pro 9 and later
+
+#ifdef AUTOMATED_TESTING
+#pragma ModuleName=MIES_RS
+#endif
 
 #include "MIES_Include"
 

--- a/Packages/doc/MIES_Regenerate-Screenshots.ipf
+++ b/Packages/doc/MIES_Regenerate-Screenshots.ipf
@@ -1,5 +1,5 @@
 #pragma TextEncoding = "UTF-8"
-#pragma rtGlobals=3				// Use modern global access method and strict wave access
+#pragma rtGlobals=3 // Use modern global access method and strict wave access
 #pragma rtFunctionErrors=1
 #pragma DefaultTab={3,20,4}		// Set default tab width in Igor Pro 9 and later
 

--- a/Packages/tests/Basic/UTF_Basic.ipf
+++ b/Packages/tests/Basic/UTF_Basic.ipf
@@ -1,6 +1,7 @@
 #pragma TextEncoding = "UTF-8"
 #pragma rtGlobals=3 // Use modern global access method and strict wave access.
 #pragma rtFunctionErrors=1
+#pragma ModuleName=Basic
 
 #include "UTF_HelperFunctions"
 

--- a/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqChirp.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqChirp.ipf
@@ -1,5 +1,6 @@
 #pragma TextEncoding = "UTF-8"
 #pragma rtGlobals=3 // Use modern global access method and strict wave access.
+#pragma rtFunctionErrors=1
 #pragma ModuleName=PatchSeqTestChirp
 
 static Function [STRUCT DAQSettings s] PS_GetDAQSettings(string device)

--- a/Packages/tests/HardwareAnalysisFunctions/UTF_ReachTargetVoltage.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_ReachTargetVoltage.ipf
@@ -1,5 +1,6 @@
 #pragma TextEncoding = "UTF-8"
 #pragma rtGlobals=3 // Use modern global access method and strict wave access.
+#pragma rtFunctionErrors=1
 #pragma ModuleName=ReachTargetVoltageTesting
 
 static Constant HEADSTAGE = 1

--- a/Packages/tests/HardwareAnalysisFunctions/UTF_SetControls.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_SetControls.ipf
@@ -1,5 +1,6 @@
 #pragma TextEncoding = "UTF-8"
 #pragma rtGlobals=3		// Use modern global access method and strict wave access.
+#pragma rtFunctionErrors=1
 #pragma ModuleName=SetControlsTesting
 
 static Function [STRUCT DAQSettings s] SC_GetDAQSettings(string device)

--- a/Packages/tests/HardwareAnalysisFunctions/UTF_SetControls.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_SetControls.ipf
@@ -1,5 +1,5 @@
 #pragma TextEncoding = "UTF-8"
-#pragma rtGlobals=3		// Use modern global access method and strict wave access.
+#pragma rtGlobals=3 // Use modern global access method and strict wave access.
 #pragma rtFunctionErrors=1
 #pragma ModuleName=SetControlsTesting
 

--- a/Packages/tests/PAPlot/UTF_PAPlot.ipf
+++ b/Packages/tests/PAPlot/UTF_PAPlot.ipf
@@ -1,6 +1,7 @@
 #pragma TextEncoding = "UTF-8"
 #pragma rtGlobals=3 // Use modern global access method and strict wave access.
 #pragma rtFunctionErrors=1
+#pragma ModuleName=PAPlot
 
 #include "UTF_HelperFunctions"
 

--- a/tools/check-code.sh
+++ b/tools/check-code.sh
@@ -73,6 +73,42 @@ then
   ret=1
 fi
 
+matches=$(git grep $opts --files-without-match  '^#pragma rtGlobals=3' '**/MIES_*.ipf' '**/UTF*.ipf' ':^*/MIES_EnhancedWMRoutines.ipf')
+
+if [[ -n "$matches" ]]
+then
+  echo "The pragma rtGlobals=3 check failed and found the following occurences:"
+  echo "$matches"
+  ret=1
+fi
+
+matches=$(git grep $opts --files-without-match  '^#pragma rtFunctionErrors=1' '**/MIES_*.ipf' '**/UTF*.ipf' ':^*/MIES_EnhancedWMRoutines.ipf')
+
+if [[ -n "$matches" ]]
+then
+  echo "The pragma rtFunctionErrors=1 check failed and found the following occurences:"
+  echo "$matches"
+  ret=1
+fi
+
+matches=$(git grep $opts --files-without-match  '^#pragma TextEncoding' '**/MIES_*.ipf' '**/UTF*.ipf' ':^*/MIES_EnhancedWMRoutines.ipf')
+
+if [[ -n "$matches" ]]
+then
+  echo "The pragma TextEncoding check failed and found the following occurences:"
+  echo "$matches"
+  ret=1
+fi
+
+matches=$(git grep $opts --files-without-match  '^#pragma (ModuleName|IndependentModule)' '**/MIES_*.ipf' '**/UTF*.ipf' ':^*/MIES_Include.ipf')
+
+if [[ -n "$matches" ]]
+then
+  echo "The pragma ModuleName/IndependentModule check failed and found the following occurences:"
+  echo "$matches"
+  ret=1
+fi
+
 # ripgrep checks
 
 files=$(git ls-files '*.ipf' '*.sh' '*.rst' '*.dot' '*.md' ':!:**/releasenotes_template.rst')


### PR DESCRIPTION
We now enforce that we always have rtGlobals=3, rtFunctionErrors=1,
TextEncoding and a ModuleName/IndependentModule pragma.

Close #1477 

Will merge once CI passes.