### PR TITLE
Keep log mode when restoring axis ranges as well

### DIFF
--- a/Packages/MIES/MIES_AnalysisBrowser_SweepBrowser.ipf
+++ b/Packages/MIES/MIES_AnalysisBrowser_SweepBrowser.ipf
@@ -286,7 +286,7 @@ Function SB_UpdateSweepPlot(win)
 
 	WAVE/Z sweepsToOverlay = OVS_GetSelectedSweeps(graph, OVS_SWEEP_SELECTION_INDEX)
 
-	WAVE axesRanges = GetAxesRanges(graph)
+	WAVE axesProps = GetAxesProperties(graph)
 
 	WAVE/T/Z cursorInfos = GetCursorInfos(graph)
 	RemoveTracesFromGraph(graph)
@@ -331,7 +331,7 @@ Function SB_UpdateSweepPlot(win)
 	BSP_UpdateSweepNote(win)
 
 	PostPlotTransformations(graph, POST_PLOT_FULL_UPDATE)
-	SetAxesRanges(graph, axesRanges)
+	SetAxesProperties(graph, axesProps)
 End
 
 Function SB_AddToSweepBrowser(sweepBrowser, fileName, dataFolder, device, sweep)

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -564,7 +564,7 @@ Constant AXIS_ORIENTATION_RIGHT  = 0x22
 /// @}
 
 /// @name Constants for Set/GetAxesRanges modes, use binary pattern
-/// @anchor AxisRangeModeConstants
+/// @anchor AxisPropModeConstants
 /// @{
 Constant AXIS_RANGE_DEFAULT        = 0x00
 Constant AXIS_RANGE_USE_MINMAX     = 0x01

--- a/Packages/MIES/MIES_DataBrowser.ipf
+++ b/Packages/MIES/MIES_DataBrowser.ipf
@@ -402,7 +402,7 @@ Function DB_UpdateSweepPlot(win)
 
 	[tgs] = BSP_GatherTiledGraphSettings(graph)
 
-	WAVE axesRanges = GetAxesRanges(graph)
+	WAVE axesProps = GetAxesProperties(graph)
 
 	WAVE/T/Z cursorInfos = GetCursorInfos(graph)
 	RemoveTracesFromGraph(graph)
@@ -462,7 +462,7 @@ Function DB_UpdateSweepPlot(win)
 
 	PostPlotTransformations(graph, POST_PLOT_FULL_UPDATE)
 
-	SetAxesRanges(graph, axesRanges)
+	SetAxesProperties(graph, axesProps)
 	DEBUGPRINT_ELAPSED(referenceTime)
 End
 

--- a/Packages/MIES/MIES_GuiUtilities.ipf
+++ b/Packages/MIES/MIES_GuiUtilities.ipf
@@ -894,10 +894,12 @@ Function/Wave GetAxesProperties(graph[, axesRegexp, orientation, mode])
 		mode = AXIS_RANGE_DEFAULT
 	endif
 
-	list    = AxisList(graph)
+	list = AxisList(graph)
+
 	if(!ParamIsDefault(axesRegexp))
 		list = GrepList(list, axesRegexp)
 	endif
+
 	list    = SortList(list)
 	numAxes = ItemsInList(list)
 

--- a/Packages/MIES/MIES_GuiUtilities.ipf
+++ b/Packages/MIES/MIES_GuiUtilities.ipf
@@ -887,7 +887,7 @@ Function/Wave GetAxesProperties(graph[, axesRegexp, orientation, mode])
 	string graph, axesRegexp
 	variable orientation, mode
 
-	string list, axis
+	string list, axis, info
 	variable numAxes, i, countAxes, minimum, maximum, axisOrientation
 
 	if(ParamIsDefault(mode))
@@ -915,7 +915,9 @@ Function/Wave GetAxesProperties(graph[, axesRegexp, orientation, mode])
 			continue
 		endif
 
-		[minimum, maximum] = GetAxisRange(graph, axis, mode=mode)
+		info = AxisInfo(graph, axis)
+
+		[minimum, maximum] = GetAxisRangeFromInfo(graph, info, axis, mode)
 		props[countAxes][%axisType] = axisOrientation
 		props[countAxes][%minimum] = minimum
 		props[countAxes][%maximum] = maximum

