### PR TITLE
Fix hooks functions for SweepBrowser

### DIFF
--- a/Packages/MIES/MIES_AnalysisBrowser_SweepBrowser.ipf
+++ b/Packages/MIES/MIES_AnalysisBrowser_SweepBrowser.ipf
@@ -368,25 +368,6 @@ Function SB_AddToSweepBrowser(sweepBrowser, fileName, dataFolder, device, sweep)
 	SetNumberInWaveNote(map, NOTE_INDEX, index + 1)
 End
 
-Function SB_SweepBrowserWindowHook(s)
-	STRUCT WMWinHookStruct &s
-
-	string graph, scPanel, ctrl
-
-	switch(s.eventCode)
-		case EVENT_WINDOW_HOOK_KILL:
-			graph = GetMainWindow(s.winName)
-
-			DFREF sweepBrowserDFR = SB_GetSweepBrowserFolder(graph)
-
-			KillOrMoveToTrash(dfr = sweepBrowserDFR)
-			break
-	endswitch
-
-	// return zero so that other hooks are called as well
-	return 0
-End
-
 Function/DF SB_OpenSweepBrowser([variable mode])
 
 	string mainWin, renameWin
@@ -404,7 +385,6 @@ Function/DF SB_OpenSweepBrowser([variable mode])
 	AddVersionToPanel(mainWin, DATA_SWEEP_BROWSER_PANEL_VERSION)
 	BSP_SetSweepBrowser(mainWin, mode)
 
-	SetWindow $mainWin, hook(cleanup)=SB_SweepBrowserWindowHook
 	SB_SetUserData(mainWin)
 
 	DFREF sweepBrowserDFR = BSP_GetFolder(mainWin, MIES_BSP_PANEL_FOLDER)

--- a/Packages/MIES/MIES_BrowserSettingsPanel.ipf
+++ b/Packages/MIES/MIES_BrowserSettingsPanel.ipf
@@ -90,7 +90,7 @@ End
 /// @brief UnHides BrowserSettings side Panel
 ///
 /// @param mainPanel 	mainWindow panel name
-Function BSP_UnHidePanel(mainPanel)
+static Function BSP_UnHidePanel(mainPanel)
 	string mainPanel
 
 	BSP_UnHideSweepControls(mainPanel)
@@ -100,7 +100,7 @@ Function BSP_UnHidePanel(mainPanel)
 	BSP_MainPanelButtonToggle(mainPanel, 0)
 End
 
-Function BSP_UnHideSettingsPanel(mainPanel)
+static Function BSP_UnHideSettingsPanel(mainPanel)
 	string mainPanel
 
 	string bsPanel
@@ -117,7 +117,7 @@ End
 /// @brief open bottom Panel
 ///
 /// @param mainPanel 	mainWindow panel name
-Function BSP_UnHideSweepControls(mainPanel)
+static Function BSP_UnHideSweepControls(mainPanel)
 	string mainPanel
 
 	string scPanel

--- a/Packages/MIES/MIES_BrowserSettingsPanel.ipf
+++ b/Packages/MIES/MIES_BrowserSettingsPanel.ipf
@@ -95,6 +95,7 @@ Function BSP_UnHidePanel(mainPanel)
 
 	BSP_UnHideSweepControls(mainPanel)
 	BSP_UnHideSettingsPanel(mainPanel)
+	BSP_UnHideSettingsHistory(mainPanel)
 
 	BSP_MainPanelButtonToggle(mainPanel, 0)
 End
@@ -1547,7 +1548,7 @@ Function BSP_UnsetDynamicSettingsHistory(win)
 	SetWindow $shPanel, hook(resetScaling)=$""
 End
 
-Function BSP_UnHideSettingsHistory(win)
+static Function BSP_UnHideSettingsHistory(win)
 	string win
 
 	string settingsHistoryPanel

--- a/Packages/MIES/MIES_BrowserSettingsPanel.ipf
+++ b/Packages/MIES/MIES_BrowserSettingsPanel.ipf
@@ -673,7 +673,7 @@ static Function BSP_MainPanelButtonToggle(mainPanel, visible)
 	endif
 End
 
-Function BSP_HidePanel(string win)
+static Function BSP_HidePanel(string win)
 
 	string mainPanel
 

--- a/Packages/MIES/MIES_BrowserSettingsPanel.ipf
+++ b/Packages/MIES/MIES_BrowserSettingsPanel.ipf
@@ -1529,7 +1529,7 @@ Function BSP_DynamicSettingsHistory(string win)
 
 	shPanel = LBV_GetSettingsHistoryPanel(win)
 
