### PR TITLE
Check for free/local wave leaks in CI testing

### DIFF
--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -1593,7 +1593,8 @@ Constant POST_PLOT_FULL_UPDATE = 0x8     ///< Forces a complete update from scra
 /// @anchor AsyncWorkLoadClassNames
 ///
 /// @{
-StrConstant WORKLOADCLASS_TP = "TestPulse"
+StrConstant WORKLOADCLASS_TP  = "TestPulse"
+StrConstant WORKLOADCLASS_NWB = "nwb_writing"
 /// @}
 
 /// @name Column numbers of epoch information
@@ -1716,8 +1717,6 @@ Constant DQ_STOP_REASON_FIFO_TIMEOUT      = 0x0400
 Constant DQ_STOP_REASON_STUCK_FIFO        = 0x0800
 Constant DQ_STOP_REASON_INVALID           = 0xFFFF
 /// @}
-
-StrConstant NWB_WORKLOAD_CLASS = "nwb_writing"
 
 /// @name Mode flags for ID_AskUserForSettings()
 /// @anchor AskUserSettingsModeFlag

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -4656,7 +4656,7 @@ static Function DAP_UnlockDevice(device)
 	string device
 
 	variable flags, state, hardwareType
-	string lockedDevices
+	string lockedDevices, wlName
 
 	if(!windowExists(device))
 		DEBUGPRINT("Can not unlock the non-existing panel", str=device)
@@ -4674,7 +4674,9 @@ static Function DAP_UnlockDevice(device)
 	PGC_SetAndActivateControl(device, "check_Settings_TPAfterDAQ", val = CHECKBOX_UNSELECTED)
 	DQ_StopDAQ(device, DQ_STOP_REASON_UNLOCKED_DEVICE)
 	TP_StopTestPulse(device)
-	ASSERT(!ASYNC_WaitForWLCToFinishAndRemove(WORKLOADCLASS_TP + device, DAP_WAITFORTPANALYSIS_TIMEOUT), "TP analysis did not finish within timeout")
+
+	wlName = GetWorkLoadName(WORKLOADCLASS_TP, device)
+	ASSERT(!ASYNC_WaitForWLCToFinishAndRemove(wlName, DAP_WAITFORTPANALYSIS_TIMEOUT), "TP analysis did not finish within timeout")
 	NWB_ASYNC_FinishWriting(device)
 
 	PGC_SetAndActivateControl(device, "check_Settings_TPAfterDAQ", val = state)

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -8582,3 +8582,7 @@ Function ArchiveLogFilesOnceAndKeepMonth()
 		endif
 	endfor
 End
+
+Function/S GetWorkLoadName(string workload, string device)
+	return workload + "_" + device
+End

--- a/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
+++ b/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
@@ -678,7 +678,7 @@ Function NWB_ASYNC_FinishWriting(string device)
 	string workload, msg
 	variable i
 
-	workload = NWB_ASYNC_WorkLoadName(device)
+	workload = GetWorkLoadName(WORKLOADCLASS_NWB, device)
 
 	for(i = 0; i < NWB_ASYNC_MAX_ITERATIONS; i += 1)
 		if(!ASYNC_WaitForWLCToFinishAndRemove(workload, NWB_ASYNC_WRITING_TIMEOUT))
@@ -688,10 +688,6 @@ Function NWB_ASYNC_FinishWriting(string device)
 		sprintf msg, "Waiting for NWB writing thread %d/%d.\r", i + 1, NWB_ASYNC_MAX_ITERATIONS
 		BUG(msg)
 	endfor
-End
-
-static Function/S NWB_ASYNC_WorkLoadName(string device)
-	return NWB_WORKLOAD_CLASS + "_" + device
 End
 
 Function NWB_CheckForMissingSweeps(string device, WAVE/T sweepNames)
