### PR TITLE
tools: Gather diagnostics and log files for each CI run with IP

### DIFF
--- a/tools/autorun-test.sh
+++ b/tools/autorun-test.sh
@@ -5,6 +5,13 @@
 # https://stackoverflow.com/a/246128
 ScriptDir=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
 
+function finish
+{
+  source ${ScriptDir}/gather-logfiles-and-crashdumps.sh
+}
+
+trap finish exit
+
 usage()
 {
   echo "Usage: $0 [-p <name of pxp to run against>] [-v <igor version string>]" 1>&2
@@ -38,8 +45,6 @@ then
   echo "The Igor Pro Version is empty." 1>&2
   exit 1
 fi
-
-source ${ScriptDir}/cleanup-logfiles.sh
 
 StateFile=$(dirname ${experiment})/DO_AUTORUN.txt
 touch $StateFile

--- a/tools/cleanup-logfiles.sh
+++ b/tools/cleanup-logfiles.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-set -e
-
-find "$APPDATA/WaveMetrics" -type f -iname Log.jsonl -exec rm {} \;

--- a/tools/gather-logfiles-and-crashdumps.sh
+++ b/tools/gather-logfiles-and-crashdumps.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+IFS=$'\n'
+
+set -e
+
+files=$(find "$APPDATA/WaveMetrics" -type f -iname Log.jsonl)
+
+for i in $files
+do
+  name=$(echo $i | sed -e "s/.*WaveMetrics\/Igor Pro /IP/g" -e "s/Packages\///g" -e "s/\//_/g")
+  cp "$i" "$name"
+done
+
+folders=$(find "$APPDATA/WaveMetrics" -type d -iname Diagnostics)
+
+for i in $folders
+do
+  name=$(echo $i | sed -e "s/.*WaveMetrics\/Igor Pro /IP/g" -e "s/\//_/g")
+  cp -r "$i" "$name"
+done
+
+# now that we have successfully copied both logfiles and diagnostics, we can
+# safely remove them
+rm --verbose $files
+
+for i in $folders
+do
+  rm --verbose --dir $i/* 2> /dev/null || true
+done


### PR DESCRIPTION
Since b5e648ac (tools/autorun-test.sh: Cleanup logfiles, 2022-12-13) we cleanup logfiles before a CI run of IP. This did fix the issue of accumulating large logfiles.

And since 96af30d6 (UploadCrashDumpsDaily/UploadLogFilesDaily: Do nothing in CI, 2023-03-29) we don't upload the diagnostic/log files anymore in CI.

What we actually want to do with diagnostics and log files is attach them as artefact to the running CI job. This is now implemented by tools/gather-logfiles-and-crashdumps.sh.

Close #1638 