### PR TITLE
Tests/CheckTPEntriesFromLBN: Use a larger ITI

### DIFF
--- a/Packages/tests/HardwareBasic/UTF_SweepFormulaHardware.ipf
+++ b/Packages/tests/HardwareBasic/UTF_SweepFormulaHardware.ipf
@@ -581,6 +581,9 @@ Function SF_InsertedTPVersusTP_preAcq(string device)
 	PGC_SetAndActivateControl(device, "SetVar_DataAcq_TPAmplitudeIC", val=-150)
 
 	CtrlNamedBackGround StopTPAfterSomeTime, start=(ticks + 420), period=60, proc=StartAcq_IGNORE
+
+	AI_SendToAmp(device, 0, I_CLAMP_MODE, MCC_SETPRIMARYSIGNALGAIN_FUNC, 5)
+	AI_SendToAmp(device, 1, V_CLAMP_MODE, MCC_SETPRIMARYSIGNALGAIN_FUNC, 1)
 End
 
 // UTF_TD_GENERATOR DeviceNameGeneratorMD1

--- a/Packages/tests/HardwareBasic/UTF_TestPulseAndTPDuringDAQ.ipf
+++ b/Packages/tests/HardwareBasic/UTF_TestPulseAndTPDuringDAQ.ipf
@@ -168,7 +168,7 @@ End
 static Function CheckTPEntriesFromLBN([string str])
 
 	STRUCT DAQSettings s
-	InitDAQSettingsFromString(s, "MD1_RA1_I0_L0_BKG1_GSI0_ITI3"           + \
+	InitDAQSettingsFromString(s, "MD1_RA1_I0_L0_BKG1_GSI0_ITI5"           + \
 								 "__HS0_DA0_AD0_CM:IC:_ST:StimulusSetA_DA_0:"  + \
 								 "__HS1_DA1_AD1_CM:VC:_ST:StimulusSetC_DA_0:")
 


### PR DESCRIPTION
This makes the test pass with a slow machine and/or UTF coverage.

Will merge once CI passes.
