### PR TITLE
AfterCompiledHook: Use more threads

### DIFF
--- a/Packages/MIES/MIES_IgorHooks.ipf
+++ b/Packages/MIES/MIES_IgorHooks.ipf
@@ -314,6 +314,8 @@ static Function AfterCompiledHook()
 
 	ShowTraceInfoTags()
 
+	MultiThreadingControl setmode=4
+
 	LOG_AddEntry(PACKAGE_MIES, "end")
 End
 

--- a/Packages/MIES/MIES_PulseAveraging.ipf
+++ b/Packages/MIES/MIES_PulseAveraging.ipf
@@ -2768,7 +2768,13 @@ End
 /// \endrst
 static Function PA_AutomaticTimeAlignment(STRUCT PulseAverageSetIndices &pasi)
 
-	variable i, j, numActive, jsonID, numEntries
+	variable i, j, numActive, jsonID, numEntries, oldSetMode
+
+	MultiThreadingControl getMode
+	oldSetMode = V_AutoMultiThread
+
+	// require serial execution for WaveStats in PA_GetFeaturePosition
+	MultiThreadingControl setMode = 0
 
 	WAVE properties = pasi.properties
 	WAVE/WAVE propertiesWaves = pasi.propertiesWaves
@@ -2806,6 +2812,8 @@ static Function PA_AutomaticTimeAlignment(STRUCT PulseAverageSetIndices &pasi)
 			Multithread junk[] = PA_SetFeaturePosition(propertiesWaves[setIndizes[p]][PA_PROPERTIESWAVES_INDEX_PULSE], propertiesWaves[setIndizes[p]][PA_PROPERTIESWAVES_INDEX_PULSENOTE], JSON_GetVariable(jsonID, keys[p], ignoreErr=1))
 		endfor
 	endfor
+
+	MultiThreadingControl setMode = oldSetMode
 
 	JSON_Release(jsonID)
 End

--- a/Packages/MIES/MIES_TestPulse.ipf
+++ b/Packages/MIES/MIES_TestPulse.ipf
@@ -959,6 +959,7 @@ threadsafe Function/DF TP_TSAnalysis(dfrInp)
 #endif
 
 	refPoint = tpStartPoint + evalOffsetPointsCorrected
+	// as data is always too small for threaded execution, the values of V_minRowLoc/V_maxRowLoc are reproducible
 	WaveStats/P/Q/M=1/R=[refPoint, refPoint + 0.25 / sampleInt] data
 	instPoint = (clampAmp < 0) ? V_minRowLoc : V_maxRowLoc
 	instVal = data[instPoint]


### PR DESCRIPTION
MultiThreadingControl allows to adjust when automatic threads are created for calculations.

The default (mode = 1) does use automatic threads only in the main thread. From other projects we know that this can be a limitation which is difficult to realize and thus lift.

Let's choose mode == 4 which uses automatic threads also in explicit/preemptive user threads.

- [ ] Investigate why the test PAT_ExtendedAverageCheck fails

Close #1512.