### PR TITLE
Reenable SC_SpikeControl tests

### DIFF
--- a/Packages/tests/HardwareAnalysisFunctions/UTF_HardwareAnalysisFunctions.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_HardwareAnalysisFunctions.ipf
@@ -95,7 +95,7 @@ Function RunWithOpts([string testcase, string testsuite, variable allowdebug, va
 	list = AddListItem("UTF_ReachTargetVoltage.ipf", list, ";", inf)
 	list = AddListItem("UTF_MultiPatchSeqFastRheoEstimate.ipf", list, ";", inf)
 	list = AddListItem("UTF_MultiPatchSeqDAScale.ipf", list, ";", inf)
-	// list = AddListItem("UTF_MultiPatchSeqSpikeControl.ipf", list, ";", inf)
+	list = AddListItem("UTF_MultiPatchSeqSpikeControl.ipf", list, ";", inf)
 
 	if(ParamIsDefault(testsuite))
 		testsuite = list


### PR DESCRIPTION
This reverts commit 66a0eee4c (Packages/tests/HardwareAnalysisFunctions/UTF_HardwareAnalysisFunctions.ipf: Don't run the SC_SpikeControl tests, 2023-01-09).

We can do that because the real crash fix for the tests was ac0946e6 (ITC hardware: Only open and close the ITC device once for a test run, 2023-05-03).