### PR TITLE
Fix CI: add missing artifact

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -60,6 +60,7 @@ jobs:
         with:
           name: BuildInstaller-${{ matrix.kind }}-assets
           path: |
+            *.zip
             tools/installer/MIES-*.exe
           if-no-files-found: error
 


### PR DESCRIPTION
70daa61bd (CI: add GH actions for main and release builds, 2023-04-20)
introduced a zip archive as artifact for deployment for workflows on the
main/release branch. This was dropped after the merge of PR and
main/release workflow in c3a8d873b (CI: Main workflow calls the PR
workflow now, 2023-05-31) which wasn't intended.

Close #1759

Thanks for opening a PR in MIES :sparkles:!

- Code can only be merged if the continous integration tests pass
- [ ] Please ensure that the branch is named correctly. See
  [here](https://alleninstitute.github.io/MIES/developers.html#branch-naming-scheme) for the detailed explanation.
