### PR TITLE
SF: Fix plotter to sf_assert properly for single text waves as input

### DIFF
--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -1418,7 +1418,7 @@ static Function SF_FormulaPlotter(string graph, string formula, [DFREF dfr, vari
 			WAVE wvY = GetSweepFormulaY(dfr, dataCnt)
 			SF_Assert(!(IsTextWave(wvY) && IsTextWave(wvX)), "One wave needs to be numeric for plotting")
 
-			if(IsTextWave(wvY) && WaveExists(wvX))
+			if(IsTextWave(wvY))
 				SF_Assert(WaveExists(wvX), "Cannot plot a single text wave")
 				ModifyGraph/W=$win swapXY = 1
 				WAVE dummy = wvY

--- a/Packages/tests/Basic/UTF_SweepFormula.ipf
+++ b/Packages/tests/Basic/UTF_SweepFormula.ipf
@@ -1497,6 +1497,13 @@ static Function TestPlotting()
 	REQUIRE_EQUAL_VAR(WindowExists(win), 1)
 	win = winBase + "_#" + winBase + "_2"
 	REQUIRE_EQUAL_VAR(WindowExists(win), 1)
+
+	try
+		MIES_SF#SF_FormulaPlotter(sweepBrowser, "[abc,def]")
+		FAIL()
+	catch
+		PASS()
+	endtry
 End
 
 static Function TestOperationSelect()


### PR DESCRIPTION
- the plotter can only plot text wave data when an corresponding x-wave is given. This was not checked properly, such that an RTE was generated for simple 1d text waves as input without an x-wave.

This check was corrected.

since ff9f96495b0985c9836ca3585638f2ab471d93c6