-	SetWindow $shPanel, hook(main)=DB_CloseSettingsHistoryHook
+	SetWindow $shPanel, hook(main)=BSP_ClosePanelHook
 	SetWindow $shPanel, hook(description)=LBV_EntryDescription
 	SetWindow $shPanel, hook(resetScaling)=IH_ResetScaling
 End

--- a/Packages/MIES/MIES_BrowserSettingsPanel.ipf
+++ b/Packages/MIES/MIES_BrowserSettingsPanel.ipf
@@ -174,6 +174,8 @@ static Function BSP_AddWindowHooks(string win)
 	bsPanel = BSP_GetPanel(win)
 	SetWindow $bsPanel, hook(main)=BSP_ClosePanelHook
 	SetWindow $bsPanel, hook(sweepFormula)=BSP_SweepFormulaHook
+	SetWindow $bsPanel, hook(nbinteract)=BSP_SFHelpWindowHook
+	SetWindow $bsPanel, tooltipHook(nbinteract)=BSP_TTHookSFFormulaNB
 
 	shPanel = LBV_GetSettingsHistoryPanel(win)
 	SetWindow $shPanel, hook(main)=BSP_ClosePanelHook
@@ -196,6 +198,8 @@ Function BSP_RemoveWindowHooks(string win)
 	bsPanel = BSP_GetPanel(win)
 	SetWindow $bsPanel, hook(main)=$""
 	SetWindow $bsPanel, hook(sweepFormula)=$""
+	SetWindow $bsPanel, hook(nbinteract)=$""
+	SetWindow $bsPanel, tooltipHook(nbinteract)=$""
 
 	shPanel = LBV_GetSettingsHistoryPanel(win)
 	SetWindow $shPanel, hook(main)=$""

--- a/Packages/MIES/MIES_BrowserSettingsPanel.ipf
+++ b/Packages/MIES/MIES_BrowserSettingsPanel.ipf
@@ -675,10 +675,14 @@ End
 
 static Function BSP_HidePanel(string win)
 
-	string mainPanel
+	string mainPanel, currentWindow
+
+	currentWindow = GetMainWindow(GetCurrentWindow())
 
 	mainPanel = GetMainWindow(win)
 	SetWindow $win hide=1
+
+	DoWindow/F $currentWindow
 
 	BSP_MainPanelButtonToggle(mainPanel, 1)
 End

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -19,7 +19,7 @@ Constant DAQ_CONFIG_WAVE_VERSION = 2
 
 /// Used to upgrade the GuiStateWave as well as the DA Ephys panel
 Constant DA_EPHYS_PANEL_VERSION           = 57
-Constant DATA_SWEEP_BROWSER_PANEL_VERSION = 44
+Constant DATA_SWEEP_BROWSER_PANEL_VERSION = 45
 Constant WAVEBUILDER_PANEL_VERSION        = 13
 Constant ANALYSISBROWSER_PANEL_VERSION    =  1
 

--- a/Packages/MIES/MIES_DataBrowser.ipf
+++ b/Packages/MIES/MIES_DataBrowser.ipf
@@ -10,7 +10,7 @@
 /// @brief __DB__ Panel for browsing acquired data during acquisition
 
 Function/S DB_OpenDataBrowser([variable mode])
-	string win, winBSP, device, devicesWithData, bsPanel
+	string win, device, devicesWithData, bsPanel
 
 	if(ParamIsDefault(mode))
 		mode = BROWSER_MODE_USER
@@ -20,10 +20,6 @@ Function/S DB_OpenDataBrowser([variable mode])
 
 	Execute "DataBrowser()"
 	win = GetCurrentWindow()
-
-	winBSP = BSP_GetPanel(win)
-	SetWindow $winBSP, hook(nbinteract)=BSP_SFHelpWindowHook
-	SetWindow $winBSP, tooltipHook(nbinteract)=BSP_TTHookSFFormulaNB
 
 	AddVersionToPanel(win, DATA_SWEEP_BROWSER_PANEL_VERSION)
 	BSP_SetDataBrowser(win, mode)

--- a/Packages/MIES/MIES_DataBrowser.ipf
+++ b/Packages/MIES/MIES_DataBrowser.ipf
@@ -551,23 +551,6 @@ static Function DB_UpdateToLastSweepWrapper(string win, variable force)
 	LBV_UpdateTagsForTextualLBNEntries(win, last)
 End
 
