### PR TITLE
Bugfix for exp save request popup on new exp creation with no previous changes

### DIFF
--- a/Packages/MIES/MIES_DAC-Hardware.ipf
+++ b/Packages/MIES/MIES_DAC-Hardware.ipf
@@ -1397,11 +1397,6 @@ Function HW_ITC_ReadADC(deviceID, channel, [flags])
 
 	HW_ITC_HandleReturnValues(flags, V_ITCError, V_ITCXOPError)
 
-	// @todo ITCXOP: manually return NaN on error until https://github.com/AllenInstitute/ITCXOP2/issues/19 is fixed
-	if(V_ITCError != 0 || V_ITCXOPError != 0)
-		return NaN
-	endif
-
 	return V_Value
 End
 
@@ -1433,11 +1428,6 @@ Function HW_ITC_ReadDigital(deviceID, xopChannel, [flags])
 	while(HW_ITC_ShouldContinue(tries++, V_ITCError, V_ITCXOPError))
 
 	HW_ITC_HandleReturnValues(flags, V_ITCError, V_ITCXOPError)
-
-	// @todo ITCXOP: manually return NaN on error until https://github.com/AllenInstitute/ITCXOP2/issues/19 is fixed
-	if(V_ITCError != 0 || V_ITCXOPError != 0)
-		return NaN
-	endif
 
 	return V_Value
 End

--- a/Packages/MIES/MIES_GuiPopupMenuExt.ipf
+++ b/Packages/MIES/MIES_GuiPopupMenuExt.ipf
@@ -426,8 +426,17 @@ End
 Function/S PEXT_PopupMenuItems(subMenuNr)
 	variable subMenuNr
 
+	variable modifiedBefore
+
+	ExperimentModified
+	modifiedBefore = V_flag
+
 	WAVE/T itemListWave = GetPopupExtMenuWave()
 	variable subMenuCnt = DimSize(itemListWave, ROWS)
+
+	if(!modifiedBefore)
+		ExperimentModified 0
+	endif
 
 	if(subMenuNr >= subMenuCnt)
 		return ""

--- a/Packages/MIES/MIES_IgorHooks.ipf
+++ b/Packages/MIES/MIES_IgorHooks.ipf
@@ -252,6 +252,10 @@ static Function IgorStartOrNewHook(igorApplicationNameStr)
 	string igorApplicationNameStr
 
 	string miesVersion
+	variable modifiedBefore
+
+	ExperimentModified
+	modifiedBefore = V_flag
 
 	PS_FixPackageLocation(PACKAGE_MIES)
 
@@ -268,6 +272,10 @@ static Function IgorStartOrNewHook(igorApplicationNameStr)
 	StartZeroMQSockets()
 
 	LOG_AddEntry(PACKAGE_MIES, "end")
+
+	if(!modifiedBefore)
+		ExperimentModified 0
+	endif
 
 	return 0
 End
@@ -304,22 +312,22 @@ static Function AfterCompiledHook()
 
 	variable modifiedBefore
 
-	LOG_AddEntry(PACKAGE_MIES, "start")
-
 	ExperimentModified
 	modifiedBefore = V_flag
 
-	ASYNC_Start(threadprocessorCount, disableTask=1)
+	LOG_AddEntry(PACKAGE_MIES, "start")
 
-	if(!modifiedBefore)
-		ExperimentModified 0
-	endif
+	ASYNC_Start(threadprocessorCount, disableTask=1)
 
 	ShowTraceInfoTags()
 
 	MultiThreadingControl setmode=4
 
 	LOG_AddEntry(PACKAGE_MIES, "end")
+
+	if(!modifiedBefore)
+		ExperimentModified 0
+	endif
 End
 
 #endif

--- a/Packages/MIES/MIES_PulseAveraging.ipf
+++ b/Packages/MIES/MIES_PulseAveraging.ipf
@@ -3665,17 +3665,6 @@ static Function PA_SetColorScale(string win, string colScale)
 			image = StringFromList(j, images)
 			ModifyImage/W=$graph $image ctab={,,$colScale,0}
 		endfor
-
-#if (NumberByKey("BUILD", IgorInfo(0)) < 36300)
-		// workaround IP bug where the color scale is not updated
-		colorScaleGraph = PA_GetColorScaleGraph(graph)
-		colorScales = AnnotationList(colorScaleGraph)
-		numAnnotations = ItemsInList(colorScales)
-		for(j = 0; j < numAnnotations; j += 1)
-			str = StringFromList(j, colorScales)
-			ColorScale/C/N=$str/W=$colorScaleGraph
-		endfor
-#endif
 	endfor
 End
 