--- a/Packages/MIES/MIES_GuiUtilities.ipf
+++ b/Packages/MIES/MIES_GuiUtilities.ipf
@@ -1011,11 +1011,9 @@ Function SetAxesProperties(graph, props[, axesRegexp, orientation, mode])
 			endif
 		endif
 
-		if(!IsFinite(minimum) || !IsFinite(maximum))
-			continue
+		if(IsFinite(minimum) && IsFinite(maximum))
+			SetAxis/W=$graph $axis, minimum, maximum
 		endif
-
-		SetAxis/W=$graph $axis, minimum, maximum
 	endfor
 End
 

--- a/Packages/MIES/MIES_GuiUtilities.ipf
+++ b/Packages/MIES/MIES_GuiUtilities.ipf
@@ -860,6 +860,19 @@ Function GetAxisOrientation(graph, axes)
 	DoAbortNow("unknown axis type")
 End
 
+/// @brief Return the recreation macro for an axis
+static Function/S GetAxisRecreationMacro(string info)
+
+	string key
+	variable index
+
+	// straight from the AxisInfo help
+	key = ";RECREATION:"
+	index = strsearch(info,key,0)
+
+	return info[index + strlen(key), inf]
+End
+
 /// @brief Returns a wave with the minimum and maximum
 /// values of each axis
 ///

--- a/Packages/MIES/MIES_GuiUtilities.ipf
+++ b/Packages/MIES/MIES_GuiUtilities.ipf
@@ -962,10 +962,12 @@ Function SetAxesProperties(graph, props[, axesRegexp, orientation, mode])
 
 	numRows = DimSize(props, ROWS)
 
-	list    = AxisList(graph)
+	list = AxisList(graph)
+
 	if(!ParamIsDefault(axesRegexp))
 		list = GrepList(list, axesRegexp)
 	endif
+
 	list    = SortList(list)
 	numAxes = ItemsInList(list)
 

--- a/Packages/MIES/MIES_GuiUtilities.ipf
+++ b/Packages/MIES/MIES_GuiUtilities.ipf
@@ -873,6 +873,26 @@ static Function/S GetAxisRecreationMacro(string info)
 	return info[index + strlen(key), inf]
 End
 
+/// @brief Return the logmode of the axis
+Function GetAxisLogMode(string graph, string axis)
+	string info
+
+	info = AxisInfo(graph, axis)
+
+	if(IsEmpty(info))
+		return NaN
+	endif
+
+	return GetAxisLogModeFromInfo(info)
+End
+
+static Function GetAxisLogModeFromInfo(string info)
+	string recMacro
+
+	recMacro = GetAxisRecreationMacro(info)
+	return NumberByKey("log(x)", recMacro, "=")
+End
+
 /// @brief Returns a wave with the minimum and maximum
 /// values of each axis
 ///

--- a/Packages/MIES/MIES_GuiUtilities.ipf
+++ b/Packages/MIES/MIES_GuiUtilities.ipf
@@ -924,7 +924,7 @@ Function/Wave GetAxesProperties(graph[, axesRegexp, orientation, mode])
 	endfor
 
 	if(countAxes != numAxes)
-		Redimension/N=(countAxes, 3) props
+		Redimension/N=(countAxes, -1) props
 	endif
 
 	return props

--- a/Packages/MIES/MIES_GuiUtilities.ipf
+++ b/Packages/MIES/MIES_GuiUtilities.ipf
@@ -793,7 +793,7 @@ End
 ///
 /// @return minimum and maximum value of the axis range
 Function [variable minimum, variable maximum] GetAxisRange(string graph, string axis, [variable mode])
-	string info, flags
+	string info
 
 	if(!windowExists(graph))
 		return [NaN, NaN]
