### PR TITLE
tools/initial-repo-config.sh: Adjust the fetch refspec

### DIFF
--- a/tools/initial-repo-config.sh
+++ b/tools/initial-repo-config.sh
@@ -15,6 +15,7 @@ git checkout :/
 # fetch submodules
 git submodule init
 git submodule update --checkout
+git submodule foreach "git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'"
 
 # recursive submodule checkout can be done with
 # git submodule update --checkout --init --recursive


### PR DESCRIPTION
Since e0d04315 (.gitmodules: Clone the submodules shallowly, 2021-04-08) we clone the submodules shallowly to speedup CI.

Cloning a repository shallowly creates the fetch refspec

+refs/heads/<defaultbranch>:refs/remotes/origin/<defaultbranch>

And due to this refspec it is not possible to fetch other branches.

By adjusting the refspec of all submodules to the default one, we allow fetching other branches as well. This is not detrimental for CI as the shallow clone of the submodules is already done once this script is run.

Will merge once CI passes.

@MichaelHuth This should solve the issue that on MIES repo clones the submodules can not fetch other branches.