-/// @brief procedure for the open button of the side panel
-Function DB_ButtonProc_Panel(ba) : ButtonControl
-	STRUCT WMButtonAction &ba
-
-	string win
-
-	switch(ba.eventcode)
-		case 2: // mouse up
-			win = GetMainWindow(ba.win)
-			BSP_UnHideSettingsHistory(win)
-			break
-	endswitch
-
-	BSP_ButtonProc_Panel(ba)
-	return 0
-End
-
 Function DB_PopMenuProc_LockDBtoDevice(pa) : PopupMenuControl
 	STRUCT WMPopupAction &pa
 

--- a/Packages/MIES/MIES_DataBrowser.ipf
+++ b/Packages/MIES/MIES_DataBrowser.ipf
@@ -93,10 +93,9 @@ Function DB_ResetAndStoreCurrentDBPanel()
 	Checkbox check_BrowserSettings_OVS WIN = $bsPanel, value= 0
 
 	BSP_InitPanel(device)
+	BSP_RemoveWindowHooks(device)
 
-	BSP_UnsetDynamicSweepControlOfDataBrowser(device)
-	BSP_UnsetDynamicStartupSettingsOfDataBrowser(device)
-	BSP_UnsetDynamicSettingsHistory(device)
+	BSP_UnsetDynamicStartupSettings(device)
 
 	// store current positions as reference
 	StoreCurrentPanelsResizeInfo(bsPanel)
@@ -300,8 +299,7 @@ static Function/S DB_LockToDevice(win, device)
 		newWindow = DATABROWSER_WINDOW_TITLE
 		print "Please choose a device assignment for the data browser"
 		ControlWindowToFront()
-		BSP_UnsetDynamicStartupSettingsOfDataBrowser(win)
-		BSP_UnsetDynamicSettingsHistory(win)
+		BSP_UnsetDynamicStartupSettings(win)
 	else
 		newWindow = "DB_" + device
 	endif
@@ -317,7 +315,6 @@ static Function/S DB_LockToDevice(win, device)
 	DB_SetUserData(newWindow, device)
 	if(windowExists(BSP_GetPanel(newWindow)) && BSP_HasBoundDevice(newWindow))
 		BSP_DynamicStartupSettings(newWindow)
-		BSP_DynamicSettingsHistory(newWindow)
 		[first, last] = BSP_FirstAndLastSweepAcquired(newWindow)
 		DB_UpdateLastSweepControls(newWindow, first, last)
 	endif

--- a/Packages/MIES/MIES_DataBrowser.ipf
+++ b/Packages/MIES/MIES_DataBrowser.ipf
@@ -21,7 +21,6 @@ Function/S DB_OpenDataBrowser([variable mode])
 	Execute "DataBrowser()"
 	win = GetCurrentWindow()
 
-	SetWindow $win, hook(cleanup)=DB_WindowHook
 	winBSP = BSP_GetPanel(win)
 	SetWindow $winBSP, hook(nbinteract)=BSP_SFHelpWindowHook
 	SetWindow $winBSP, tooltipHook(nbinteract)=BSP_TTHookSFFormulaNB
@@ -799,41 +798,6 @@ Function/S DB_GetBoundDataBrowser(string device, [variable mode])
 	PGC_SetAndActivateControl(bsPanel, "popup_DB_lockedDevices", str = device)
 
 	return DB_FindDataBrowser(device)
-End
-
-Function DB_WindowHook(s)
-	STRUCT WMWinHookStruct &s
-
-	string win
-
-	switch(s.eventCode)
-		case EVENT_WINDOW_HOOK_KILL:
-
-			win = s.winName
-
-			NVAR JSONid = $GetSettingsJSONid()
-			PS_StoreWindowCoordinate(JSONid, win)
-
-			if(!BSP_HasBoundDevice(win))
-				break
-			endif
-
-			AssertOnAndClearRTError()
-			try
-				// catch all error conditions, asserts and aborts
-				// and silently ignore them
-				DFREF dfr = BSP_GetFolder(win, MIES_BSP_PANEL_FOLDER, versionCheck = 0); AbortOnRTE
-
-				KillOrMoveToTrash(dfr = dfr); AbortOnRTE
-			catch
-				ClearRTError()
-			endtry
-
-			break
-	endswitch
-
-	// return zero so that other hooks are called as well
-	return 0
 End
 
 /// @brief Jumps in the SweepFormula help notebook of the current data/sweepbrowser to the first location