--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -1364,9 +1364,7 @@ static Function [WAVE/T plotGraphs, WAVE/WAVE infos] SF_PreparePlotter(string wi
 		endfor
 	endif
 
-	// @todo IP9: workaround IP bug as plotGraphs can not be used directly in the range-based for loop
-	WAVE/T localPlotGraphs = plotGraphs
-	for(win : localPlotGraphs)
+	for(win : plotGraphs)
 		RemoveTracesFromGraph(win)
 		ModifyGraph/W=$win swapXY = 0
 	endfor
@@ -1425,10 +1423,6 @@ static Function/S SF_CombineYUnits(WAVE/T units)
 
 	WAVE/T unique = GetUniqueEntries(units, dontDuplicate=1)
 	for(unit : unique)
-		// @todo Remove if part when "null string for empty string wave elment" bug in IP9 is fixed
-		if(IsNull(unit))
-			unit = ""
-		endif
 		result += unit + separator
 	endfor
 

--- a/Packages/MIES/MIES_TestPulse.ipf
+++ b/Packages/MIES/MIES_TestPulse.ipf
@@ -462,8 +462,6 @@ static Function [variable result, variable tau, variable baseline] TP_AutoFitBas
 		Duplicate/O data, root:Res_AutoTPDebuggingData/WAVE=residuals
 
 		if(!WindowExists("AutoTPDebugging"))
-			// @todo move away from manual layouting when /AR, /AD, /R=wv are fixed
-
 			Display/K=1/N=AutoTPDebugging displayedData
 
 			AppendToGraph/W=AutoTPDebugging/L=res residuals

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -3438,8 +3438,7 @@ End
 
 /// UTF_NOINSTRUMENTATION
 threadsafe static Function NameChecker(string name, variable liberal)
-	// @todo remove the IsEmpty check once this is resolved upstream.
-	return !IsEmpty(name) && !cmpstr(name, CleanupName(name, !!liberal, MAX_OBJECT_NAME_LENGTH_IN_BYTES))
+	return !cmpstr(name, CleanupName(name, !!liberal, MAX_OBJECT_NAME_LENGTH_IN_BYTES))
 End
 
 /// @brief Find an integer `x` which is larger than `a` but the

--- a/Packages/MIES_Include.ipf
+++ b/Packages/MIES_Include.ipf
@@ -16,11 +16,11 @@
 // These are sphinx substitutions destined for Packages/doc/installation_subst.txt.
 // They are defined here so that we can parse them from within IP.
 //
-// .. |IgorPro9Nightly| replace:: `Igor Pro 9 <https://www.byte-physics.de/Downloads/WinIgor9_30APR2022.zip>`__
+// .. |IgorPro9Nightly| replace:: `Igor Pro 9 <https://www.byte-physics.de/Downloads/WinIgor9_01APR2023.zip>`__
 
 #pragma IgorVersion=9.00
 
-#if (NumberByKey("BUILD", IgorInfo(0)) < 38961)
+#if (NumberByKey("BUILD", IgorInfo(0)) < 39935)
 #define TOO_OLD_IGOR
 #endif
 

--- a/Packages/tests/Basic/UTF_JSONWaveNotes.ipf
+++ b/Packages/tests/Basic/UTF_JSONWaveNotes.ipf
@@ -157,12 +157,10 @@ static Function TestSetWaveInJSONWaveNote()
 	WAVE data = JWN_GetNumericWaveFromWaveNote(wv, "wave")
 	CHECK_EQUAL_WAVES(wvDataI64, data, mode = WAVE_DATA | DIMENSION_SIZES)
 
-#if (IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 39150)
 	Make/FREE/L/U wvDataUI64 = p
 	JWN_SetWaveInWaveNote(wv, "wave", wvDataUI64);
 	WAVE data = JWN_GetNumericWaveFromWaveNote(wv, "wave")
 	CHECK_EQUAL_WAVES(wvDataUI64, data, mode = WAVE_DATA | DIMENSION_SIZES)
-#endif
 
 	WAVE/Z data = JWN_GetNumericWaveFromWaveNote(wv, "does_not_exist")
 	CHECK_WAVE(data, NULL_WAVE)

--- a/Packages/tests/Basic/UTF_Utils.ipf
+++ b/Packages/tests/Basic/UTF_Utils.ipf
@@ -233,15 +233,9 @@ Function AcceptsValid10()
 
 	variable now      = DateTimeInUTC()
 	variable expected = now
-#if (IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 39493)
 	// DateTime currently returns six digits of precision
 	variable actual   = ParseISO8601TimeStamp(GetIso8601TimeStamp(secondsSinceIgorEpoch = now, numFracSecondsDigits = 6))
 	CHECK_CLOSE_VAR(actual, expected)
-#else
-	// DateTime currently returns three digits of precision
-	variable actual   = ParseISO8601TimeStamp(GetIso8601TimeStamp(secondsSinceIgorEpoch = now, numFracSecondsDigits = 3))
-	CHECK_EQUAL_VAR(actual, expected)
-#endif
 End
 
 Function AcceptsValid11()


### PR DESCRIPTION
Change to require latest nightly (39935).

- [x] Update IP9 nightly version on all three CI machines
- [x] Remove workarounds for fixed IP9 bugs
- [x] Investigate test failures and crash

close https://github.com/AllenInstitute/MIES/issues/1658