### PR TITLE
SF: Fix pending RTE due to wrong format in error msg generation

### DIFF
--- a/Packages/MIES/MIES_SweepFormula_Helpers.ipf
+++ b/Packages/MIES/MIES_SweepFormula_Helpers.ipf
@@ -65,7 +65,7 @@ Function SFH_GetArgumentAsNumeric(variable jsonId, string jsonPath, string graph
 
 		sep = ", "
 		allowedValuesAsStr = RemoveEnding(NumericWaveToList(allowedValues, sep), sep)
-		sprintf msg, "Argument #%d of operation %s: The text argument \"%s\" is not one of the allowed values (%s)", argNum, opShort, result, allowedValuesAsStr
+		sprintf msg, "Argument #%d of operation %s: The numeric argument \"%g\" is not one of the allowed values (%s)", argNum, opShort, result, allowedValuesAsStr
 		SFH_ASSERT(GetRowIndex(allowedValues, val = result) >= 0, msg)
 	endif
 


### PR DESCRIPTION
- in SFH_GetArgumentAsNumeric

since 075f2ea
