### PR TITLE
Automatize panel type handling on window configuration restore

### DIFF
--- a/Packages/MIES/MIES_AnalysisBrowserMacro.ipf
+++ b/Packages/MIES/MIES_AnalysisBrowserMacro.ipf
@@ -114,6 +114,7 @@ Window AnalysisBrowser() : Panel
 	SetWindow kwTopWin,userdata(ResizeControlsInfo)=A"!!*'\"z!!#EIJ,hu%zzzzzzzzzzzzzzzzzzzzz"
 	SetWindow kwTopWin,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzzzzzzzzzzzzzzz"
 	SetWindow kwTopWin,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzzzzzzzzz!!!"
+	SetWindow kwTopWin,userdata(Config_PanelType)="AnalysisBrowser"
 	SetWindow kwTopWin,userdata(JSONSettings_StoreCoordinates)="1"
 	SetWindow kwTopWin,userdata(JSONSettings_WindowName)="analysisbrowser"
 	SetWindow kwTopWin,userdata(ResizeControlsGuides)="splitGuide;UGVL;"

--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -473,6 +473,10 @@ Function CONF_RestoreWindow(string fName[, string rigFile])
 				WBP_CreateWaveBuilderPanel()
 				wName = GetMainWindow(GetCurrentWindow())
 				wName = CONF_JSONToWindow(wName, restoreMask, jsonID)
+			elseif(!CmpStr(panelType, PANELTAG_ANALYSISBROWSER))
+				AB_OpenAnalysisBrowser()
+				wName = GetMainWindow(GetCurrentWindow())
+				wName = CONF_JSONToWindow(wName, restoreMask, jsonID)
 			else
 				ASSERT(0, "Configuration file entry for panel type has an unknown type (" + panelType + ").")
 			endif

--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -333,7 +333,7 @@ Function CONF_AutoLoader([string customIPath])
 		if(V_Value == -1)
 			rigCandidate = ""
 		endif
-		CONF_RestoreWindow(mainFileList[i], rigFile = rigCandidate, usePanelTypeFromFile = 1)
+		CONF_RestoreWindow(mainFileList[i], rigFile = rigCandidate)
 	endfor
 End
 
@@ -423,20 +423,16 @@ Function CONF_SaveWindow(fName)
 	endtry
 End
 
-/// @brief Restores the GUI state of window and all of its subwindows from a configuration file
+/// @brief Restores the GUI state of window and all of its subwindows from a configuration file. If the configuration file contains a panel type string then
+///        a new window of that type is opened and restored.
 ///
 /// @param fName file name of configuration file to read configuration
-/// @param usePanelTypeFromFile [optional, default = 0] if set to 1 then the panel type from the json is interpreted and a new panel of that type is opened
 /// @param rigFile [optional, default = ""] name of secondary rig configuration file with complementary data. This parameter is valid when loading for a DA_Ephys panel
-Function CONF_RestoreWindow(fName[, usePanelTypeFromFile, rigFile])
-	string fName
-	variable usePanelTypeFromFile
-	string rigFile
+Function CONF_RestoreWindow(string fName[, string rigFile])
 
 	variable jsonID, restoreMask
 	string input, wName, errMsg, fullFilePath, panelType
 
-	usePanelTypeFromFile = ParamIsDefault(usePanelTypeFromFile) ? 0 : !!usePanelTypeFromFile
 	rigFile = SelectString(ParamIsDefault(rigFile), rigFile, "")
 
 	PathInfo/S $CONF_GetSettingsPath(CONF_AUTO_LOADER_GLOBAL)
@@ -445,14 +441,24 @@ Function CONF_RestoreWindow(fName[, usePanelTypeFromFile, rigFile])
 	restoreMask = EXPCONFIG_SAVE_VALUE | EXPCONFIG_SAVE_USERDATA | EXPCONFIG_SAVE_DISABLED
 	AssertOnAndClearRTError()
 	try
