### PR TITLE
Tests: Fix GenerateAnalysisFunctionTable

### DIFF
--- a/Packages/MIES/analysis_function_parameters.itx
+++ b/Packages/MIES/analysis_function_parameters.itx
@@ -1,5 +1,5 @@
 IGOR
-WAVES/T/N=(66,5)	analysis_function_parameters
+WAVES/T/N=(60,5)	analysis_function_parameters
 BEGIN
 	"Name"	"Type"	"Optionality"	"Used by"	"Help"
 	"AbsoluteVoltageDiff"	"variable"	"required"	"VM"	"Maximum absolute allowed difference of the baseline membrane potentials [mV].\r Set to `inf` to disable this check."
@@ -15,18 +15,12 @@ BEGIN
 	"BaselineTargetVThreshold"	"variable"	"optional"	"CR, DA, RA, RB"	"Threshold value in mV for the target V baseline QC check (defaults to 1)"
 	"BoundsEvaluationMode"	"string"	"required"	"CR"	"Select the bounds evaluation mode: Symmetric (Lower and Upper), Depolarized (Upper) or Hyperpolarized (Lower)"
 	"DAScaleModifier"	"variable"	"mixed"	"CR, DA, SC"	"Modifier value to the DA Scale of headstages for too few spikes\r[Optional] Percentage how the DAScale value is adapted if it is outside of the MinimumSpikeCount\"/\"MaximumSpikeCount\" band. Ignored for \"Sub\".\rModifier value to the DA Scale of headstages with spikes during chirp"
-	"DAScaleModifier"	"variable"	"optional"	"CR, DA, SC"	"Modifier value to the DA Scale of headstages for too few spikes\r[Optional] Percentage how the DAScale value is adapted if it is outside of the MinimumSpikeCount\"/\"MaximumSpikeCount\" band. Ignored for \"Sub\".\rModifier value to the DA Scale of headstages with spikes during chirp"
-	"DAScaleModifier"	"variable"	"required"	"CR, DA, SC"	"Modifier value to the DA Scale of headstages for too few spikes\r[Optional] Percentage how the DAScale value is adapted if it is outside of the MinimumSpikeCount\"/\"MaximumSpikeCount\" band. Ignored for \"Sub\".\rModifier value to the DA Scale of headstages with spikes during chirp"
-	"DAScaleOperator"	"string"	"optional"	"CR, SC"	"Set the math operator to use for combining the DAScale and the too few spikes modifier. Valid strings are \"+\" (addition) and \"*\" (multiplication).\rSet the math operator to use for combining the DAScale and the modifier. Valid strings are \"+\" (addition) and \"*\" (multiplication)."
-	"DAScaleOperator"	"string"	"required"	"CR, SC"	"Set the math operator to use for combining the DAScale and the too few spikes modifier. Valid strings are \"+\" (addition) and \"*\" (multiplication).\rSet the math operator to use for combining the DAScale and the modifier. Valid strings are \"+\" (addition) and \"*\" (multiplication)."
 	"DAScaleOperator"	"string"	"mixed"	"CR, SC"	"Set the math operator to use for combining the DAScale and the too few spikes modifier. Valid strings are \"+\" (addition) and \"*\" (multiplication).\rSet the math operator to use for combining the DAScale and the modifier. Valid strings are \"+\" (addition) and \"*\" (multiplication)."
 	"DAScales"	"wave"	"required"	"DA, DS"	"DA Scale Factors in pA"
 	"DAScaleSpikePositionModifier"	"variable"	"required"	"SC"	"Modifier value to the DA Scale of headstages with failing spike positions."
 	"DAScaleSpikePositionOperator"	"string"	"required"	"SC"	"Set the math operator to use for combining the DAScale and the spike position modifier. Valid strings are \"+\" (addition) and \"*\" (multiplication)."
 	"DaScaleTooManySpikesModifier"	"variable"	"required"	"SC"	"Modifier value to the DA Scale of headstages for too many spikes"
 	"DaScaleTooManySpikesOperator"	"string"	"required"	"SC"	"Set the math operator to use for combining the DAScale and the too many spikes modifier. Valid strings are \"+\" (addition) and \"*\" (multiplication)."
