### PR TITLE
MIES_GuiUtilities.ipf: Don't use info as wave name

### DIFF
--- a/Packages/MIES/MIES_GuiUtilities.ipf
+++ b/Packages/MIES/MIES_GuiUtilities.ipf
@@ -1156,9 +1156,9 @@ End
 Function GraphHasCursors(graph)
 	string graph
 
-	Make/FREE/N=(ItemsInList(CURSOR_NAMES)) info = WaveExists(CsrWaveRef($StringFromList(p, CURSOR_NAMES), graph))
+	Make/FREE/N=(ItemsInList(CURSOR_NAMES)) wv = WaveExists(CsrWaveRef($StringFromList(p, CURSOR_NAMES), graph))
 
-	return WaveMax(info) > 0
+	return WaveMax(wv) > 0
 End
 
 /// @brief Return a 1D text wave with all infos about the cursors
@@ -1174,9 +1174,9 @@ Function/WAVE GetCursorInfos(graph)
 		return $""
 	endif
 
-	Make/T/FREE/N=(ItemsInList(CURSOR_NAMES)) info = CsrInfo($StringFromList(p, CURSOR_NAMES), graph)
+	Make/T/FREE/N=(ItemsInList(CURSOR_NAMES)) wv = CsrInfo($StringFromList(p, CURSOR_NAMES), graph)
 
-	return info
+	return wv
 End
 
 /// @brief Restore the cursors from the info of GetCursorInfos().


### PR DESCRIPTION
This is now a funtion name in the latest UTF version.

Thanks for opening a PR in MIES :sparkles:!

- Code can only be merged if the continous integration tests pass
- [ ] Please ensure that the branch is named correctly. See
  [here](https://alleninstitute.github.io/MIES/developers.html#branch-naming-scheme) for all detailed explanation. In
  short: Branches targeting the release branch should have a `-backport` suffix, others targeting main must not have
  this suffix. This is done so that the correct CI plan is executed.
