### PR TITLE
Speed up TextWaveToList using wfprintf

### DIFF
--- a/Packages/MIES/MIES_SweepFormula_Helpers.ipf
+++ b/Packages/MIES/MIES_SweepFormula_Helpers.ipf
@@ -852,7 +852,7 @@ Function [WAVE/T keys, WAVE/T values] SFH_CreateResultsWaveWithCode(string graph
 
 	WAVE/Z selectData = SF_ExecuteFormula("select()", graph, singleResult=1, useVariables=0)
 	if(WaveExists(selectData))
-		values[0][%$"Sweep Formula sweeps/channels"][INDEP_HEADSTAGE] = NumericWaveToList(selectData, ";")
+		values[0][%$"Sweep Formula sweeps/channels"][INDEP_HEADSTAGE] = NumericWaveToList(selectData, ",", colSep = ";")
 	endif
 
 	shPanel = LBV_GetSettingsHistoryPanel(graph)

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -3164,7 +3164,7 @@ threadsafe Function/S NumericWaveToList(WAVE/Z wv, string sep, [string format, s
 	numCols = DimSize(wv, COLS)
 
 	if(numCols > 1)
-		fullFormat = ReplicateString(format + sep, numCols) + colSep
+		fullFormat = ReplicateString(format + colSep, numCols) + sep
 	else
 		fullFormat = format + sep
 	endif

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -3201,7 +3201,8 @@ threadsafe Function/WAVE ListToNumericWave(list, sep, [type])
 		type = IGOR_TYPE_64BIT_FLOAT
 	endif
 
-	Make/FREE/Y=(type)/N=(ItemsInList(list, sep)) wv = str2num(StringFromList(p, list, sep))
+	Make/FREE/Y=(type)/N=(ItemsInList(list, sep)) wv
+	MultiThread wv = str2num(StringFromList(p, list, sep))
 
 	return wv
 End

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -2888,6 +2888,7 @@ threadsafe Function/S TextWaveToList(WAVE/T/Z txtWave, string rowSep, [string co
 	string entry, seps
 	string list = ""
 	variable i, j, k, l, lasti, lastj, lastk, lastl, numRows, numCols, numLayers, numChunks, count, done
+	variable numColsLoop, numLayersLoop, numChunksLoop
 
 	if(!WaveExists(txtWave))
 		return ""
@@ -2927,15 +2928,17 @@ threadsafe Function/S TextWaveToList(WAVE/T/Z txtWave, string rowSep, [string co
 	if(numRows == 0)
 		return list
 	endif
-
-	numCols = max(1, DimSize(txtWave, COLS))
-	numLayers = max(1, DimSize(txtWave, LAYERS))
-	numChunks = max(1, DimSize(txtWave, CHUNKS))
+	numCols = DimSize(txtWave, COLS)
+	numLayers = DimSize(txtWave, LAYERS)
+	numChunks = DimSize(txtWave, CHUNKS)
+	numColsLoop = max(1, numCols)
+	numLayersLoop = max(1, numLayers)
+	numChunksLoop = max(1, numChunks)
 
 	for(i = 0; i < numRows; i += 1)
-		for(j = 0; j < numCols; j += 1)
-			for(k = 0; k < numLayers; k += 1)
-				for(l = 0; l < numChunks; l += 1)
+		for(j = 0; j < numColsLoop; j += 1)
+			for(k = 0; k < numLayersLoop; k += 1)
+				for(l = 0; l < numChunksLoop; l += 1)
 					entry = txtWave[i][j][k][l]
 
 					if(stopOnEmpty && IsEmpty(entry))
@@ -2993,15 +2996,15 @@ threadsafe Function/S TextWaveToList(WAVE/T/Z txtWave, string rowSep, [string co
 		return list
 	endif
 
-	if(numChunks > 1)
+	if(numChunks)
 		list += chunkSep
 	endif
 
-	if(numLayers > 1)
+	if(numLayers)
 		list += layerSep
 	endif
 
-	if(numCols > 1)
+	if(numCols)
 		list += colSep
 	endif
 

--- a/Packages/tests/Basic/UTF_Utils.ipf
+++ b/Packages/tests/Basic/UTF_Utils.ipf
@@ -4154,7 +4154,7 @@ Function NWLWorks()
 
 	Make/FREE dataFP = {{1, 2, 3}, {4, 5, 6}}
 	result = NumericWaveToList(dataFP, ";")
-	expected = "1;4;,2;5;,3;6;,"
+	expected = "1,4,;2,5,;3,6,;"
 	CHECK_EQUAL_STR(result, expected)
 
 	Make/FREE/N=0 dataEmpty

--- a/Packages/tests/Basic/UTF_Utils.ipf
+++ b/Packages/tests/Basic/UTF_Utils.ipf
@@ -2787,6 +2787,32 @@ Function TWTLMaxElements()
 	CHECK_EQUAL_STR(list, refList)
 End
 
+static Function TWTLSingleElementNDSeparators()
+
+	string list
+	string refList
+
+	Make/FREE/T/N=(1, 1, 1, 1) wt = "test"
+	list = TextWaveToList(wt, ";")
+	refList = "test/:,;"
+	CHECK_EQUAL_STR(list, refList)
+
+	Make/FREE/T/N=(1, 1, 1) wt = "test"
+	list = TextWaveToList(wt, ";")
+	refList = "test:,;"
+	CHECK_EQUAL_STR(list, refList)
+
+	Make/FREE/T/N=(1, 1) wt = "test"
+	list = TextWaveToList(wt, ";")
+	refList = "test,;"
+	CHECK_EQUAL_STR(list, refList)
+
+	Make/FREE/T/N=(1) wt = "test"
+	list = TextWaveToList(wt, ";")
+	refList = "test;"
+	CHECK_EQUAL_STR(list, refList)
+End
+
 Function/WAVE SomeTextWaves()
 	Make/WAVE/FREE/N=5 all
 


### PR DESCRIPTION
- for IP9+ because wfprintf only supports long strings since
- NumericWaveToList and TextWaveToList use now the same functions
- for 1D and 2D waves only

close https://github.com/AllenInstitute/MIES/issues/1779