### PR TITLE
DB_UpdateSweepPlot: Upgrade labnotebooks before plotting

### DIFF
--- a/Packages/MIES/MIES_DataBrowser.ipf
+++ b/Packages/MIES/MIES_DataBrowser.ipf
@@ -415,6 +415,10 @@ Function DB_UpdateSweepPlot(win)
 
 	device = BSP_GetDevice(win)
 
+	// fetch keys waves to trigger a potential labnotebook upgrade
+	WAVE numericalKeys = DB_GetLBNWave(win, LBN_NUMERICAL_KEYS)
+	WAVE textualKeys   = DB_GetLBNWave(win, LBN_TEXTUAL_KEYS)
+
 	WAVE numericalValues = DB_GetLBNWave(win, LBN_NUMERICAL_VALUES)
 	WAVE textualValues   = DB_GetLBNWave(win, LBN_TEXTUAL_VALUES)
 


### PR DESCRIPTION
This allows for old labnotebooks to be compatible again.
