### PR TITLE
SF: Shrink legend text if only sweep number changes

### DIFF
--- a/Packages/tests/Basic/UTF_SweepFormula.ipf
+++ b/Packages/tests/Basic/UTF_SweepFormula.ipf
@@ -2583,3 +2583,34 @@ static Function TestAverageOverSweeps()
 	TestAverageOverSweeps_CheckMeta(data, NaN, NaN, NaN)
 
 End
+
+static function TestLegendShrink()
+
+	string str, result
+	string strRef
+
+	str = "\s(T000000d0_Sweep_0_AD1) Sweep 0 AD1\r\s(T000000d1_Sweep_1_AD1) Sweep 1 AD1\r\s(T000000d2_Sweep_2_AD1) Sweep 2 AD1"
+	strref = "\s(T000000d0_Sweep_0_AD1)Sweeps 0-2 AD1"
+	result = MIES_SF#SF_ShrinkLegend(str)
+	CHECK_EQUAL_STR(strRef, result)
+
+	str = "\s(T000000d0_Sweep_0_AD1) Sweep 0 AD1\r\s(T000000d1_Sweep_1_AD1) Sweep 1 AD1\r\s(T000000d2_Sweep_2_AD1) Sweep 2 AD2"
+	strref = str
+	result = MIES_SF#SF_ShrinkLegend(str)
+	CHECK_EQUAL_STR(strRef, result)
+
+	str = "\s(T000000d0_Sweep_0_AD1) Sweep 0 AD1\r\s(T000000d1_Sweep_1_AD1) Sweep 1 AD1\r\s(T000000d2_Sweep_2_AD1) operation Sweep 2 AD1"
+	strref = str
+	result = MIES_SF#SF_ShrinkLegend(str)
+	CHECK_EQUAL_STR(strRef, result)
+
+	str = "\s(T000000d0_Sweep_0_AD1) Sweep 0 AD1\r\s(T000000d1_Sweep_1_AD1) Sweep 1 AD1\r\s(T000000d2_Sweep_2_AD1) Sweep 23 AD1"
+	strref = "\s(T000000d0_Sweep_0_AD1)Sweeps 0-1,23 AD1"
+	result = MIES_SF#SF_ShrinkLegend(str)
+	CHECK_EQUAL_STR(strRef, result)
+
+	str = "some other Sweep legend"
+	strref = str
+	result = MIES_SF#SF_ShrinkLegend(str)
+	CHECK_EQUAL_STR(strRef, result)
+End

--- a/Packages/tests/Basic/UTF_Utils.ipf
+++ b/Packages/tests/Basic/UTF_Utils.ipf
@@ -6201,3 +6201,62 @@ Function CO_Works()
 	CHECK_EQUAL_VAR(AlreadyCalledOnce("efgh"), 0)
 	CHECK_EQUAL_VAR(AlreadyCalledOnce("efgh"), 1)
 End
+
+static Function CompressNumericalList()
+
+	string list, ref
+
+	list = "1,2"
+	ref = "1-2"
+	list = MIES_UTILS#CompressNumericalList(list, ",")
+	CHECK_EQUAL_STR(list, ref)
+
+	list = "-1,0,1"
+	ref = "-1-1"
+	list = MIES_UTILS#CompressNumericalList(list, ",")
+	CHECK_EQUAL_STR(list, ref)
+
+	list = "1,2,3,5,6,7"
+	ref = "1-3,5-7"
+	list = MIES_UTILS#CompressNumericalList(list, ",")
+	CHECK_EQUAL_STR(list, ref)
+
+	list = ""
+	ref = ""
+	list = MIES_UTILS#CompressNumericalList(list, ",")
+	CHECK_EQUAL_STR(list, ref)
+
+	list = "1,2,2,3,3,4,6"
+	ref = "1-4,6"
+	list = MIES_UTILS#CompressNumericalList(list, ",")
+	CHECK_EQUAL_STR(list, ref)
+
+	list = "6,4,3,3,2,2,1"
+	ref = "1-4,6"
+	list = MIES_UTILS#CompressNumericalList(list, ",")
+	CHECK_EQUAL_STR(list, ref)
+
+	list = "string"
+	try
+		list = MIES_UTILS#CompressNumericalList(list, ",")
+		FAIL()
+	catch
+		PASS()
+	endtry
+
+	list = "1,1.5,2"
+	try
+		list = MIES_UTILS#CompressNumericalList(list, ",")
+		FAIL()
+	catch
+		PASS()
+	endtry
+
+	list = "1,2"
+	try
+		list = MIES_UTILS#CompressNumericalList(list, "")
+		FAIL()
+	catch
+		PASS()
+	endtry
+End


### PR DESCRIPTION
When only sweep numbers change in the legend of the sweepformula plot then the numbers are joined in a comma separated list.
Only one line is shown in the graph legend.

close https://github.com/AllenInstitute/MIES/issues/1470