-		if(usePanelTypeFromFile)
-			[input, fullFilePath] = LoadTextFile(fName, fileFilter = EXPCONFIG_FILEFILTER, message = "Open configuration file")
-			if(IsEmpty(input))
-				return 0
+		[input, fullFilePath] = LoadTextFile(fName, fileFilter = EXPCONFIG_FILEFILTER, message = "Open configuration file")
+		if(IsEmpty(input))
+			return 0
+		endif
+		jsonID = CONF_ParseJSON(input)
+		panelType = JSON_GetString(jsonID, "/" + EXPCONFIG_RESERVED_TAGENTRY)
+		if(IsEmpty(panelType))
+			wName = GetMainWindow(GetCurrentWindow())
+			if(PanelIsType(wName, PANELTAG_DAEPHYS))
+				if(!IsEmpty(rigFile))
+					CONF_JoinRigFile(jsonID, rigFile)
+				endif
+				wName = CONF_RestoreDAEphys(jsonID, fullFilePath)
+			else
+				wName = CONF_JSONToWindow(wName, restoreMask, jsonID)
+				print "Configuration restored for " + wName
 			endif
-			jsonID = CONF_ParseJSON(input)
-			panelType = JSON_GetString(jsonID, "/" + EXPCONFIG_RESERVED_TAGENTRY)
-			ASSERT(!IsEmpty(panelType), "Configuration file entry for panel type (" + EXPCONFIG_RESERVED_TAGENTRY + ") is empty.")
+		else
 			if(!CmpStr(panelType, PANELTAG_DAEPHYS))
 				if(!IsEmpty(rigFile))
 					CONF_JoinRigFile(jsonID, rigFile)
@@ -462,31 +468,9 @@ Function CONF_RestoreWindow(fName[, usePanelTypeFromFile, rigFile])
 				DB_OpenDataBrowser()
 				wName = GetMainWindow(GetCurrentWindow())
 				wName = CONF_JSONToWindow(wName, restoreMask, jsonID)
-				print "Configuration restored for " + wName
+				print "Data Browser restored in window \"" + wName + "\""
 			else
-				ASSERT(0, "Configuration file entry for panel type has an unknown panel tag (" + panelType + ").")
-			endif
-
-		else
-			wName = GetMainWindow(GetCurrentWindow())
-			if(PanelIsType(wName, PANELTAG_DAEPHYS))
-				[input, fullFilePath] = LoadTextFile(fName, fileFilter = EXPCONFIG_FILEFILTER, message = "Open configuration file for DA_Ephys panel")
-				if(IsEmpty(input))
-					return 0
-				endif
-				jsonID = CONF_ParseJSON(input)
-				if(!IsEmpty(rigFile))
-					CONF_JoinRigFile(jsonID, rigFile)
-				endif
-				wName = CONF_RestoreDAEphys(jsonID, fullFilePath)
-			else
-				[input, fullFilePath] = LoadTextFile(fName, fileFilter = EXPCONFIG_FILEFILTER, message = "Open configuration file for frontmost window")
-				if(IsEmpty(input))
-					return 0
-				endif
-				jsonID = CONF_ParseJSON(input)
-				wName = CONF_JSONToWindow(wName, restoreMask, jsonID)
-				print "Configuration restored for " + wName
+				ASSERT(0, "Configuration file entry for panel type has an unknown type (" + panelType + ").")
 			endif
 		endif
 

--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -469,6 +469,10 @@ Function CONF_RestoreWindow(string fName[, string rigFile])
 				wName = GetMainWindow(GetCurrentWindow())
 				wName = CONF_JSONToWindow(wName, restoreMask, jsonID)
 				print "Data Browser restored in window \"" + wName + "\""
+			elseif(!CmpStr(panelType, PANELTAG_WAVEBUILDER))
+				WBP_CreateWaveBuilderPanel()
+				wName = GetMainWindow(GetCurrentWindow())
+				wName = CONF_JSONToWindow(wName, restoreMask, jsonID)
 			else
 				ASSERT(0, "Configuration file entry for panel type has an unknown type (" + panelType + ").")
 			endif

--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -477,6 +477,10 @@ Function CONF_RestoreWindow(string fName[, string rigFile])
 				AB_OpenAnalysisBrowser()
 				wName = GetMainWindow(GetCurrentWindow())
 				wName = CONF_JSONToWindow(wName, restoreMask, jsonID)
