### PR TITLE
UTF_HardwareAnalysisFunctions.ipf: Remove duplicated UTF_AutoTestpuls…

### DIFF
--- a/Packages/tests/HardwareAnalysisFunctions/UTF_HardwareAnalysisFunctions.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_HardwareAnalysisFunctions.ipf
@@ -6,7 +6,6 @@
 #include "::UTF_HardwareHelperFunctions"
 
 // keep sorted
-#include "UTF_AutoTestpulse"
 #include "UTF_MultiPatchSeqDAScale"
 #include "UTF_MultiPatchSeqFastRheoEstimate"
 #include "UTF_MultiPatchSeqSpikeControl"
@@ -91,7 +90,6 @@ Function RunWithOpts([string testcase, string testsuite, variable allowdebug, va
 	list = AddListItem("UTF_MultiPatchSeqFastRheoEstimate.ipf", list, ";", inf)
 	list = AddListItem("UTF_MultiPatchSeqDAScale.ipf", list, ";", inf)
 	list = AddListItem("UTF_MultiPatchSeqSpikeControl.ipf", list, ";", inf)
-	list = AddListItem("UTF_AutoTestpulse.ipf", list, ";", inf)
 
 	if(ParamIsDefault(testsuite))
 		testsuite = list


### PR DESCRIPTION
…e.ipf

This is already present in UTF_HardwareBasic.ipf. Bug introduced in 41b4abdc (Reorganize test folders, 2022-08-26).