### PR TITLE
BSP_SFHelpWindowHook: Interrupt the user less when typing

### DIFF
--- a/Packages/MIES/MIES_BrowserSettingsPanel.ipf
+++ b/Packages/MIES/MIES_BrowserSettingsPanel.ipf
@@ -26,6 +26,8 @@ static StrConstant BROWSERSETTINGS_AXES_SCALING_CHECKBOXES = "check_Display_Visi
 static StrConstant SWEEPCONTROL_CONTROLS_DATABROWSER = "check_SweepControl_AutoUpdate;setvar_SweepControl_SweepNo;"
 static StrConstant SWEEPCONTROL_CONTROLS_SWEEPBROWSER = "popup_SweepControl_Selector;"
 
+static StrConstant BSP_USER_DATA_SF_CONTENT_CRC = "SweepFormulaContentCRC"
+
 /// @brief return the name of the external panel depending on main window name
 ///
 /// @param mainPanel 	mainWindow panel name
@@ -1785,7 +1787,7 @@ Function BSP_SFHelpWindowHook(s)
 	STRUCT WMWinHookStruct &s
 
 	string mainWin, sfWin, bspPanel, cmdStr
-	variable modMask
+	variable modMask,refContentCRC, contentCRC
 
 	switch(s.eventCode)
 		case EVENT_WINDOW_HOOK_MOUSEDOWN:
@@ -1817,11 +1819,14 @@ Function BSP_SFHelpWindowHook(s)
 				return 1
 			endif
 			break
-		case EVENT_WINDOW_HOOK_ACTIVATE:
 		case EVENT_WINDOW_HOOK_DEACTIVATE:
-			sfWin = BSP_GetSFFormula(GetMainWindow(s.winName))
-			if(!CmpStr(sfWin, s.winName))
+			mainWin = GetMainWindow(s.winName)
+			sfWin = BSP_GetSFFormula(mainWin)
+			refContentCRC = str2num(GetUserData(mainWin, "", BSP_USER_DATA_SF_CONTENT_CRC))
+			contentCRC = GetNotebookCRC(sfWin)
+			if(!CmpStr(sfWin, s.winName) && refContentCRC != contentCRC)
 				BSP_SFFormulaColoring(sfWin)
+				SetWindow $mainWin userData($BSP_USER_DATA_SF_CONTENT_CRC)=num2istr(contentCRC)
 			endif
 			break
 	endswitch

--- a/Packages/MIES/MIES_BrowserSettingsPanel.ipf
+++ b/Packages/MIES/MIES_BrowserSettingsPanel.ipf
@@ -1860,7 +1860,7 @@ static Function BSP_SFFormulaColoring(string sfWin)
 	endfor
 
 	Notebook $sfWin, selection={startOfFile, startOfFile}
-	Notebook $sfWin, findText={"", 1}
+	Notebook $sfWin, findText={"", 0}
 End
 
 Function BSP_TTHookSFFormulaNB(STRUCT WMTooltipHookStruct &s)

--- a/Packages/MIES/MIES_GuiUtilities.ipf
+++ b/Packages/MIES/MIES_GuiUtilities.ipf
@@ -2292,10 +2292,10 @@ Function ColorNotebookKeywords(string win, string keyWord, variable r, variable 
 	endif
 
 	Notebook $win, selection={startOfFile, startOfFile}
-	Notebook $win, findText={"", 1}
+	Notebook $win, findText={"", 0}
 
 	do
-		Notebook $win, findText={keyWord, 1}
+		Notebook $win, findText={keyWord, 6}
 		if(V_flag == 1)
 			Notebook $win, textRGB=(r, g, b)
 		endif

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -6249,3 +6249,18 @@ Function/WAVE JSONToWave(string str)
 
 	return data
 End
+
+/// @brief Return the CRC of the contents of the plain/formatted notebook
+///
+/// Takes into account formatting but ignores selection.
+Function GetNotebookCRC(string win)
+
+	string content
+
+	content = WinRecreation(win, 1)
+
+	// Filter out // lines which contain the selection
+	content = GrepList(content, "//.*", 1, "\r")
+
+	return StringCRC(0, content)
+End


### PR DESCRIPTION
Currently the coloring of the notebook commands requires to change the notebook selection. This can interfere quite easily with the user typing. So let's skip coloring the keywords if the contents did not change and only do it on deactivation.

It really is annoying.