@@ -961,7 +957,7 @@ Function NWB_AppendSweepDuringDAQ(string device, WAVE DAQDataWave, WAVE DAQConfi
 	WAVE/T s.textualResultsValues = GetTextualResultsValues()
 	WAVE/T s.textualResultsKeys   = GetTextualResultsKeys()
 
-	workload = NWB_ASYNC_WorkLoadName(s.device)
+	workload = GetWorkLoadName(WORKLOADCLASS_NWB, s.device)
 
 	DFREF threadDFR = ASYNC_PrepareDF("NWB_ASYNC_Worker", "NWB_ASYNC_Readout", workload, inOrder = 1)
 

--- a/Packages/MIES/MIES_TestPulse.ipf
+++ b/Packages/MIES/MIES_TestPulse.ipf
@@ -1507,7 +1507,11 @@ End
 /// @returns data folder that can be pushed for execution by the async frame work
 Function/DF TP_PrepareAnalysisDF(string device, STRUCT TPAnalysisInput &tpInput)
 
-	DFREF threadDF = ASYNC_PrepareDF("TP_TSAnalysis", "TP_ROAnalysis", WORKLOADCLASS_TP + device, inOrder=0)
+	string wlName
+
+	wlName = GetWorkLoadName(WORKLOADCLASS_TP, device)
+
+	DFREF threadDF = ASYNC_PrepareDF("TP_TSAnalysis", "TP_ROAnalysis", wlName, inOrder=0)
 	ASYNC_AddParam(threadDF, w=tpInput.data)
 	ASYNC_AddParam(threadDF, var=tpInput.clampAmp)
 	ASYNC_AddParam(threadDF, var=tpInput.clampMode)

--- a/Packages/tests/Basic/UTF_Basic.ipf
+++ b/Packages/tests/Basic/UTF_Basic.ipf
@@ -148,4 +148,9 @@ End
 
 Function TEST_CASE_END_OVERRIDE(string testcase)
 	CheckForBugMessages()
+
+	AdditionalExperimentCleanup()
+
+	DFREF dfr = GetMIESPath()
+	KillDataFolder dfr
 End

--- a/Packages/tests/Basic/UTF_Basic.ipf
+++ b/Packages/tests/Basic/UTF_Basic.ipf
@@ -52,6 +52,7 @@ Function RunWithOpts([string testcase, string testsuite, variable allowdebug, va
 	string traceOptions
 	string list = ""
 	string name = GetTestName()
+	variable waveTrackingMode = GetWaveTrackingMode()
 
 	// speeds up testing to start with a fresh copy
 	KillWindow/Z HistoryCarbonCopy
@@ -130,9 +131,9 @@ Function RunWithOpts([string testcase, string testsuite, variable allowdebug, va
 	endif
 
 	if(IsEmpty(testcase))
-		RunTest(testsuite, name = name, enableJU = enableJU, debugMode= debugMode, traceOptions=traceOptions, traceWinList=traceWinList, keepDataFolder = keepDataFolder)
+		RunTest(testsuite, name = name, enableJU = enableJU, debugMode= debugMode, traceOptions=traceOptions, traceWinList=traceWinList, keepDataFolder = keepDataFolder, waveTrackingMode = waveTrackingMode)
 	else
-		RunTest(testsuite, name = name, enableJU = enableJU, debugMode= debugMode, testcase = testcase, traceOptions=traceOptions, traceWinList=traceWinList, keepDataFolder = keepDataFolder)
+		RunTest(testsuite, name = name, enableJU = enableJU, debugMode= debugMode, testcase = testcase, traceOptions=traceOptions, traceWinList=traceWinList, keepDataFolder = keepDataFolder, waveTrackingMode = waveTrackingMode)
 	endif
 End
 

--- a/Packages/tests/Basic/UTF_ThreadsafeDataSharing.ipf
+++ b/Packages/tests/Basic/UTF_ThreadsafeDataSharing.ipf
@@ -12,6 +12,13 @@ static Function TEST_CASE_BEGIN_OVERRIDE(string testname)
 	TUFXOP_Clear/N=(KEY)/Q/Z
 End
 
+static Function TEST_CASE_END_OVERRIDE(string testname)
+
+	AdditionalExperimentCleanup()
+
+	TUFXOP_Clear/N=(KEY)/Q/Z
+End
+
 static Function ChecksParams()
 
 	try

--- a/Packages/tests/HardwareAnalysisFunctions/UTF_HardwareAnalysisFunctions.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_HardwareAnalysisFunctions.ipf
@@ -38,6 +38,7 @@ Function RunWithOpts([string testcase, string testsuite, variable allowdebug, va
 	string traceOptions
 	string list = ""
 	string name = GetTestName()
+	variable waveTrackingMode = GetWaveTrackingMode()
 
 	// speeds up testing to start with a fresh copy
 	KillWindow/Z HistoryCarbonCopy
@@ -112,8 +113,8 @@ Function RunWithOpts([string testcase, string testsuite, variable allowdebug, va
 	endif
 
 	if(IsEmpty(testcase))
-		RunTest(testsuite, name = name, enableJU = enableJU, debugMode= debugMode, traceOptions=traceOptions, traceWinList=traceWinList, keepDataFolder = keepDataFolder)
+		RunTest(testsuite, name = name, enableJU = enableJU, debugMode= debugMode, traceOptions=traceOptions, traceWinList=traceWinList, keepDataFolder = keepDataFolder, waveTrackingMode = waveTrackingMode)
 	else
-		RunTest(testsuite, name = name, enableJU = enableJU, debugMode= debugMode, testcase = testcase, traceOptions=traceOptions, traceWinList=traceWinList, keepDataFolder = keepDataFolder)
+		RunTest(testsuite, name = name, enableJU = enableJU, debugMode= debugMode, testcase = testcase, traceOptions=traceOptions, traceWinList=traceWinList, keepDataFolder = keepDataFolder, waveTrackingMode = waveTrackingMode)
 	endif
 End

--- a/Packages/tests/HardwareBasic/UTF_HardwareBasic.ipf
+++ b/Packages/tests/HardwareBasic/UTF_HardwareBasic.ipf
@@ -39,6 +39,7 @@ Function RunWithOpts([string testcase, string testsuite, variable allowdebug, va
 	string traceOptions
 	string list = ""
 	string name = GetTestName()
+	variable waveTrackingMode = GetWaveTrackingMode()
 
 	// speeds up testing to start with a fresh copy
 	KillWindow/Z HistoryCarbonCopy
@@ -115,8 +116,8 @@ Function RunWithOpts([string testcase, string testsuite, variable allowdebug, va
 	endif
 
 	if(IsEmpty(testcase))
-		RunTest(testsuite, name = name, enableJU = enableJU, debugMode= debugMode, traceOptions=traceOptions, traceWinList=traceWinList, keepDataFolder=keepDataFolder)
+		RunTest(testsuite, name = name, enableJU = enableJU, debugMode= debugMode, traceOptions=traceOptions, traceWinList=traceWinList, keepDataFolder=keepDataFolder, waveTrackingMode = waveTrackingMode)
 	else
-		RunTest(testsuite, name = name, enableJU = enableJU, debugMode= debugMode, testcase = testcase, traceOptions=traceOptions, traceWinList=traceWinList, keepDataFolder=keepDataFolder)
+		RunTest(testsuite, name = name, enableJU = enableJU, debugMode= debugMode, testcase = testcase, traceOptions=traceOptions, traceWinList=traceWinList, keepDataFolder=keepDataFolder, waveTrackingMode = waveTrackingMode)
 	endif
 End

--- a/Packages/tests/HardwareBasic/UTF_TestPulseAndTPDuringDAQ.ipf
+++ b/Packages/tests/HardwareBasic/UTF_TestPulseAndTPDuringDAQ.ipf
@@ -951,6 +951,7 @@ static Function WaitAndCheckStoredTPs_IGNORE(device, expectedNumTPchannels)
 
 	variable i, channel, numTPChan, numStored, numTP
 	variable tresh, m, tpLength, pulseLengthMS
+	string wlName
 
 	WAVE/Z TPStorage = GetTPStorage(device)
 	CHECK_WAVE(TPStorage, NORMAL_WAVE)
@@ -961,7 +962,8 @@ static Function WaitAndCheckStoredTPs_IGNORE(device, expectedNumTPchannels)
 	CHECK_WAVE(storedTestPulses, WAVE_WAVE)
 	numTP = GetNumberFromWaveNote(storedTestPulses, NOTE_INDEX)
 
-	CHECK(!ASYNC_WaitForWLCToFinishAndRemove(WORKLOADCLASS_TP + device, TP_WAIT_TIMEOUT))
+	wlName = GetWorkLoadName(WORKLOADCLASS_TP, device)
+	CHECK(!ASYNC_WaitForWLCToFinishAndRemove(wlName, TP_WAIT_TIMEOUT))
 
 	WAVE TPSettingsCalculated = GetTPsettingsCalculated(device)
 

--- a/Packages/tests/HistoricData/UTF_HistoricData.ipf
+++ b/Packages/tests/HistoricData/UTF_HistoricData.ipf
@@ -37,6 +37,7 @@ Function RunWithOpts([string testcase, string testsuite, variable allowdebug, va
 	string traceOptions
 	string list = ""
 	string name = GetTestName()
+	variable waveTrackingMode = GetWaveTrackingMode()
 
 	// speeds up testing to start with a fresh copy
 	KillWindow/Z HistoryCarbonCopy
@@ -91,9 +92,9 @@ Function RunWithOpts([string testcase, string testsuite, variable allowdebug, va
 	endif
 
 	if(IsEmpty(testcase))
-		RunTest(testsuite, name = name, enableJU = enableJU, debugMode= debugMode, traceOptions=traceOptions, traceWinList=traceWinList, keepDataFolder = keepDataFolder)
+		RunTest(testsuite, name = name, enableJU = enableJU, debugMode= debugMode, traceOptions=traceOptions, traceWinList=traceWinList, keepDataFolder = keepDataFolder, waveTrackingMode = waveTrackingMode)
 	else
-		RunTest(testsuite, name = name, enableJU = enableJU, debugMode= debugMode, testcase = testcase, traceOptions=traceOptions, traceWinList=traceWinList, keepDataFolder = keepDataFolder)
+		RunTest(testsuite, name = name, enableJU = enableJU, debugMode= debugMode, testcase = testcase, traceOptions=traceOptions, traceWinList=traceWinList, keepDataFolder = keepDataFolder, waveTrackingMode = waveTrackingMode)
 	endif
 End
 

--- a/Packages/tests/HistoricData/UTF_HistoricData.ipf
+++ b/Packages/tests/HistoricData/UTF_HistoricData.ipf
@@ -108,6 +108,9 @@ Function TEST_CASE_BEGIN_OVERRIDE(name)
 End
 
 Function TEST_CASE_END_OVERRIDE(string testcase)
+
+	AdditionalExperimentCleanup()
+
 	CheckForBugMessages()
 End
 

--- a/Packages/tests/PAPlot/UTF_PAPlot.ipf
+++ b/Packages/tests/PAPlot/UTF_PAPlot.ipf
@@ -22,6 +22,7 @@ Function RunWithOpts([string testcase, string testsuite, variable allowdebug, va
 	string traceOptions
 	string list = ""
 	string name = GetTestName()
+	variable waveTrackingMode = GetWaveTrackingMode()
 
 	// speeds up testing to start with a fresh copy
 	KillWindow/Z HistoryCarbonCopy
@@ -74,8 +75,8 @@ Function RunWithOpts([string testcase, string testsuite, variable allowdebug, va
 	endif
 
 	if(IsEmpty(testcase))
-		RunTest(testsuite, name = name, enableJU = enableJU, debugMode= debugMode, traceOptions=traceOptions, traceWinList=traceWinList, keepDataFolder = keepDataFolder)
+		RunTest(testsuite, name = name, enableJU = enableJU, debugMode= debugMode, traceOptions=traceOptions, traceWinList=traceWinList, keepDataFolder = keepDataFolder, waveTrackingMode = waveTrackingMode)
 	else
-		RunTest(testsuite, name = name, enableJU = enableJU, debugMode= debugMode, testcase = testcase, traceOptions=traceOptions, traceWinList=traceWinList, keepDataFolder = keepDataFolder)
+		RunTest(testsuite, name = name, enableJU = enableJU, debugMode= debugMode, testcase = testcase, traceOptions=traceOptions, traceWinList=traceWinList, keepDataFolder = keepDataFolder, waveTrackingMode = waveTrackingMode)
 	endif
 End

--- a/Packages/tests/PAPlot/UTF_PA_Tests.ipf
+++ b/Packages/tests/PAPlot/UTF_PA_Tests.ipf
@@ -425,6 +425,8 @@ End
 
 static Function TEST_CASE_END_OVERRIDE(string testcase)
 	CheckForBugMessages()
+
+	AdditionalExperimentCleanup()
 End
 
 // use copy of mies folder and restore it each time

--- a/Packages/tests/UTF_HardwareHelperFunctions.ipf
+++ b/Packages/tests/UTF_HardwareHelperFunctions.ipf
@@ -87,23 +87,6 @@ Function TEST_CASE_BEGIN_OVERRIDE(name)
 	DeleteFile/Z GetExperimentNWBFileForExport()
 End
 
-Function DoExpensiveChecks()
-
-	variable expensive
-
-#ifdef AUTOMATED_TESTING_EXPENSIVE
-	return 1
-#endif
-
-	expensive = GetEnvironmentVariableAsBoolean("CI_EXPENSIVE_CHECKS")
-
-	if(IsFinite(expensive))
-		return expensive
-	endif
-
-	return 0
-End
-
 Function TEST_CASE_END_OVERRIDE(name)
 	string name
 

--- a/Packages/tests/UTF_HardwareHelperFunctions.ipf
+++ b/Packages/tests/UTF_HardwareHelperFunctions.ipf
@@ -191,7 +191,9 @@ Function TEST_CASE_END_OVERRIDE(name)
 		endif
 	endif
 
+	ASYNC_Stop()
 	AdditionalExperimentCleanup()
+	ASYNC_Start(ThreadProcessorCount, disableTask = 1)
 End
 
 /// @brief Checks user epochs for consistency

--- a/Packages/tests/UTF_HardwareHelperFunctions.ipf
+++ b/Packages/tests/UTF_HardwareHelperFunctions.ipf
@@ -90,7 +90,7 @@ End
 Function TEST_CASE_END_OVERRIDE(name)
 	string name
 
-	string dev, experimentNWBFile, baseFolder, nwbFile
+	string dev, experimentNWBFile, baseFolder, nwbFile, wlName
 	variable numEntries, i, fileID, nwbVersion, expensiveChecks
 
 	// be sure that DAQ/TP is stopped before we do anything else
@@ -109,6 +109,12 @@ Function TEST_CASE_END_OVERRIDE(name)
 	numEntries = ItemsInList(devices)
 	for(i = 0; i < numEntries; i += 1)
 		dev = StringFromList(i, devices)
+
+		wlName = GetWorkLoadName(WORKLOADCLASS_TP, dev)
+		CHECK(!ASYNC_WaitForWLCToFinishAndRemove(wlName, 10))
+
+		wlName = GetWorkLoadName(WORKLOADCLASS_NWB, dev)
+		CHECK(!ASYNC_WaitForWLCToFinishAndRemove(wlName, 10))
 
 		// no analysis function errors
 		NVAR errorCounter = $GetAnalysisFuncErrorCounter(dev)

--- a/Packages/tests/UTF_HardwareHelperFunctions.ipf
+++ b/Packages/tests/UTF_HardwareHelperFunctions.ipf
@@ -190,6 +190,8 @@ Function TEST_CASE_END_OVERRIDE(name)
 			MoveFile experimentNWBFile as (baseFolder + nwbFile)
 		endif
 	endif
+
+	AdditionalExperimentCleanup()
 End
 
 /// @brief Checks user epochs for consistency

--- a/Packages/tests/UTF_HelperFunctions.ipf
+++ b/Packages/tests/UTF_HelperFunctions.ipf
@@ -978,3 +978,12 @@ Function DoExpensiveChecks()
 
 	return 0
 End
+
+Function GetWaveTrackingMode()
+
+	if(DoExpensiveChecks())
+		return UTF_WAVE_TRACKING_ALL
+	endif
+
+	return UTF_WAVE_TRACKING_NONE
+End

--- a/Packages/tests/UTF_HelperFunctions.ipf
+++ b/Packages/tests/UTF_HelperFunctions.ipf
@@ -961,3 +961,20 @@ Function [string abWin, string sweepBrowsers] OpenAnalysisBrowser(WAVE/T files, 
 
 	return [abWin, sweepBrowsers]
 End
+
+Function DoExpensiveChecks()
+
+	variable expensive
+
+#ifdef AUTOMATED_TESTING_EXPENSIVE
+	return 1
+#endif
+
+	expensive = GetEnvironmentVariableAsBoolean("CI_EXPENSIVE_CHECKS")
+
+	if(IsFinite(expensive))
+		return expensive
+	endif
+
+	return 0
+End


### PR DESCRIPTION
- [x] Rebase to main once https://github.com/AllenInstitute/MIES/pull/1948 is merged
- [x] Cleanup commits

<details>
<summary>Done</summary>
- [ ] Update IP nightly to a version with fixed WaveTracking ( > 40067) on the CI machines and rerun CI
- [x] Update test jobs to only do wave tracking in expensive mode
- [x] Update UTF to a version with https://github.com/byte-physics/igor-unit-testing-framework/issues/340 fixed
- [x] Nicify commits
- [x] Fix wave leaks as listed at https://github.com/byte-physics/igor-unit-testing-framework/pull/297#issuecomment-1313886592
   - [x] PaPlot.pxp
   - [x] Basic.pxp
   - [x] HardwareBasic.pxp
   - [x] HardwareAnalysisFunctions.pxp 
- [x] Update JSON XOP
- [x] Bug report sent to WM (#4392), fixed in 40067
</details>