-	"FailedLevel"	"variable"	"required"	"CR, VM"	"Absolute level for spike search"
-	"FailedLevel"	"variable"	"optional"	"CR, VM"	"Absolute level for spike search"
 	"FailedLevel"	"variable"	"mixed"	"CR, VM"	"Absolute level for spike search"
 	"FailedPulseLevel"	"variable"	"optional"	"SC"	"[Optional, uses the already set value] Numeric level to use for the failed pulse search in the PA plot tab."
 	"FinalSlopePercent"	"variable"	"optional"	"DA"	"[Optional] As additional passing criteria the slope of the f-I plot must be larger than this value. Note: The slope is used in percent. Ignored for \"Sub\"."

--- a/Packages/MIES/analysis_function_parameters.itx
+++ b/Packages/MIES/analysis_function_parameters.itx
@@ -1,5 +1,5 @@
 IGOR
-WAVES/T/N=(65,5)	analysis_function_parameters
+WAVES/T/N=(66,5)	analysis_function_parameters
 BEGIN
 	"Name"	"Type"	"Optionality"	"Used by"	"Help"
 	"AbsoluteVoltageDiff"	"variable"	"required"	"VM"	"Maximum absolute allowed difference of the baseline membrane potentials [mV].\r Set to `inf` to disable this check."
@@ -10,11 +10,12 @@ BEGIN
 	"AutobiasTargetV"	"variable"	"optional"	"CR"	"Autobias targetV [mV] value set in PRE_SET_EVENT"
 	"AutobiasTargetVAtSetEnd"	"variable"	"optional"	"CR"	"Autobias targetV [mV] value set in POST_SET_EVENT (only set if set QC passes)."
 	"BaselineChunkLength"	"variable"	"optional"	"AR, SE, VM"	"Length of a baseline QC chunk to evaluate (defaults to 500)"
-	"BaselineRMSLongThreshold"	"variable"	"optional"	"AR, CR, DA, PB, RA, RB, SE, SP, VM"	"Threshold value in mV for the long RMS baseline QC check (defaults to 0.5)"
-	"BaselineRMSShortThreshold"	"variable"	"optional"	"AR, CR, DA, PB, RA, RB, SE, SP, VM"	"Threshold value in mV for the short RMS baseline QC check (defaults to 0.07)"
+	"BaselineRMSLongThreshold"	"variable"	"optional"	"AR, CR, DA, PB, RA, RB, SE, VM"	"Threshold value in mV for the long RMS baseline QC check (defaults to 0.5)"
+	"BaselineRMSShortThreshold"	"variable"	"optional"	"AR, CR, DA, PB, RA, RB, SE, VM"	"Threshold value in mV for the short RMS baseline QC check (defaults to 0.07)"
+	"BaselineTargetVThreshold"	"variable"	"optional"	"CR, DA, RA, RB"	"Threshold value in mV for the target V baseline QC check (defaults to 1)"
 	"BoundsEvaluationMode"	"string"	"required"	"CR"	"Select the bounds evaluation mode: Symmetric (Lower and Upper), Depolarized (Upper) or Hyperpolarized (Lower)"
-	"DAScaleModifier"	"variable"	"optional"	"CR, DA, SC"	"Modifier value to the DA Scale of headstages for too few spikes\r[Optional] Percentage how the DAScale value is adapted if it is outside of the MinimumSpikeCount\"/\"MaximumSpikeCount\" band. Ignored for \"Sub\".\rModifier value to the DA Scale of headstages with spikes during chirp"
 	"DAScaleModifier"	"variable"	"mixed"	"CR, DA, SC"	"Modifier value to the DA Scale of headstages for too few spikes\r[Optional] Percentage how the DAScale value is adapted if it is outside of the MinimumSpikeCount\"/\"MaximumSpikeCount\" band. Ignored for \"Sub\".\rModifier value to the DA Scale of headstages with spikes during chirp"
+	"DAScaleModifier"	"variable"	"optional"	"CR, DA, SC"	"Modifier value to the DA Scale of headstages for too few spikes\r[Optional] Percentage how the DAScale value is adapted if it is outside of the MinimumSpikeCount\"/\"MaximumSpikeCount\" band. Ignored for \"Sub\".\rModifier value to the DA Scale of headstages with spikes during chirp"
 	"DAScaleModifier"	"variable"	"required"	"CR, DA, SC"	"Modifier value to the DA Scale of headstages for too few spikes\r[Optional] Percentage how the DAScale value is adapted if it is outside of the MinimumSpikeCount\"/\"MaximumSpikeCount\" band. Ignored for \"Sub\".\rModifier value to the DA Scale of headstages with spikes during chirp"
 	"DAScaleOperator"	"string"	"optional"	"CR, SC"	"Set the math operator to use for combining the DAScale and the too few spikes modifier. Valid strings are \"+\" (addition) and \"*\" (multiplication).\rSet the math operator to use for combining the DAScale and the modifier. Valid strings are \"+\" (addition) and \"*\" (multiplication)."
 	"DAScaleOperator"	"string"	"required"	"CR, SC"	"Set the math operator to use for combining the DAScale and the too few spikes modifier. Valid strings are \"+\" (addition) and \"*\" (multiplication).\rSet the math operator to use for combining the DAScale and the modifier. Valid strings are \"+\" (addition) and \"*\" (multiplication)."

