### PR TITLE
More Github Actions improvements

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -66,7 +66,6 @@ jobs:
   GenerateReport:
     name: 📊 Generate Reports
     runs-on: [ self-hosted, Linux, Docker ]
-    if: always()
     needs:
       - CallPR
     steps:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -95,7 +95,8 @@ jobs:
             -s "$(pwd)" \
             -d "${{ steps.download.outputs.download-path }}" \
             -h "${{ steps.cache-download.outputs.data }}" \
-            -o report
+            -o report \
+            -l "${{ secrets.GHA_MIES_REPORTGENERATOR_LICENSE }}"
       - name: 📤 Upload latest report to FTP
         run: |
           tools/ftp-upload/upload-files.sh \

--- a/tools/ftp-upload/Dockerfile
+++ b/tools/ftp-upload/Dockerfile
@@ -9,9 +9,18 @@ RUN DEBIAN_FRONTEND=noninteractive \
         openssl && \
     apt-get clean
 
-ARG FTP_SERVER
-RUN echo \
-        | openssl s_client -servername ${FTP_SERVER} -connect ${FTP_SERVER}:21 -starttls ftp -prexit 2>&1 \
-        | sed -ne '/-BEGIN\ CERTIFICATE-/,/-END\ CERTIFICATE-/p' \
-        > /usr/local/share/ca-certificates/${FTP_SERVER}.crt && \
-    update-ca-certificates
+ARG UNAME=ci
+ARG UID=1000
+ARG GID=1000
+
+RUN groupadd -g ${GID} -o ${UNAME} && \
+    useradd -m -u ${UID} -g ${GID} -o -s /bin/bash ${UNAME}
+
+USER ${UNAME}
+
+RUN mkdir ~/.lftp &&                                      \
+    echo "set ssl:check-hostname false" >> ~/.lftp/rc &&  \
+    echo "set ftp:ssl-force true" >> ~/.lftp/rc &&        \
+    echo "set ftp:ssl-protect-data true" >> ~/.lftp/rc && \
+    echo "set ftp:ssl-protect-fxp true" >> ~/.lftp/rc &&  \
+    echo "set ftp:ssl-protect-list true" >> ~/.lftp/rc

--- a/tools/ftp-upload/download-files.sh
+++ b/tools/ftp-upload/download-files.sh
@@ -58,7 +58,11 @@ top_level=$(git rev-parse --show-toplevel)
 
 # build containter
 echo "##[group]Build Docker container 'ftp-upload'"
-docker build --build-arg FTP_SERVER=$server_name -t ftp-upload $top_level/tools/ftp-upload
+docker build \
+    --build-arg UID=$(id -u) \
+    --build-arg GID=$(id -g) \
+    -t ftp-upload \
+    $top_level/tools/ftp-upload
 echo "##[endgroup]"
 
 # upload

--- a/tools/ftp-upload/upload-files.sh
+++ b/tools/ftp-upload/upload-files.sh
@@ -48,12 +48,16 @@ top_level=$(git rev-parse --show-toplevel)
 
 # build containter
 echo "##[group]Build Docker container 'ftp-upload'"
-docker build --build-arg FTP_SERVER=$server_name -t ftp-upload $top_level/tools/ftp-upload
+docker build \
+    --build-arg UID=$(id -u) \
+    --build-arg GID=$(id -g) \
+    -t ftp-upload \
+    $top_level/tools/ftp-upload
 echo "##[endgroup]"
 
 # upload
 echo "##[group]Upload files using ftp"
 docker run --rm -v "$directory:/data" ftp-upload \
-    lftp -e "set ssl:verify-certificate no; mirror --verbose=3 -R /data \"$target\"; quit" \
+    lftp -e "mirror --verbose=3 -R /data \"$target\"; quit" \
         -u "$user_name,$password" $server_name
 echo "##[endgroup]"

--- a/tools/report-generator/build.sh
+++ b/tools/report-generator/build.sh
@@ -103,7 +103,7 @@ docker run --rm \
         "-reporttypes:Html;HtmlChart;JsonSummary;PngChart;Badges;MarkdownDeltaSummary" \
         -historydir:/home/ci/history \
         -title:MIES \
-        -tag:$(git rev-parse --short HEAD) \
+        "-tag:$(git log -1 --pretty=reference)" \
         $license
 echo "##[endgroup]"
 

--- a/tools/report-generator/build.sh
+++ b/tools/report-generator/build.sh
@@ -4,7 +4,7 @@ set -e
 
 function usage ()
 {
-    echo "Usage: $0 [-s <source dir>] [-d <cobertura dir>] [-h <history dir>] [-o <output dir>]" 1>&2
+    echo "Usage: $0 [-s <source dir>] [-d <cobertura dir>] [-h <history dir>] [-o <output dir>] [-l <license>]" 1>&2
     exit 1
 }
 
@@ -13,7 +13,7 @@ directory="$(pwd)"
 history="$(pwd)/history"
 output="$(date -Id)"
 
-while getopts ":s:d:h:o:" key; do
+while getopts ":s:d:h:o:l:" key; do
     case "${key}" in
         s)
             source="${OPTARG}"
@@ -26,6 +26,9 @@ while getopts ":s:d:h:o:" key; do
             ;;
         o)
             output="${OPTARG}"
+            ;;
+        l)
+            license=" \"-license:${OPTARG}\""
             ;;
         *)
             usage
@@ -100,7 +103,8 @@ docker run --rm \
         "-reporttypes:Html;HtmlChart;JsonSummary;PngChart;Badges;MarkdownDeltaSummary" \
         -historydir:/home/ci/history \
         -title:MIES \
-        -tag:$(git rev-parse --short HEAD)
+        -tag:$(git rev-parse --short HEAD) \
+        $license
 echo "##[endgroup]"
 
 # output some variables (this makes CI integration easier)


### PR DESCRIPTION
Changes:

- Report Generator uses now a different tag format
- Report Generator now uses the pro license
- Coverage reports are generated only for successful builds
- FTP up- and download docker has been updated. It does no longer store the ssl certificate and has some lftp settings preconfigured.

Close #1758 