--- a/Packages/MIES/MIES_DataBrowser_Macro.ipf
+++ b/Packages/MIES/MIES_DataBrowser_Macro.ipf
@@ -12,7 +12,7 @@
 Window DataBrowser() : Graph
 	PauseUpdate; Silent 1		// building window...
 	Display /W=(739.5,170,1279.5,715.25)/K=1  as "DataBrowser"
-	Button button_BSP_open,pos={3.00,3.00},size={24.00,24.00},disable=1,proc=DB_ButtonProc_Panel
+	Button button_BSP_open,pos={3.00,3.00},size={24.00,24.00},disable=1,proc=BSP_ButtonProc_Panel
 	Button button_BSP_open,title="<<",help={"Open Side Panel"}
 	Button button_BSP_open,userdata(ResizeControlsInfo)=A"!!,>M!!#8L!!#=#!!#=#z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	Button button_BSP_open,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"

--- a/Packages/MIES/MIES_DataBrowser_Macro.ipf
+++ b/Packages/MIES/MIES_DataBrowser_Macro.ipf
@@ -13,7 +13,7 @@ Window DataBrowser() : Graph
 	PauseUpdate; Silent 1		// building window...
 	Display /W=(739.5,170,1279.5,715.25)/K=1  as "DataBrowser"
 	Button button_BSP_open,pos={3.00,3.00},size={24.00,24.00},disable=1,proc=BSP_ButtonProc_Panel
-	Button button_BSP_open,title="<<",help={"Open Side Panel"}
+	Button button_BSP_open,title="<<",help={"Restore side panels"}
 	Button button_BSP_open,userdata(ResizeControlsInfo)=A"!!,>M!!#8L!!#=#!!#=#z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	Button button_BSP_open,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	Button button_BSP_open,userdata(ResizeControlsInfo)+=A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"

--- a/Packages/tests/HardwareBasic/UTF_Databrowser.ipf
+++ b/Packages/tests/HardwareBasic/UTF_Databrowser.ipf
@@ -22,3 +22,59 @@ Function CanFindAllDataBrowsers([string str])
 
 	CHECK_EQUAL_VAR(DimSize(matches, ROWS), 2)
 End
+
+static Function/WAVE AllDatabrowserSubWindows()
+
+	string win
+
+	win = DB_OpenDatabrowser()
+
+	WAVE/T/Z allWindows = ListToTextWave(GetAllWindows(win), ";")
+	CHECK_WAVE(allWindows, TEXT_WAVE)
+
+	allWindows[] = StringFromList(1, allWindows[p], "#")
+
+	RemoveTextWaveEntry1D(allWindows, "", all = 1)
+
+	WAVE/T/Z allWindowsUnique = GetUniqueEntries(allWindows)
+	CHECK_WAVE(allWindowsUnique, TEXT_WAVE)
+
+	SetDimensionLabels(allWindowsUnique, TextWaveToList(allWindowsUnique, ";"), ROWS)
+
+	KillWindow $win
+
+	return allWindowsUnique
+End
+
+// UTF_TD_GENERATOR AllDatabrowserSubWindows
+Function RestoreButtonWorks([string str])
+
+	string win, subWindow
+
+	win = DB_OpenDatabrowser()
+	subWindow = str
+
+	CHECK(WindowExists(subWindow))
+
+	// restore button is hidden
+	CHECK(IsControlHidden(win, "button_BSP_open"))
+
+	// restore button is not hidden amymore after killing the subwindow
+	KillWindow $subWindow
+	CHECK(!IsControlHidden(win, "button_BSP_open"))
+
+	// subwindow is hidden
+	GetWindow $subWindow hide
+	CHECK_EQUAL_VAR(V_Value, 0x1)
+
+	// restoring
+	PGC_SetAndActivateControl(win, "button_BSP_open")
+	CHECK(WindowExists(subWindow))
+
+	// subwindow is not hidden
+	GetWindow $subWindow hide
+	CHECK_EQUAL_VAR(V_Value, 0x0)
+
+	// but the button is hidden again
+	CHECK(IsControlHidden(win, "button_BSP_open"))
+End


### PR DESCRIPTION
This fixes the problem with the missing "restore" button once the settings history was closed.

It also fixes the problem that the really helpful SF hooks did not work with the SweepBrowser.

I also cleaned the code up a bit.