--- a/Packages/tests/HardwareBasic/UTF_AnalysisFunctionManagement.ipf
+++ b/Packages/tests/HardwareBasic/UTF_AnalysisFunctionManagement.ipf
@@ -190,11 +190,17 @@ static Function [WAVE/T required, WAVE/T optional, WAVE/T mixed] GetAllAnalysisP
 	WAVE/Z mixedRequiredAndOptional = GetSetIntersection(allRequiredParamsUnique, allOptParamsUnique)
 	CHECK_WAVE(mixedRequiredAndOptional, TEXT_WAVE)
 
-	ChangeFreeWaveName(allRequiredParamsUnique, "required")
-	ChangeFreeWaveName(allOptParamsUnique, "optional")
+	WAVE/T/Z allRequiredParamsUniqueNoMixed = GetSetDifference(allRequiredParamsUnique, mixedRequiredAndOptional)
+	CHECK_WAVE(allRequiredParamsUniqueNoMixed, TEXT_WAVE)
+
+	WAVE/T/Z allOptParamsUniqueNoMixed = GetSetDifference(allOptParamsUnique, mixedRequiredAndOptional)
+	CHECK_WAVE(allOptParamsUniqueNoMixed, TEXT_WAVE)
+
+	ChangeFreeWaveName(allRequiredParamsUniqueNoMixed, "required")
+	ChangeFreeWaveName(allOptParamsUniqueNoMixed, "optional")
 	ChangeFreeWaveName(mixedRequiredAndOptional, "mixed")
 
-	return [allRequiredParamsUnique, allOptParamsUnique, mixedRequiredAndOptional]
+	return [allRequiredParamsUniqueNoMixed, allOptParamsUniqueNoMixed, mixedRequiredAndOptional]
 End
 
 static Function AnalysisParamsMustHaveSameOptionality()
@@ -298,7 +304,7 @@ static Function GenerateAnalysisFunctionTable()
 	// if this test fails and the CRC changes
 	// commit the file `Packages/MIES/analysis_function_parameters.itx`
 	// and check that the changes therein are intentional
-	CHECK_EQUAL_VAR(WaveCRC(0, output, 0), 4074123754)
+	CHECK_EQUAL_VAR(WaveCRC(0, output, 0), 844628669)
 	StoreWaveOnDisk(output, "analysis_function_parameters")
 End
 

--- a/Packages/tests/HardwareBasic/UTF_AnalysisFunctionManagement.ipf
+++ b/Packages/tests/HardwareBasic/UTF_AnalysisFunctionManagement.ipf
@@ -298,7 +298,7 @@ static Function GenerateAnalysisFunctionTable()
 	// if this test fails and the CRC changes
 	// commit the file `Packages/MIES/analysis_function_parameters.itx`
 	// and check that the changes therein are intentional
-	CHECK_EQUAL_VAR(WaveCRC(0, output, 0), 1545885765)
+	CHECK_EQUAL_VAR(WaveCRC(0, output, 0), 4074123754)
 	StoreWaveOnDisk(output, "analysis_function_parameters")
 End
 


### PR DESCRIPTION
The recently added test added in 39178e5 (Documentation/Tests: Add table with all analysis parameters, 2022-10-30) did cross with 58d4c2b (PSQ_SquarePulse: Remove unused analysis parameters, 2022-10-23) which removed an unused analysis parameter.

Regenerate the table and fix that.Thanks for opening a PR in MIES :sparkles:!

- Code can only be merged if the continous integration tests pass
- [ ] Please ensure that the branch is named correctly. See
  [here](https://alleninstitute.github.io/MIES/developers.html#branch-naming-scheme) for all detailed explanation. In
  short: Branches targeting the release branch should have a `-backport` suffix, others targeting main must not have
  this suffix. This is done so that the correct CI plan is executed.
