### PR TITLE
bugfix for SetStringInWaveNote generating pending RTE

### DIFF
--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -1205,7 +1205,8 @@ End
 ///
 /// The expected wave note format is: `key1:val1;key2:str2;`
 threadsafe Function SetStringInWaveNote(WAVE wv, string key, string str, [variable recursive])
-	variable numEntries = numpnts(wv)
+
+	variable numEntries
 
 	if(ParamIsDefault(recursive))
 		recursive = 0
@@ -1218,6 +1219,7 @@ threadsafe Function SetStringInWaveNote(WAVE wv, string key, string str, [variab
 
 	Note/K wv, ReplaceStringByKey(key, note(wv), str)
 
+	numEntries = numpnts(wv)
 	if(!recursive || !IsWaveRefWave(wv) || numEntries == 0)
 		return NaN
 	endif


### PR DESCRIPTION
- Retrieving numEntries by calling numpnts created a pending RTE for a null wave argument. The RTE was hidden in the tests because the function is declared threadsafe.
- solution: First check argument with ASSERT_TS before calling numpnts

since a1bc2f34b1e24417a7def6ae76d2f4b38b6a0f4a