+			elseif(!CmpStr(panelType, PANELTAG_IVSCCP))
+				IVS_CreatePanel()
+				wName = GetMainWindow(GetCurrentWindow())
+				wName = CONF_JSONToWindow(wName, restoreMask, jsonID)
 			else
 				ASSERT(0, "Configuration file entry for panel type has an unknown type (" + panelType + ").")
 			endif

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -21,7 +21,7 @@ Constant DAQ_CONFIG_WAVE_VERSION = 2
 Constant DA_EPHYS_PANEL_VERSION           = 60
 Constant DATA_SWEEP_BROWSER_PANEL_VERSION = 46
 Constant WAVEBUILDER_PANEL_VERSION        = 14
-Constant ANALYSISBROWSER_PANEL_VERSION    =  2
+Constant ANALYSISBROWSER_PANEL_VERSION    =  3
 
 /// Version of the stimset wave note
 Constant STIMSET_NOTE_VERSION = 9
@@ -1468,6 +1468,7 @@ StrConstant EXPCONFIG_UDATA_PANELTYPE = "Config_PanelType"
 StrConstant PANELTAG_DAEPHYS = "DA_Ephys"
 StrConstant PANELTAG_DATABROWSER = "DataBrowser"
 StrConstant PANELTAG_WAVEBUILDER = "WaveBuilder"
+StrConstant PANELTAG_ANALYSISBROWSER = "AnalysisBrowser"
 /// @}
 
 StrConstant EXPCONFIG_UDATA_SOURCEFILE_PATH = "Config_FileName"

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -20,7 +20,7 @@ Constant DAQ_CONFIG_WAVE_VERSION = 2
 /// Used to upgrade the GuiStateWave as well as the DA Ephys panel
 Constant DA_EPHYS_PANEL_VERSION           = 60
 Constant DATA_SWEEP_BROWSER_PANEL_VERSION = 46
-Constant WAVEBUILDER_PANEL_VERSION        = 13
+Constant WAVEBUILDER_PANEL_VERSION        = 14
 Constant ANALYSISBROWSER_PANEL_VERSION    =  2
 
 /// Version of the stimset wave note
@@ -1467,6 +1467,7 @@ StrConstant EXPCONFIG_UDATA_PANELTYPE = "Config_PanelType"
 
 StrConstant PANELTAG_DAEPHYS = "DA_Ephys"
 StrConstant PANELTAG_DATABROWSER = "DataBrowser"
+StrConstant PANELTAG_WAVEBUILDER = "WaveBuilder"
 /// @}
 
 StrConstant EXPCONFIG_UDATA_SOURCEFILE_PATH = "Config_FileName"

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -1469,6 +1469,7 @@ StrConstant PANELTAG_DAEPHYS = "DA_Ephys"
 StrConstant PANELTAG_DATABROWSER = "DataBrowser"
 StrConstant PANELTAG_WAVEBUILDER = "WaveBuilder"
 StrConstant PANELTAG_ANALYSISBROWSER = "AnalysisBrowser"
+StrConstant PANELTAG_IVSCCP = "IVSCControlPanel"
 /// @}
 
 StrConstant EXPCONFIG_UDATA_SOURCEFILE_PATH = "Config_FileName"

--- a/Packages/MIES/MIES_IVSCC.ipf
+++ b/Packages/MIES/MIES_IVSCC.ipf
@@ -343,6 +343,7 @@ Window IVSCCControlPanel() : Panel
 	Button button_runGigOhmSealQC,pos={48.00,103.00},size={190.00,30.00},proc=IVS_ButtonProc_GOhmSeal,title="Run GΩ seal check"
 	Button button_runBaselineQC,pos={48.00,61.00},size={190.00,30.00},proc=IVS_ButtonProc_BaselineQC,title="Run baseline QC"
 	Button button_runAccessResisQC,pos={48.00,145.00},size={190.00,30.00},proc=IVS_ButtonProc_AccessResist,title="Run access resistance QC check"
+	SetWindow kwTopWin,userdata(Config_PanelType)="IVSCControlPanel"
 EndMacro
 
 /// @brief Return the Set QC passed/failed state for the given sweep

