### PR TITLE
SF: bugfix: Add epoch range clipping for SFH_GetSweepsForFormula

### DIFF
--- a/Packages/MIES/MIES_SweepFormula_Helpers.ipf
+++ b/Packages/MIES/MIES_SweepFormula_Helpers.ipf
@@ -501,8 +501,8 @@ Function/WAVE SFH_GetSweepsForFormula(string graph, WAVE range, WAVE/Z selectDat
 				rangeEnd = limit(rangeEnd, -inf, lastx)
 			endif
 
-			SFH_ASSERT(rangeStart == -inf || (IsFinite(rangeStart) && rangeStart >= leftx(sweep) && rangeStart < rightx(sweep)), "Specified starting range not inside sweep " + num2istr(sweepNo) + ".")
-			SFH_ASSERT(rangeEnd == inf || (IsFinite(rangeEnd) && rangeEnd >= leftx(sweep) && rangeEnd < rightx(sweep)), "Specified ending range not inside sweep " + num2istr(sweepNo) + ".")
+			SFH_ASSERT(rangeStart == -inf || (IsFinite(rangeStart) && rangeStart >= leftx(sweep) && rangeStart < lastx), "Specified starting range not inside sweep " + num2istr(sweepNo) + ".")
+			SFH_ASSERT(rangeEnd == inf || (IsFinite(rangeEnd) && rangeEnd > leftx(sweep) && rangeEnd <= lastx), "Specified ending range not inside sweep " + num2istr(sweepNo) + ".")
 			Duplicate/FREE/R=(rangeStart, rangeEnd) sweep, rangedSweepData
 
 			JWN_SetWaveInWaveNote(rangedSweepData, SF_META_RANGE, {rangeStart, rangeEnd})

--- a/Packages/MIES/MIES_SweepFormula_Helpers.ipf
+++ b/Packages/MIES/MIES_SweepFormula_Helpers.ipf
@@ -394,7 +394,7 @@ Function/WAVE SFH_GetSweepsForFormula(string graph, WAVE range, WAVE/Z selectDat
 
 	variable i, j, rangeStart, rangeEnd, DAChannel, sweepNo
 	variable chanNr, chanType, cIndex, isSweepBrowser
-	variable numSelected, index, numEpochPatterns, numRanges, numEpochs, epIndex
+	variable numSelected, index, numEpochPatterns, numRanges, numEpochs, epIndex, lastx
 	string dimLabel, device, dataFolder
 	string	allEpochsRegex = "^.*$"
 
@@ -488,6 +488,18 @@ Function/WAVE SFH_GetSweepsForFormula(string graph, WAVE range, WAVE/Z selectDat
 		for(j = 0; j < numRanges; j += 1)
 			rangeStart = adaptedRange[0][j]
 			rangeEnd   = adaptedRange[1][j]
+			lastx = rightx(sweep) - DimDelta(sweep, ROWS)
+			// Release 8c6e5da (EP_WriteEpochInfoIntoSweepSettings: Handle unacquired data, 2021-07-13) and before:
+			// we did not cap epoch ranges properly on aborted/shortened sweeps
+			// we also did not calculate the sampling points for TP and Stimesets exactly the same way
+			// Thus, if necessary we clip the data here.
+			if(WaveExists(epochNames))
+				// complete epoch starting at or beyond sweep end
+				if(rangeStart >= lastx)
+					continue
+				endif
+				rangeEnd = limit(rangeEnd, -inf, lastx)
+			endif
 
 			SFH_ASSERT(rangeStart == -inf || (IsFinite(rangeStart) && rangeStart >= leftx(sweep) && rangeStart < rightx(sweep)), "Specified starting range not inside sweep " + num2istr(sweepNo) + ".")
 			SFH_ASSERT(rangeEnd == inf || (IsFinite(rangeEnd) && rangeEnd >= leftx(sweep) && rangeEnd < rightx(sweep)), "Specified ending range not inside sweep " + num2istr(sweepNo) + ".")

--- a/Packages/tests/HistoricData/UTF_HistoricData.ipf
+++ b/Packages/tests/HistoricData/UTF_HistoricData.ipf
@@ -20,6 +20,7 @@ static StrConstant HTTP_FOLDER_URL = "https://www.byte-physics.de/Downloads/alle
 
 // keep sorted
 #include "UTF_HistoricDashboard"
+#include "UTF_HistoricEpochClipping"
 
 // Entry point for UTF
 Function run()
@@ -81,6 +82,7 @@ Function RunWithOpts([string testcase, string testsuite, variable allowdebug, va
 
 	// sorted list
 	list = AddListItem("UTF_HistoricDashboard.ipf", list, ";", inf)
+	list = AddListItem("UTF_HistoricEpochClipping.ipf", list, ";", inf)
 
 	if(ParamIsDefault(testsuite))
 		testsuite = list
@@ -175,7 +177,8 @@ Function/WAVE GetHistoricDataFiles()
 	                     "Chat-IRES-Cre-neo;Ai14-582723.15.10.01.pxp",        \
 	                     "Pvalb-IRES-Cre;Ai14-646904.13.03.02.pxp",           \
 	                     "Sst-IRES-Cre;Ai14-554002.08.06.02.pxp",             \
-	                     "Sst-IRES-Cre;Th-P2A-FlpO;Ai65-561491.09.09.02.pxp"}
+								"Sst-IRES-Cre;Th-P2A-FlpO;Ai65-561491.09.09.02.pxp", \
+								"epoch_clipping_2022_03_08_140256.pxp"}
 
 	/// @TODO use hashes to verify files once IP supports strings > 2GB
 

--- a/Packages/tests/HistoricData/UTF_HistoricEpochClipping.ipf
+++ b/Packages/tests/HistoricData/UTF_HistoricEpochClipping.ipf
@@ -1,0 +1,23 @@
+#pragma TextEncoding = "UTF-8"
+#pragma rtGlobals=3 // Use modern global access method and strict wave access.
+#pragma rtFunctionErrors=1
+#pragma ModuleName=HistoricEochClipping
+
+/// UTF_TD_GENERATOR GetHistoricDataFiles
+static Function TestEpochClipping([string str])
+
+	string abWin, sweepBrowsers, file, bsPanel, sbWin
+	variable jsonId
+
+	file = "input:" + str
+
+	[abWin, sweepBrowsers] = OpenAnalysisBrowser({file}, loadSweeps = 1)
+	sbWin = StringFromList(0, sweepBrowsers)
+	CHECK_PROPER_STR(sbWin)
+	bsPanel = BSP_GetPanel(sbWin)
+
+	jsonId = MIES_SF#SF_FormulaParser("data(\"Stimset;\", select(channels(AD),sweeps()))")
+	CHECK_NEQ_VAR(jsonId, NaN)
+	WAVE/WAVE result = MIES_SF#SF_FormulaExecutor(sbWin, jsonId)
+	JSON_Release(jsonId)
+End


### PR DESCRIPTION
After
8c6e5da (EP_WriteEpochInfoIntoSweepSettings: Handle unacquired data, 2021-07-13) we corrected the epoch range calculation that epochs are properly clipped to the sweep range. Older data can contain epochs that have ranges beyond the sweep range.

For that data, we needed a workaround that clips epochs or skips outlier epochs:

- epochs outside the sweep range are skipped
- epochs starting within the sweep and ending outside are clipped before retrieving the sweep data in that range.

Note: the original old epoch data in the LBN is not touched.

close https://github.com/AllenInstitute/MIES/issues/1595