@@ -809,6 +809,13 @@ Function [variable minimum, variable maximum] GetAxisRange(string graph, string 
 	if(isEmpty(info))
 		return [NaN, NaN]
 	endif
+
+	[minimum, maximum] = GetAxisRangeFromInfo(graph, info, axis, mode)
+End
+
+static Function [variable minimum, variable maximum] GetAxisRangeFromInfo(string graph, string info, string axis, variable mode)
+
+	string flags
 
 	if(mode == AXIS_RANGE_DEFAULT)
 		flags = StringByKey("SETAXISFLAGS", info)

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -52,10 +52,10 @@ Function HorizExpandWithVisX()
 
 	graph = GetCurrentWindow()
 
-	WAVE ranges = GetAxesRanges(graph, orientation = AXIS_ORIENTATION_HORIZ, mode = AXIS_RANGE_INC_AUTOSCALED)
-	numEntries = DimSize(ranges, ROWS)
+	WAVE axesProps = GetAxesProperties(graph, orientation = AXIS_ORIENTATION_HORIZ, mode = AXIS_RANGE_INC_AUTOSCALED)
+	numEntries = DimSize(axesProps, ROWS)
 	for(i = 0; i < numEntries; i += 1)
-		axis = GetDimLabel(ranges, ROWS, i)
+		axis = GetDimLabel(axesProps, ROWS, i)
 
 		[first, last] = GetMarqueeHelper(axis, kill = 0, doAssert = 0, horiz = 1)
 
@@ -64,8 +64,8 @@ Function HorizExpandWithVisX()
 			continue
 		endif
 
-		minimum = ranges[i][%minimum]
-		maximum = ranges[i][%maximum]
+		minimum = axesProps[i][%minimum]
+		maximum = axesProps[i][%maximum]
 
 		first = limit(first , minimum, maximum)
 		last  = limit(last, minimum, maximum)
@@ -6996,14 +6996,14 @@ Function UpdateSweepInGraph(string win, variable index)
 
 	graph = GetMainWindow(win)
 
-	WAVE axesRanges = GetAxesRanges(graph)
+	WAVE axesProps = GetAxesProperties(graph)
 	WAVE/T/Z cursorInfos = GetCursorInfos(graph)
 
 	RemoveSweepFromGraph(win, index)
 	AddSweepToGraph(win, index)
 
 	RestoreCursors(graph, cursorInfos)
-	SetAxesRanges(graph, axesRanges)
+	SetAxesProperties(graph, axesProps)
 End
 
 /// @brief Generic window hooks for storing the window

--- a/Packages/MIES/MIES_Oscilloscope.ipf
+++ b/Packages/MIES/MIES_Oscilloscope.ipf
@@ -236,7 +236,7 @@ Function SCOPE_CreateGraph(device, dataAcqOrTP)
 
 	[axisMinTop, axisMaxTop] = GetAxisRange(graph, AXIS_SCOPE_TP_TIME, mode=AXIS_RANGE_INC_AUTOSCALED)
 	if(dataAcqOrTP != TEST_PULSE_MODE || !showPowerSpectrum && scopeScaleMode == GUI_SETTING_OSCI_SCALE_FIXED)
-		WAVE previousADAxesRanges = GetAxesRanges(graph, axesRegexp=AXIS_SCOPE_AD_REGEXP, orientation=AXIS_ORIENTATION_LEFT, mode=AXIS_RANGE_INC_AUTOSCALED)
+		WAVE previousADAxesProperties = GetAxesProperties(graph, axesRegexp=AXIS_SCOPE_AD_REGEXP, orientation=AXIS_ORIENTATION_LEFT, mode=AXIS_RANGE_INC_AUTOSCALED)
 	endif
 
 	RemoveTracesFromGraph(graph)
@@ -360,8 +360,8 @@ Function SCOPE_CreateGraph(device, dataAcqOrTP)
 		YaxisLow -= YaxisSpacing
 	endfor
 
-	if(WaveExists(previousADAxesRanges))
-		SetAxesRanges(graph, previousADAxesRanges, axesRegexp=AXIS_SCOPE_AD_REGEXP, orientation=AXIS_ORIENTATION_LEFT, mode=AXIS_RANGE_USE_MINMAX)
+	if(WaveExists(previousADAxesProperties))
+		SetAxesProperties(graph, previousADAxesProperties, axesRegexp=AXIS_SCOPE_AD_REGEXP, orientation=AXIS_ORIENTATION_LEFT, mode=AXIS_RANGE_USE_MINMAX)
 	endif
 
 	SCOPE_SetADAxisLabel(device, dataAcqOrTP, activeHeadStage)

--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -1267,7 +1267,7 @@ static Function [WAVE/T plotGraphs, WAVE/WAVE infos] SF_PreparePlotter(string wi
 		endif
 
 		if(WindowExists(win))
-			WAVE/T/Z axes     = GetAxesRanges(win)
+			WAVE/T/Z axes     = GetAxesProperties(win)
 			WAVE/T/Z cursors  = GetCursorInfos(win)
 			WAVE/T/Z annoInfo = GetAnnotationInfo(win)
 
@@ -1682,16 +1682,16 @@ static Function SF_FormulaPlotter(string graph, string formula, [DFREF dfr, vari
 		endif
 
 		if(keepUserSelection)
-			WAVE/Z cursorInfos = infos[j][%cursors]
-			WAVE/Z axesRanges  = infos[j][%axes]
-			WAVE/Z annoInfos   = infos[j][%annotations]
+			WAVE/Z cursorInfos    = infos[j][%cursors]
+			WAVE/Z axesProperties = infos[j][%axes]
+			WAVE/Z annoInfos      = infos[j][%annotations]
 
 			if(WaveExists(cursorInfos))
 				RestoreCursors(win, cursorInfos)
 			endif
 
-			if(WaveExists(axesRanges))
-				SetAxesRanges(win, axesRanges)
+			if(WaveExists(axesProperties))
+				SetAxesProperties(win, axesProperties)
 			endif
 
 			if(WaveExists(annoInfos))

--- a/Packages/MIES/MIES_WaveBuilderPanel.ipf
+++ b/Packages/MIES/MIES_WaveBuilderPanel.ipf
@@ -244,7 +244,7 @@ static Function WBP_DisplaySetInPanel()
 		DoAbortNow("Wavebuilder panel is out of date. Please close and reopen it.")
 	endif
 
-	WAVE ranges = GetAxesRanges(waveBuilderGraph)
+	WAVE axesProps = GetAxesProperties(waveBuilderGraph)
 
 	RemoveTracesFromGraph(waveBuilderGraph)
 
@@ -296,7 +296,7 @@ static Function WBP_DisplaySetInPanel()
 	epochHLEndLeft    = min(0, minYValue)
 
 	SetAxis/W=$waveBuilderGraph/A/E=3 left
-	SetAxesRanges(waveBuilderGraph, ranges)
+	SetAxesProperties(waveBuilderGraph, axesProps)
 End
 
 /// @brief Reponsible for adjusting controls which depend on other controls
@@ -1661,8 +1661,8 @@ Function WBP_ShowFFTSpectrumIfReq(segmentWave, sweep)
 	graphMag   = extPanel + "#magnitude"
 	graphPhase = extPanel + "#phase"
 
-	WAVE axesRangesMag   = GetAxesRanges(graphMag)
-	WAVE axesRangesPhase = GetAxesRanges(graphPhase)
+	WAVE axesPropsMag   = GetAxesProperties(graphMag)
+	WAVE axesPropsPhase = GetAxesProperties(graphPhase)
 	WAVE/T/Z cursorInfosMag = GetCursorInfos(graphMag)
 	WAVE/T/Z cursorInfosPhase = GetCursorInfos(graphPhase)
 
@@ -1685,8 +1685,8 @@ Function WBP_ShowFFTSpectrumIfReq(segmentWave, sweep)
 	ModifyGraph/W=$graphMag rgb($trace)   = (s.red, s.green, s.blue)
 	ModifyGraph/W=$graphPhase rgb($trace) = (s.red, s.green, s.blue)
 
-	SetAxesRanges(graphMag, axesRangesMag)
-	SetAxesRanges(graphPhase, axesRangesPhase)
+	SetAxesProperties(graphMag, axesPropsMag)
+	SetAxesProperties(graphPhase, axesPropsPhase)
 	RestoreCursors(graphMag, cursorInfosMag)
 	RestoreCursors(graphPhase, cursorInfosPhase)
 End


### PR DESCRIPTION
This was only requested for the SweepFormula graphs, but I'm now doing it for all other graphs where we restored axes ranges as well. This made for me the most sense.