### PR TITLE
Tests/AcceptsValid10: Adapt to higher DateTime precision

### DIFF
--- a/Packages/tests/Basic/UTF_Utils.ipf
+++ b/Packages/tests/Basic/UTF_Utils.ipf
@@ -233,9 +233,15 @@ Function AcceptsValid10()
 
 	variable now      = DateTimeInUTC()
 	variable expected = now
+#if (IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 39493)
+	// DateTime currently returns six digits of precision
+	variable actual   = ParseISO8601TimeStamp(GetIso8601TimeStamp(secondsSinceIgorEpoch = now, numFracSecondsDigits = 6))
+	CHECK_CLOSE_VAR(actual, expected)
+#else
 	// DateTime currently returns three digits of precision
 	variable actual   = ParseISO8601TimeStamp(GetIso8601TimeStamp(secondsSinceIgorEpoch = now, numFracSecondsDigits = 3))
 	CHECK_EQUAL_VAR(actual, expected)
+#endif
 End
 
 Function AcceptsValid11()


### PR DESCRIPTION
Introduced in IP9 r39493. Using CLOSE instead of EQUAL also avoids spurious test case errors due to rounding issues.

Thanks for opening a PR in MIES :sparkles:!

- Code can only be merged if the continous integration tests pass
- [ ] Please ensure that the branch is named correctly. See
  [here](https://alleninstitute.github.io/MIES/developers.html#branch-naming-scheme) for all detailed explanation. In
  short: Branches targeting the release branch should have a `-backport` suffix, others targeting main must not have
  this suffix. This is done so that the correct CI plan is executed.
