### PR TITLE
Fix for GUI getters returning string through S_value could be null

### DIFF
--- a/Packages/MIES/MIES_GuiUtilities.ipf
+++ b/Packages/MIES/MIES_GuiUtilities.ipf
@@ -416,6 +416,10 @@ Function/S GetSetVariableString(win, control)
 	ControlInfo/W=$win $control
 	ASSERT(V_flag != 0, "Non-existing control or window")
 	ASSERT(abs(V_flag) == CONTROL_TYPE_SETVARIABLE, "Control is not a setvariable")
+	if(IsNull(S_Value))
+		return ""
+	endif
+
 	return S_Value
 end
 
@@ -426,6 +430,10 @@ Function/S GetPopupMenuString(win, control)
 	ControlInfo/W=$win $control
 	ASSERT(V_flag != 0, "Non-existing control or window")
 	ASSERT(abs(V_flag) == CONTROL_TYPE_POPUPMENU, "Control is not a popupmenu")
+	if(IsNull(S_Value))
+		return ""
+	endif
+
 	return S_Value
 End
 
@@ -505,6 +513,10 @@ Function/S GetValDisplayAsString(win, control)
 	ControlInfo/W=$win $control
 	ASSERT(V_flag != 0, "Non-existing control or window")
 	ASSERT(abs(V_flag) == CONTROL_TYPE_VALDISPLAY, "Control is not a val display")
+	if(IsNull(S_Value))
+		return ""
+	endif
+
 	return S_value
 End
 

--- a/Packages/tests/Basic/UTF_Utils.ipf
+++ b/Packages/tests/Basic/UTF_Utils.ipf
@@ -6734,3 +6734,30 @@ Function StoreRestoreAxisProps([string str])
 
 	KillWindow $win
 End
+
+static Function NoNullReturnFromGetValDisplayAsString()
+
+	NewPanel/N=testpanelVal
+	ValDisplay vdisp win=testpanelVal
+
+	GetValDisplayAsString("testpanelVal", "vdisp")
+	PASS()
+End
+
+static Function NoNullReturnFromGetPopupMenuString()
+
+	NewPanel/N=testpanelPM
+	PopupMenu pmenu win=testpanelPM
+
+	GetPopupMenuString("testpanelPM", "pmenu")
+	PASS()
+End
+
+static Function NoNullReturnFromGetSetVariableString()
+
+	NewPanel/N=testpanelSV
+	SetVariable svari win=testpanelSV
+
+	GetSetVariableString("testpanelSV", "svari")
+	PASS()
+End


### PR DESCRIPTION
GUI getters GetPopupMenuString, GetSetVariableString, GetValDisplayAsString were not aware that ControlInfo can return S_value that is null if the controls value was never set before.

This caused for theses cases a RTE due to the null string being returned. The RTE was not caught and thus pending.