--- a/Packages/MIES/MIES_Menu.ipf
+++ b/Packages/MIES/MIES_Menu.ipf
@@ -21,7 +21,7 @@ Menu "Mies Panels"
 	"-"
 	SubMenu "Automation"
 		"Load Standard Configuration/1"        , /Q, CONF_AutoLoader()
-		"Load Window Configuration"            , /Q, CONF_RestoreWindow("", usePanelTypeFromFile = 1)
+		"Load Window Configuration"            , /Q, CONF_RestoreWindow("")
 		"Save Window Configuration"            , /Q, CONF_SaveWindow("")
 		"Blowout/8"                            , /Q, BWO_SelectDevice()
 		"Save and Clear Experiment"            , /Q, SaveExperimentSpecial(SAVE_AND_CLEAR)

--- a/Packages/MIES/MIES_WaveBuilder_Macro.ipf
+++ b/Packages/MIES/MIES_WaveBuilder_Macro.ipf
@@ -1224,6 +1224,7 @@ Window WaveBuilder() : Panel
 	SetWindow kwTopWin,userdata(ResizeControlsGuides)="UGH1;UGV0;"
 	SetWindow kwTopWin,userdata(ResizeControlsInfoUGH1)="NAME:UGH1;WIN:WaveBuilder;TYPE:User;HORIZONTAL:1;POSITION:237.00;GUIDE1:FT;GUIDE2:;RELPOSITION:237;"
 	SetWindow kwTopWin,userdata(panelVersion)="12"
+	SetWindow kwTopWin,userdata(Config_PanelType)="WaveBuilder"
 	SetWindow kwTopWin,userdata(ResizeControlsInfoUGV0)="NAME:UGV0;WIN:WaveBuilder;TYPE:User;HORIZONTAL:0;POSITION:187.00;GUIDE1:FL;GUIDE2:;RELPOSITION:187;"
 	SetWindow kwTopWin,userdata(JSONSettings_StoreCoordinates)="1"
 	SetWindow kwTopWin,userdata(JSONSettings_WindowName)="wavebuilder"

--- a/Packages/tests/Basic/UTF_Configuration.ipf
+++ b/Packages/tests/Basic/UTF_Configuration.ipf
@@ -344,3 +344,17 @@ static Function TCONF_SaveNotebookAndRestore()
 	nbText = GetNotebookText(wName, mode=2)
 	CHECK_EQUAL_STR(nbTextRef2, nbText)
 End
+
+/// @brief Checks if every (qualified) panel has a panel type set
+///
+/// UTF_TD_GENERATOR GetMiesMacrosWithPanelType
+static Function TCONF_CheckMacrosForPanelType([string str])
+
+	string win, panelType
+
+	Execute/Q str + "()"
+	win = WinName(0, -1)
+	panelType = GetUserData(win, "", EXPCONFIG_UDATA_PANELTYPE)
+	INFO("Panel: " + win)
+	CHECK_PROPER_STR(panelType)
+End

--- a/Packages/tests/HardwareBasic/UTF_ConfigurationHardware.ipf
+++ b/Packages/tests/HardwareBasic/UTF_ConfigurationHardware.ipf
@@ -136,7 +136,7 @@ static Function CheckIfConfigurationRestoresMCCFilterGain([string str])
 
 	KillWindow $str
 
-	CONF_RestoreWindow(rewrittenConfig, usePanelTypeFromFile=1)
+	CONF_RestoreWindow(rewrittenConfig)
 
 	gain = 5
 	filterFreq = 6

--- a/Packages/tests/HardwareBasic/UTF_ConfigurationHardware.ipf
+++ b/Packages/tests/HardwareBasic/UTF_ConfigurationHardware.ipf
@@ -149,3 +149,34 @@ static Function CheckIfConfigurationRestoresMCCFilterGain([string str])
 	val = AI_SendToAmp(str, headStage + 1, I_CLAMP_MODE, MCC_GETPRIMARYSIGNALGAIN_FUNC, NaN)
 	CHECK_EQUAL_VAR(val, gain)
 End
