### PR TITLE
tools/nwb-read-tests/run.sh: Update version to 2.3.1

### DIFF
--- a/tools/nwb-read-tests/0001-Support-nwb_version-as-a-fixed-length-string-1669.patch
+++ b/tools/nwb-read-tests/0001-Support-nwb_version-as-a-fixed-length-string-1669.patch
@@ -1,0 +1,19 @@
+diff --git a/src/pynwb/__init__.py b/src/pynwb/__init__.py
+index a5d3bdfc..2df273d4 100644
+--- a/src/pynwb/__init__.py
++++ b/src/pynwb/__init__.py
+@@ -258,6 +258,11 @@ class NWBHDF5IO(_HDF5IO):
+         #  or when the HDF5 file is not a valid NWB file
+         except KeyError:
+             return None, None
++        # Other system may have written nwb_version as a fixed-length string, resulting in a numpy.bytes_ object
++        # on read, rather than a variable-length string. To address this, decode the bytes if necessary.
++        if not isinstance(nwb_version_string, str):
++            nwb_version_string = nwb_version_string.decode()
++
+         # Parse the version string
+         nwb_version_parts = nwb_version_string.replace("-", ".").replace("_", ".").split(".")
+         nwb_version = tuple([int(i) if i.isnumeric() else i
+-- 
+2.40.0.windows.1
+

--- a/tools/nwb-read-tests/Dockerfile
+++ b/tools/nwb-read-tests/Dockerfile
@@ -6,6 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update &&                          \
     apt-get install -y --no-install-recommends \
       git                                      \
+      patch                                    \
       python-is-python3                        \
       python3-minimal                          \
       python3-pip                              \
@@ -18,6 +19,11 @@ ARG PACKAGE_WITH_VERSION
 RUN pip3 install $PACKAGE_WITH_VERSION
 
 RUN pip3 check
+
+COPY 0001-Support-nwb_version-as-a-fixed-length-string-1669.patch /root
+
+RUN patch -d /usr/local/lib/python3.9/dist-packages                         \
+    -p2 </root/0001-Support-nwb_version-as-a-fixed-length-string-1669.patch
 
 ARG USERID
 ARG GROUPID

--- a/tools/nwb-read-tests/nwbv2-read-test.py
+++ b/tools/nwb-read-tests/nwbv2-read-test.py
@@ -25,7 +25,7 @@ def checkFile(path):
         return 1
 
     # 1.) Validation
-    comp = run(["python", "-m", "pynwb.validate", "--cached-namespace", path],
+    comp = run(["python", "-m", "pynwb.validate", path],
                stdout=PIPE, stderr=STDOUT, universal_newlines=True, timeout=120)
 
     if comp.returncode != 0:

--- a/tools/nwb-read-tests/run.sh
+++ b/tools/nwb-read-tests/run.sh
@@ -25,7 +25,7 @@ echo "Start building Docker container \"$tag\""
 
 docker build --build-arg USERID=$(id -u)                     \
              --build-arg GROUPID=$(id -g)                    \
-             --build-arg PACKAGE_WITH_VERSION="pynwb==2.1.0" \
+             --build-arg PACKAGE_WITH_VERSION="pynwb==2.3.1" \
              -t $tag $top_level/tools/nwb-read-tests
 
 # use 'docker run -it ..' for interactive debugging


### PR DESCRIPTION
- [x] Blocked by https://github.com/NeurodataWithoutBorders/pynwb/issues/1668
- [x] Patch pynwb 2.3.1 with the attached patch
[0001-Support-nwb_version-as-a-fixed-length-string-1669.patch](https://github.com/AllenInstitute/MIES/files/10999571/0001-Support-nwb_version-as-a-fixed-length-string-1669.patch)
