### PR TITLE
NWB_GetFileForExport: Compare session start times with tolerance

### DIFF
--- a/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
+++ b/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
@@ -203,7 +203,7 @@ static Function [variable fileID, variable createdNewNWBFile] NWB_GetFileForExpo
 		NWB_AddSpecifications(fileID, nwbVersion)
 
 		sessionStartTimeReadBack = NWB_ReadSessionStartTime(fileID)
-		ASSERT(ti.session_start_time == sessionStartTimeReadBack, "Buggy timestamp handling")
+		ASSERT(CheckIfClose(ti.session_start_time, sessionStartTimeReadBack, tol = 1e-6), "Buggy timestamp handling")
 
 		fileIDExport   = fileID
 		filePathExport = filePath


### PR DESCRIPTION
This avoids spurious errors due to the enhanced precision of DateTime introduced in IP9 r39493.

Will merge once CI passes.