### PR TITLE
WB_TrigCalculateInflectionPoints: Prefer CheckIfClose over plain =

### DIFF
--- a/Packages/MIES/MIES_WaveBuilder.ipf
+++ b/Packages/MIES/MIES_WaveBuilder.ipf
@@ -1448,7 +1448,7 @@ static Function WB_TrigCalculateInflectionPoints(struct SegmentParameters &pa, v
 
 		ASSERT(IsFinite(xzero), "xzero must be finite")
 		ASSERT(xzero >= 0, "xzero must >= 0")
-		ASSERT(xzero <= pa.duration, "xzero must <= pa.duration")
+		ASSERT(xzero < pa.duration || CheckIfClose(xzero, pa.duration), "xzero must <= pa.duration")
 
 		EnsureLargeEnoughWave(inflectionPoints, minimumSize = idx, dimension = ROWS, initialValue = NaN)
 		inflectionPoints[idx++] = xzero


### PR DESCRIPTION
Although Igor Pro does also do some floating point comparison magic, we need to use the real deal in this case.

Close #1598