+
+/// @brief Checks if every typed panel restores with auto opening
+///
+/// IUTF_TD_GENERATOR s0:GetMiesMacrosWithPanelType
+/// IUTF_TD_GENERATOR s1:DeviceNameGenerator
+static Function TCONF_CheckTypedPanelRestore([STRUCT IUTF_mData &md])
+
+	string win, winRestored
+	string fName = GetFolder(FunctionPath("")) + "CheckTypedPanelRestore.json"
+
+	Execute/Q md.s0 + "()"
+	win = WinName(0, -1)
+	if(!CmpStr(win, BASE_WINDOW_NAME))
+		// special handling for DAEphys
+		KillWindow $win
+		CreateLockedDAEphys(md.s1)
+		win = WinName(0, -1)
+		PGC_SetAndActivateControl(win, "check_Settings_RequireAmpConn", val=0)
+		PGC_SetAndActivateControl(win, "Check_DataAcqHS_00",val=1)
+		PGC_SetAndActivateControl(win, "Gain_DA_00",val=20)
+		PGC_SetAndActivateControl(win, "setvar_Settings_VC_DAgain",val=20)
+		PGC_SetAndActivateControl(win, "Gain_AD_00",val=0.0025)
+		PGC_SetAndActivateControl(win, "setvar_Settings_VC_ADgain",val=0.0025)
+	endif
+	CONF_SaveWindow(fName)
+	KillWindow $win
+	CONF_RestoreWindow(fName)
+	winRestored = WinName(0, -1)
+	DeleteFile fName
+	CHECK_EQUAL_STR(win, winRestored)
+End

--- a/Packages/tests/HardwareBasic/UTF_DAEphys.ipf
+++ b/Packages/tests/HardwareBasic/UTF_DAEphys.ipf
@@ -326,7 +326,7 @@ Function CheckIfConfigurationRestoresMCCFilterGain([str])
 
 	KillWindow $str
 
-	CONF_RestoreWindow(rewrittenConfig, usePanelTypeFromFile=1)
+	CONF_RestoreWindow(rewrittenConfig)
 
 	gain = 5
 	filterFreq = 6

--- a/Packages/tests/UTF_DataGenerators.ipf
+++ b/Packages/tests/UTF_DataGenerators.ipf
@@ -250,3 +250,15 @@ static Function/WAVE SF_TestVariablesGen()
 	Make/FREE/WAVE wv = {t1, t2, t3, t4}
 	return wv
 End
+
+Function/WAVE GetMiesMacrosWithPanelType()
+	WAVE/T allMiesMacros = GetMIESMacros()
+
+	Make/FREE/T panelsWithoutType = {"ID_Headstage_Panel", "ID_Popup_Panel", "DP_DebugPanel", "SBE_ExportSettingsPanel"}
+
+	WAVE/T matches = GetSetDifference(allMiesMacros, panelsWithoutType)
+
+	SetDimensionLabels(matches, TextWaveToList(matches, ";"), ROWS)
+
+	return matches
+End

--- a/Packages/tests/UTF_HelperFunctions.ipf
+++ b/Packages/tests/UTF_HelperFunctions.ipf
@@ -762,11 +762,13 @@ End
 
 Function/WAVE GetMIESMacros()
 
-	string allMacros
+	string win
+	string allMacros = ""
 
-	allMacros = MacroList("*", ";", "")
-
-	allMacros = GrepList(allMacros, "FunctionProfilingPanel", 1)
+	WAVE/T miesWindows = ListToTextWave(WinList("MIES_*.ipf", ";", "WIN:128"), ";")
+	for(win : miesWindows)
+		allMacros += MacroList("*", ";", "WIN:" + win)
+	endfor
 
 	return ListToTextWave(allMacros, ";")
 End


### PR DESCRIPTION
- Previously we had the optional parameter usePanelTypeFromFile to hint the restore function that the file should have a panel type and a new window of that type if opened before restore.
- This is changed now, such that this optional parameter is discarded. Instead we check if a panel type information is present in the file and create a new window if so.

close https://github.com/AllenInstitute/MIES/issues/1766

Please note, that the wave builder has no panel type. Thus, for restore no new wavebuilder panel is opened automatically as the function can not know. The wave builder is treated as a generic window, where the user must have that window as front window when attempting the configuration restore.