### PR TITLE
Feature/1689 Extend SF operation div for data sets

### DIFF
--- a/Packages/MIES/MIES_AnalysisFunctions_Dashboard.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_Dashboard.ipf
@@ -1101,7 +1101,7 @@ static Function AD_SelectResult(win, [index])
 	if(!BSP_IsDataBrowser(win) && WaveExists(sweeps))
 		WAVE allSweeps = GetPlainSweepList(win)
 		WAVE/Z presentSweeps = GetSetIntersection(allSweeps, sweeps)
-		if(!WaveExists(presentSweeps) || EqualWaves(presentSweeps, sweeps, 1) != 1)
+		if(!WaveExists(presentSweeps) || EqualWaves(presentSweeps, sweeps, EQWAVES_DATA) != 1)
 			printf "Some requested sweeps can not be displayed, as they are not loaded into this sweepbrowser.\r"
 			ControlWindowToFront()
 		endif

--- a/Packages/MIES/MIES_AnalysisFunctions_MultiPatchSeq_SpikeControl.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_MultiPatchSeq_SpikeControl.ipf
@@ -43,7 +43,7 @@ static Function [variable minTrials, variable maxTrials] SC_GetTrials(string dev
 	WAVE stimsetAcqCycleIDPrev = GetLastSetting(numericalValues, sweepNo - 1, "Stimset Acq Cycle ID", DATA_ACQUISITION_MODE)
 	WAVE stimsetAcqCycleID     = GetLastSetting(numericalValues, sweepNo, "Stimset Acq Cycle ID", DATA_ACQUISITION_MODE)
 
-	if(EqualWaves(setSweepCountPrev, setSweepCount, 1) && EqualWaves(stimsetAcqCycleIDPrev, stimsetAcqCycleID, 1))
+	if(EqualWaves(setSweepCountPrev, setSweepCount, EQWAVES_DATA) && EqualWaves(stimsetAcqCycleIDPrev, stimsetAcqCycleID, EQWAVES_DATA))
 		trialsLBN[0, NUM_HEADSTAGES - 1] += (statusHS[p] == 1)
 	else
 		trialsLBN[0, NUM_HEADSTAGES - 1] = (statusHS[p] == 1 ? 0 : NaN)

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -2006,3 +2006,19 @@ Constant MODIFY_GRAPH_LOG_MODE_LOG2   = 2
 /// @}
 
 StrConstant FILE_LIST_SEP = "|"
+
+/// @name Constants for EqualWaves mode
+/// @anchor EqualWavesConstants
+/// @{
+Constant EQWAVES_DATA = 1
+Constant EQWAVES_DATATYPE = 2
+Constant EQWAVES_SCALING = 4
+Constant EQWAVES_DATAUNITS = 8
+Constant EQWAVES_DIMUNITS = 16
+Constant EQWAVES_DIMLABELS = 32
+Constant EQWAVES_WAVENOTE = 64
+Constant EQWAVES_LOCKSTATE = 128
+Constant EQWAVES_DATAFULLSCALE = 256
+Constant EQWAVES_DIMSIZE = 512
+Constant EQWAVES_ALL = -1
+/// @}

--- a/Packages/MIES/MIES_ExperimentDocumentation.ipf
+++ b/Packages/MIES/MIES_ExperimentDocumentation.ipf
@@ -353,7 +353,7 @@ static Function ED_WriteChangedValuesToNote(device, sweepNo)
 
 		ASSERT(DimSize(currentSetting, ROWS) == DimSize(lastSetting, ROWS), "last and current settings must have the same size")
 
-		if(EqualWaves(currentSetting, lastSetting, 1))
+		if(EqualWaves(currentSetting, lastSetting, EQWAVES_DATA))
 			continue
 		endif
 
@@ -442,7 +442,7 @@ static Function ED_WriteChangedValuesToNoteText(device, sweepNo)
 
 		ASSERT(DimSize(currentSetting, ROWS) == DimSize(lastSetting, ROWS), "last and current settings must have the same size")
 
-		if(EqualWaves(currentSetting, lastSetting, 1))
+		if(EqualWaves(currentSetting, lastSetting, EQWAVES_DATA))
 			continue
 		endif
 

--- a/Packages/MIES/MIES_InputDialog.ipf
+++ b/Packages/MIES/MIES_InputDialog.ipf
@@ -28,7 +28,7 @@ Function ID_AskUserForSettings(variable mode, string title, WAVE data, WAVE mock
 	variable i, state_var
 
 	ASSERT(!IsFreeWave(data), "Can only work with permanent waves")
-	ASSERT(EqualWaves(data, mock, 2 + 512), "Mismatched types or dimension sizes")
+	ASSERT(EqualWaves(data, mock, EQWAVES_DATATYPE + EQWAVES_DIMSIZE), "Mismatched types or dimension sizes")
 	ASSERT(mode == ID_HEADSTAGE_SETTINGS || mode == ID_POPUPMENU_SETTINGS, "Invalid mode")
 	ASSERT(DimSize(data, ROWS) > 0, "Empty wave")
 

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -7494,7 +7494,7 @@ Function RecreateMissingSweepAndConfigWaves(string device, DFREF deviceDataDFR)
 	WAVE/Z sweepsFromText = GetSweepsWithSetting(textualValues, "SweepNum")
 
 	// consistency check
-	ASSERT(WaveExists(sweepsFromNum) && WaveExists(sweepsFromText) && EqualWaves(sweepsFromNum, sweepsFromText, 1), "Unexpected numerical/textual LBN entries")
+	ASSERT(WaveExists(sweepsFromNum) && WaveExists(sweepsFromText) && EqualWaves(sweepsFromNum, sweepsFromText, EQWAVES_DATA), "Unexpected numerical/textual LBN entries")
 
 	WAVE sweeps = sweepsFromNum
 

--- a/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
+++ b/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
@@ -709,7 +709,7 @@ Function NWB_CheckForMissingSweeps(string device, WAVE/T sweepNames)
 		Make/FREE/N=(DimSize(sweepNames, ROWS)) sweepsFromDFR = ExtractSweepNumber(sweepNames[p])
 	endif
 
-	if(EqualWaves(sweepsfromLBN, sweepsFromDFR, 1) == 1)
+	if(EqualWaves(sweepsfromLBN, sweepsFromDFR, EQWAVES_DATA) == 1)
 		return 0
 	endif
 

--- a/Packages/MIES/MIES_PulseAveraging.ipf
+++ b/Packages/MIES/MIES_PulseAveraging.ipf
@@ -3462,7 +3462,7 @@ static Function/S PA_ShowImage(string win, STRUCT PulseAverageSettings &pa, STRU
 				Make/FREE/N=(MAX_DIMENSION_COUNT) newSizes = DimSize(img, p)
 
 				if(!(mode != POST_PLOT_ADDED_SWEEPS                                        \
-				   || !EqualWaves(oldSizes, newSizes, 1)                                 \
+				   || !EqualWaves(oldSizes, newSizes, EQWAVES_DATA)         \
 				   || pa.pulseSortOrder != PA_PULSE_SORTING_ORDER_SWEEP						\
 				   || scaleChanged                                          \
 				   || layoutChanged))

--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -3365,15 +3365,7 @@ End
 
 static Function/WAVE SF_OperationMin(variable jsonId, string jsonPath, string graph)
 
-	variable numArgs
-
-	numArgs = SFH_GetNumberOfArguments(jsonId, jsonPath)
-	SFH_ASSERT(numArgs > 0, "min requires at least one argument")
-	if(numArgs > 1)
-		WAVE/WAVE input = SF_GetArgumentTop(jsonId, jsonPath, graph, SF_OP_MIN)
-	else
-		WAVE/WAVE input = SF_ResolveDatasetFromJSON(jsonId, jsonPath, graph, 0)
-	endif
+	WAVE/WAVE input = SFH_GetNumericVarArgs(jsonId, jsonPath, graph, SF_OP_MIN)
 	WAVE/WAVE output = SFH_CreateSFRefWave(graph, SF_OP_MIN, DimSize(input, ROWS))
 
 	output[] = SF_OperationMinImpl(input[p])
@@ -5019,6 +5011,24 @@ static Function/WAVE SF_GetArgumentTop(variable jsonId, string jsonPath, string 
 	endif
 
 	WAVE/WAVE input = SF_ResolveDataset(wv)
+
+	return input
+End
+
+static Function/WAVE SFH_GetNumericVarArgs(variable jsonId, string jsonPath, string graph, string opShort)
+
+	variable numArgs
+
+	numArgs = SFH_CheckArgumentCount(jsonId, jsonPath, opShort, 1)
+	if(numArgs == 1)
+		WAVE/WAVE input = SF_ResolveDatasetFromJSON(jsonId, jsonPath, graph, 0)
+	else
+		WAVE wv = SF_FormulaExecutor(graph, jsonID, jsonPath = jsonPath)
+		WAVE/WAVE input = SF_ResolveDataset(wv)
+		SFH_ASSERT(DimSize(input, ROWS) == 1, "Expected a single data set")
+		WAVE wNum = input[0]
+		SFH_ASSERT(IsNumericWave(wNum), "Expected numeric wave")
+	endif
 
 	return input
 End

--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -803,7 +803,7 @@ static Function/WAVE SF_FormulaExecutor(string graph, variable jsonID, [string j
 	// object and array evaluation
 	JSONtype = JSON_GetType(jsonID, jsonPath)
 	if(JSONtype == JSON_NUMERIC)
-		Make/FREE out = { JSON_GetVariable(jsonID, jsonPath) }
+		Make/FREE/D out = { JSON_GetVariable(jsonID, jsonPath) }
 		return SFH_GetOutputForExecutorSingle(out, graph, "ExecutorNumberReturn")
 	elseif(JSONtype == JSON_STRING)
 		return SF_FormulaExecutorStringOrVariable(graph, jsonId, jsonPath)
@@ -816,7 +816,7 @@ static Function/WAVE SF_FormulaExecutor(string graph, variable jsonID, [string j
 		SFH_ASSERT(effectiveArrayDimCount <= MAX_DIMENSION_COUNT, "Array in evaluation has more than " + num2istr(MAX_DIMENSION_COUNT) + "dimensions.", jsonId=jsonId)
 		// Check against empty array
 		if(DimSize(topArraySize, ROWS) == 1 && topArraySize[0] == 0)
-			Make/FREE/N=0 out
+			Make/FREE/D/N=0 out
 			return SFH_GetOutputForExecutorSingle(out, graph, "ExecutorNumberReturn")
 		endif
 

--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -3222,7 +3222,7 @@ static Function/WAVE SF_OperationDivImplDataSets(WAVE/Z data0, WAVE/Z data1)
 		CopyScales data1, result
 		return result
 	endif
-	SFH_ASSERT(EqualWaves(data0, data1, 512), "div: wave size mismatch")
+	SFH_ASSERT(EqualWaves(data0, data1, EQWAVES_DIMSIZE), "div: wave size mismatch")
 
 	MatrixOp/FREE result = data0 / data1
 	CopyScales data0, result

--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -3141,31 +3141,37 @@ End
 
 static Function/WAVE SF_OperationPlus(variable jsonId, string jsonPath, string graph)
 
-	WAVE/WAVE input = SF_GetArgumentTop(jsonId, jsonPath, graph, SF_OPSHORT_PLUS)
-	WAVE/WAVE output = SFH_CreateSFRefWave(graph, SF_OPSHORT_PLUS, DimSize(input, ROWS))
+	WAVE output = SF_IndexOverDataSetsForPrimitiveOperation(jsonId, jsonpath, graph, SF_OPSHORT_PLUS)
 
-	output[] = SF_OperationPlusImpl(input[p])
-
-	SFH_TransferFormulaDataWaveNoteAndMeta(input, output, SF_OPSHORT_PLUS, "")
-
-	return SFH_GetOutputForExecutor(output, graph, SF_OPSHORT_PLUS, clear=input)
+	return SFH_GetOutputForExecutor(output, graph, SF_OPSHORT_PLUS)
 End
 
-static Function/WAVE SF_OperationPlusImpl(WAVE/Z wv)
+static Function/WAVE SF_OperationPlusImplDataSets(WAVE/Z data0, WAVE/Z data1)
 
-	if(!WaveExists(wv))
+	variable addConst
+
+	if(!WaveExists(data0) || !WaveExists(data1))
 		return $""
 	endif
-	SFH_ASSERT(DimSize(wv, ROWS), "Operand for + is empty.")
-	SFH_ASSERT(IsNumericWave(wv), "Operand for + must be numeric.")
-	MatrixOP/FREE out = sumCols(wv)^t
-	SF_FormulaWaveScaleTransfer(wv, out, SF_TRANSFER_ALL_DIMS, NaN)
-	SF_FormulaWaveScaleTransfer(wv, out, COLS, ROWS)
-	SF_FormulaWaveScaleTransfer(wv, out, LAYERS, COLS)
-	SF_FormulaWaveScaleTransfer(wv, out, CHUNKS, LAYERS)
-	Redimension/N=(-1, DimSize(out, LAYERS), DimSize(out, CHUNKS), 0)/E=1 out
+	SFH_ASSERT(IsNumericWave(data0) && IsNumericWave(data1) , "Operand for + must be numeric.")
 
-	return out
+	if(numpnts(data1) == 1)
+		addConst = data1[0]
+		MatrixOp/FREE result = data0 + addConst
+		CopyScales data0, result
+		return result
+	endif
+	if(numpnts(data0) == 1)
+		addConst = data0[0]
+		MatrixOp/FREE result = addConst + data1
+		CopyScales data1, result
+		return result
+	endif
+	SFH_ASSERT(EqualWaves(data0, data1, EQWAVES_DIMSIZE), "plus: wave size mismatch")
+
+	MatrixOp/FREE result = data0 + data1
+	CopyScales data0, result
+	return result
 End
 
 static Function/WAVE SF_IndexOverDataSetsForPrimitiveOperation(variable jsonId, string jsonPath, string graph, string opShort)
@@ -3188,6 +3194,9 @@ static Function/WAVE SF_IndexOverDataSetsForPrimitiveOperation(variable jsonId, 
 			case SF_OPSHORT_DIV:
 				output[] = SF_OperationDivImplDataSets(arg0[p], arg1[p])
 				break
+			case SF_OPSHORT_PLUS:
+				output[] = SF_OperationPlusImplDataSets(arg0[p], arg1[p])
+				break
 			default:
 				ASSERT(0, "Unsupported primitive operation")
 		endswitch
@@ -3198,6 +3207,9 @@ static Function/WAVE SF_IndexOverDataSetsForPrimitiveOperation(variable jsonId, 
 			case SF_OPSHORT_DIV:
 				output[] = SF_OperationDivImplDataSets(arg0[p], arg1[0])
 				break
+			case SF_OPSHORT_PLUS:
+				output[] = SF_OperationPlusImplDataSets(arg0[p], arg1[0])
+				break
 			default:
 				ASSERT(0, "Unsupported primitive operation")
 		endswitch
@@ -3207,6 +3219,9 @@ static Function/WAVE SF_IndexOverDataSetsForPrimitiveOperation(variable jsonId, 
 		strswitch(opShort)
 			case SF_OPSHORT_DIV:
 				output[] = SF_OperationDivImplDataSets(arg0[0], arg1[p])
+				break
+			case SF_OPSHORT_PLUS:
+				output[] = SF_OperationPlusImplDataSets(arg0[0], arg1[p])
 				break
 			default:
 				ASSERT(0, "Unsupported primitive operation")

--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -3229,23 +3229,6 @@ static Function/WAVE SF_OperationDivImplDataSets(WAVE/Z data0, WAVE/Z data1)
 	return result
 End
 
-static Function/WAVE SF_OperationDivImpl(WAVE/Z wv)
-
-	if(!WaveExists(wv))
-		return $""
-	endif
-	SFH_ASSERT(IsNumericWave(wv), "Operand for / must be numeric.")
-	SFH_ASSERT(DimSize(wv, ROWS) >= 2, "At least two operands are required")
-	MatrixOP/FREE out = (row(wv, 0) / productCols(subRange(wv, 1, numRows(wv) - 1, 0, numCols(wv) - 1)))^t
-	SF_FormulaWaveScaleTransfer(wv, out, SF_TRANSFER_ALL_DIMS, NaN)
-	SF_FormulaWaveScaleTransfer(wv, out, COLS, ROWS)
-	SF_FormulaWaveScaleTransfer(wv, out, LAYERS, COLS)
-	SF_FormulaWaveScaleTransfer(wv, out, CHUNKS, LAYERS)
-	Redimension/N=(-1, DimSize(out, LAYERS), DimSize(out, CHUNKS), 0)/E=1 out
-
-	return out
-End
-
 static Function/WAVE SF_OperationMult(variable jsonId, string jsonPath, string graph)
 
 	WAVE/WAVE input = SF_GetArgumentTop(jsonId, jsonPath, graph, SF_OPSHORT_MULT)

--- a/Packages/MIES/MIES_SweepFormula_Helpers.ipf
+++ b/Packages/MIES/MIES_SweepFormula_Helpers.ipf
@@ -240,7 +240,7 @@ Function SFH_IsEmptyRange(WAVE range)
 	ASSERT(IsNumericWave(range), "Invalid Range wave")
 	WAVE rangeRef = SFH_GetEmptyRange()
 
-	return	EqualWaves(rangeRef, range, 1)
+	return	EqualWaves(rangeRef, range, EQWAVES_DATA)
 End
 
 Function/WAVE SFH_GetFullRange()

--- a/Packages/MIES/MIES_SweepFormula_Helpers.ipf
+++ b/Packages/MIES/MIES_SweepFormula_Helpers.ipf
@@ -545,7 +545,7 @@ Function SFH_AddToArgSetupStack(WAVE output, WAVE/Z input, string argSetupStr, [
 	JSON_Release(argStackId)
 End
 
-Function/WAVE SFH_GetOutputForExecutorSingle(WAVE/Z data, string graph, string opShort[, variable discardOpStack, WAVE clear])
+Function/WAVE SFH_GetOutputForExecutorSingle(WAVE/Z data, string graph, string opShort[, variable discardOpStack, WAVE clear, string dataType])
 
 	discardOpStack = ParamIsDefault(discardOpStack) ? 0 : !!discardOpStack
 	if(!ParamIsDefault(clear))
@@ -553,6 +553,9 @@ Function/WAVE SFH_GetOutputForExecutorSingle(WAVE/Z data, string graph, string o
 	endif
 
 	WAVE/WAVE output = SFH_CreateSFRefWave(graph, opShort, 1)
+	if(!ParamIsDefault(dataType))
+		JWN_SetStringInWaveNote(output, SF_META_DATATYPE, dataType)
+	endif
 	if(WaveExists(data))
 		output[0] = data
 	endif

--- a/Packages/MIES/MIES_TraceUserData.ipf
+++ b/Packages/MIES/MIES_TraceUserData.ipf
@@ -165,7 +165,7 @@ Function/WAVE TUD_GetUserDataAsWave(string graph, string key, [WAVE/T keys, WAVE
 
 	Make/N=(DimSize(result, ROWS))/FREE matches = p
 
-	ASSERT(EqualWaves(keys, values, 512) == 1, "Unexpected size")
+	ASSERT(EqualWaves(keys, values, EQWAVES_DIMSIZE) == 1, "Unexpected size")
 
 	numEntries = DimSize(keys, ROWS)
 	for(i = 0; i < numEntries; i += 1)
@@ -224,7 +224,7 @@ End
 Function TUD_SetUserDataFromWaves(string graph, string trace, WAVE/T keys, WAVE/T values)
 	variable row, numCols, first, last, numExistingCols
 
-	ASSERT(EqualWaves(keys, values, 512) == 1, "Unexpected size")
+	ASSERT(EqualWaves(keys, values, EQWAVES_DIMSIZE) == 1, "Unexpected size")
 	ASSERT(DimSize(keys, ROWS) > 0, "Unexpected empty wave")
 
 	WAVE/T graphUserData = GetGraphUserData(graph)

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -4304,8 +4304,8 @@ Function/WAVE MergeTwoWaves(wv1, wv2)
 
 	variable numEntries, i, validEntryOne, validEntryTwo
 
-	ASSERT(EqualWaves(wv1, wv2, 512), "Non matching wave dim sizes")
-	ASSERT(EqualWaves(wv1, wv2, 2), "Non matching wave types")
+	ASSERT(EqualWaves(wv1, wv2, EQWAVES_DIMSIZE), "Non matching wave dim sizes")
+	ASSERT(EqualWaves(wv1, wv2, EQWAVES_DATATYPE), "Non matching wave types")
 	ASSERT(IsFloatingPointWave(wv1), "Expected floating point wave")
 	ASSERT(DimSize(wv1, COLS) <= 1, "Expected 1D wave")
 

--- a/Packages/tests/PAPlot/UTF_PA_Tests.ipf
+++ b/Packages/tests/PAPlot/UTF_PA_Tests.ipf
@@ -1484,7 +1484,7 @@ static Function PAT_ExtendedDeconvCheckTau()
 			CHECK(PAT_CheckIfTracesAreFront(traceListAll, traceName, patest.channels[i], patest.regions[j], 0))
 			// layout note: channel is Y, region is X, low channels start on top at yPos to 100%
 			WAVE pData = TraceNameToWaveRef(graph, traceName)
-			CHECK(!EqualWaves(refData[i][j], pData, 1, 10))
+			CHECK(!EqualWaves(refData[i][j], pData, EQWAVES_DATA, 10))
 		endfor
 	endfor
 End
@@ -1523,7 +1523,7 @@ static Function PAT_ExtendedDeconvCheckSmooth()
 			CHECK(PAT_CheckIfTracesAreFront(traceListAll, traceName, patest.channels[i], patest.regions[j], 0))
 			// layout note: channel is Y, region is X, low channels start on top at yPos to 100%
 			WAVE pData = TraceNameToWaveRef(graph, traceName)
-			CHECK(!EqualWaves(refData[i][j], pData, 1, 10))
+			CHECK(!EqualWaves(refData[i][j], pData, EQWAVES_DATA, 10))
 		endfor
 	endfor
 End

--- a/Packages/tests/UTF_HardwareHelperFunctions.ipf
+++ b/Packages/tests/UTF_HardwareHelperFunctions.ipf
@@ -447,7 +447,7 @@ Function CheckLBIndexCache_IGNORE(string device)
 						Duplicate/FREE/RMD=[entry][k] values, settings
 						Redimension/N=(LABNOTEBOOK_LAYER_COUNT)/E=1 settings
 
-						if(!EqualWaves(settings, settingsNoCache, WAVE_DATA))
+						if(!EqualWaves(settings, settingsNoCache, EQWAVES_DATA))
 
 							Note/K settings, setting
 


### PR DESCRIPTION
- [x] Once the new div extension is considered good:
    - [x] Adapt parser to always parse primitive operations (`+-/*`) to two JSON elements
    - [x] Get rid of SF_GetArgumentTop for those
    - [x] Create issue for switching other callers away from SF_GetArgumentTop, https://github.com/AllenInstitute/MIES/issues/1690
    - [x] Adapt other primitive operations to the same approach as div

close https://github.com/AllenInstitute/MIES/issues/1618
