### PR TITLE
tools/check-code.sh: Make failing test really fail

### DIFF
--- a/Packages/MIES/MIES_DataBrowser_Macro.ipf
+++ b/Packages/MIES/MIES_DataBrowser_Macro.ipf
@@ -7,7 +7,7 @@
 #endif
 
 /// @file MIES_DataBrowser_Macro.ipf
-/// @brief __DB__ Macro for DataBrowser
+/// @brief __DBM__ Macro for DataBrowser
 
 Window DataBrowser() : Graph
 	PauseUpdate; Silent 1		// building window...

--- a/tools/check-code.sh
+++ b/tools/check-code.sh
@@ -176,6 +176,7 @@ if [[ -n "$matches" ]]
 then
   echo "The list of function prefixes is not unique"
   echo "$matches"
+  ret=1
 fi
 
 exit $ret


### PR DESCRIPTION
Broken since 70a3710 (tools/check-code.sh: Check that the list of function prefixes has no duplicates, 2022-11-22).Thanks for opening a PR in MIES :sparkles:!

- Code can only be merged if the continous integration tests pass
- [ ] Please ensure that the branch is named correctly. See
  [here](https://alleninstitute.github.io/MIES/developers.html#branch-naming-scheme) for all detailed explanation. In
  short: Branches targeting the release branch should have a `-backport` suffix, others targeting main must not have
  this suffix. This is done so that the correct CI plan is executed.
