### PR TITLE
SF: Fix hidden RTE in FormulaPlotter for TextWave PlotCheck

### DIFF
--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -1572,7 +1572,7 @@ static Function SF_FormulaPlotter(string graph, string formula, [DFREF dfr, vari
 					MoveWaveWithOverWrite(wvY, wvResultY)
 				endif
 				WAVE wvY = GetSweepFormulaY(dfr, dataCnt)
-				SFH_ASSERT(!(IsTextWave(wvY) && IsTextWave(wvX)), "One wave needs to be numeric for plotting")
+				SFH_ASSERT(!(IsTextWave(wvY) && (WaveExists(wvX) && IsTextWave(wvX))), "One wave needs to be numeric for plotting")
 
 				if(IsTextWave(wvY))
 					SFH_ASSERT(WaveExists(wvX), "Cannot plot a single text wave")

--- a/Packages/tests/Basic/UTF_SweepFormula.ipf
+++ b/Packages/tests/Basic/UTF_SweepFormula.ipf
@@ -1716,7 +1716,7 @@ static Function TestPlotting()
 		MIES_SF#SF_FormulaPlotter(sweepBrowser, "[abc,def]")
 		FAIL()
 	catch
-		PASS()
+		CHECK_NO_RTE()
 	endtry
 
 	MIES_SF#SF_FormulaPlotter(sweepBrowser, strWith)


### PR DESCRIPTION
- The SFH_ASSERT check threw a RTe if the x-wave was null The RTE was hidden as it appeared in a threadsafe function (IsTextWave)
- Adapted FormulaPlotter Test
- Since ee3f8d4
