### PR TITLE
Prepare TTL epochs

### DIFF
--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -38,7 +38,7 @@ Constant SWEEP_EPOCH_VERSION = 7
 /// - New/Changed layers of entries
 ///
 /// @{
-Constant LABNOTEBOOK_VERSION = 70
+Constant LABNOTEBOOK_VERSION = 71
 Constant RESULTS_VERSION     = 2
 /// @}
 

--- a/Packages/MIES/MIES_DAC-Hardware.ipf
+++ b/Packages/MIES/MIES_DAC-Hardware.ipf
@@ -1987,6 +1987,8 @@ threadsafe Function HW_ITC_GetRackRange(rack, first, last)
 	else
 		ASSERT_TS(0, "Invalid rack parameter")
 	endif
+
+	ASSERT_TS(last - first + 1 ==  NUM_ITC_TTL_BITS_PER_RACK, "Rack channel range must be NUM_ITC_TTL_BITS_PER_RACK for each rack")
 End
 
 /// @brief Clip the ttlBit to adapt for differences in notation

--- a/Packages/MIES/MIES_DataConfigurator.ipf
+++ b/Packages/MIES/MIES_DataConfigurator.ipf
@@ -1771,9 +1771,6 @@ static Function DC_ITC_MakeTTLWave(device, rackNo)
 	WAVE/T allSetNames = DAG_GetChannelTextual(device, CHANNEL_TYPE_TTL, CHANNEL_CONTROL_WAVE)
 	WAVE/T allSetNamesIndexingEnd = DAG_GetChannelTextual(device, CHANNEL_TYPE_TTL, CHANNEL_CONTROL_INDEX_END)
 
-	WAVE sweepDataLNB      = GetSweepSettingsWave(device)
-	WAVE/T sweepDataTxTLNB = GetSweepSettingsTextWave(device)
-
 	HW_ITC_GetRackRange(rackNo, first, last)
 
 	for(i = first; i <= last; i += 1)
@@ -1834,21 +1831,21 @@ static Function DC_ITC_MakeTTLWave(device, rackNo)
 	endfor
 
 	if(rackNo == RACK_ZERO)
-		sweepDataLNB[0][%$"TTL rack zero bits"][INDEP_HEADSTAGE]                = bits
-		sweepDataTxTLNB[0][%$"TTL rack zero stim sets"][INDEP_HEADSTAGE]        = listOfSets
-		sweepDataTxTLNB[0][%$"TTL rack zero set sweep counts"][INDEP_HEADSTAGE] = setSweepCounts
-		sweepDataTxTLNB[0][%$"TTL rack zero set cycle counts"][INDEP_HEADSTAGE] = setCycleCounts
+		DC_DocumentChannelProperty(device, "rack zero bits", INDEP_HEADSTAGE, NaN, XOP_CHANNEL_TYPE_TTL, var=bits)
+		DC_DocumentChannelProperty(device, "rack zero stim sets", INDEP_HEADSTAGE, NaN, XOP_CHANNEL_TYPE_TTL, str=listOfSets)
+		DC_DocumentChannelProperty(device, "rack zero set sweep counts", INDEP_HEADSTAGE, NaN, XOP_CHANNEL_TYPE_TTL, str=setSweepCounts)
+		DC_DocumentChannelProperty(device, "rack zero set cycle counts", INDEP_HEADSTAGE, NaN, XOP_CHANNEL_TYPE_TTL, str=setCycleCounts)
 	else
-		sweepDataLNB[0][%$"TTL rack one bits"][INDEP_HEADSTAGE]                = bits
-		sweepDataTxTLNB[0][%$"TTL rack one stim sets"][INDEP_HEADSTAGE]        = listOfSets
-		sweepDataTxTLNB[0][%$"TTL rack one set sweep counts"][INDEP_HEADSTAGE] = setSweepCounts
-		sweepDataTxTLNB[0][%$"TTL rack one set cycle counts"][INDEP_HEADSTAGE] = setCycleCounts
+		DC_DocumentChannelProperty(device, "rack one bits", INDEP_HEADSTAGE, NaN, XOP_CHANNEL_TYPE_TTL, var=bits)
+		DC_DocumentChannelProperty(device, "rack one stim sets", INDEP_HEADSTAGE, NaN, XOP_CHANNEL_TYPE_TTL, str=listOfSets)
+		DC_DocumentChannelProperty(device, "rack one set sweep counts", INDEP_HEADSTAGE, NaN, XOP_CHANNEL_TYPE_TTL, str=setSweepCounts)
+		DC_DocumentChannelProperty(device, "rack one set cycle counts", INDEP_HEADSTAGE, NaN, XOP_CHANNEL_TYPE_TTL, str=setCycleCounts)
 	endif
 
-	sweepDataTxTLNB[0][%$"TTL Indexing End stimset"][INDEP_HEADSTAGE] = indexingEndStimset
-	sweepDataTxTLNB[0][%$"TTL Stimset wave note"][INDEP_HEADSTAGE]    = stimSetWaveNote
-	sweepDataTxTLNB[0][%$"TTL Stim Wave Checksum"][INDEP_HEADSTAGE]   = stimSetChecksum
-	sweepDataTxTLNB[0][%$"TTL Stim set length"][INDEP_HEADSTAGE]      = stimSetLength
+	DC_DocumentChannelProperty(device, "Indexing End stimset", INDEP_HEADSTAGE, NaN, XOP_CHANNEL_TYPE_TTL, str=indexingEndStimset)
+	DC_DocumentChannelProperty(device, "Stimset wave note", INDEP_HEADSTAGE, NaN, XOP_CHANNEL_TYPE_TTL, str=stimSetWaveNote)
+	DC_DocumentChannelProperty(device, "Stim Wave Checksum", INDEP_HEADSTAGE, NaN, XOP_CHANNEL_TYPE_TTL, str=stimSetChecksum)
+	DC_DocumentChannelProperty(device, "Stim set length", INDEP_HEADSTAGE, NaN, XOP_CHANNEL_TYPE_TTL, str=stimSetLength)
 End
 
 static Function DC_NI_MakeTTLWave(device)
@@ -1869,8 +1866,6 @@ static Function DC_NI_MakeTTLWave(device)
 	WAVE/T allSetNames = DAG_GetChannelTextual(device, CHANNEL_TYPE_TTL, CHANNEL_CONTROL_WAVE)
 	WAVE/T allSetNamesIndexingEnd = DAG_GetChannelTextual(device, CHANNEL_TYPE_TTL, CHANNEL_CONTROL_INDEX_END)
 	WAVE/WAVE TTLWave = GetTTLWave(device)
-
-	WAVE/T sweepDataTxTLNB = GetSweepSettingsTextWave(device)
 
 	for(i = 0; i < NUM_DA_TTL_CHANNELS; i += 1)
 
@@ -1907,14 +1902,14 @@ static Function DC_NI_MakeTTLWave(device)
 		TTLWave[i] = TTLWaveSingle
 	endfor
 
-	sweepDataTxTLNB[0][%$"TTL channels"][INDEP_HEADSTAGE]             = channels
-	sweepDataTxTLNB[0][%$"TTL stim sets"][INDEP_HEADSTAGE]            = listOfSets
-	sweepDataTxTLNB[0][%$"TTL set sweep counts"][INDEP_HEADSTAGE]     = setSweepCounts
-	sweepDataTxTLNB[0][%$"TTL set cycle counts"][INDEP_HEADSTAGE]     = setCycleCounts
-	sweepDataTxTLNB[0][%$"TTL Indexing End stimset"][INDEP_HEADSTAGE] = indexingEndStimset
-	sweepDataTxTLNB[0][%$"TTL Stimset wave note"][INDEP_HEADSTAGE]    = stimSetWaveNote
-	sweepDataTxTLNB[0][%$"TTL Stim Wave Checksum"][INDEP_HEADSTAGE]   = stimSetChecksum
-	sweepDataTxTLNB[0][%$"TTL Stim set length"][INDEP_HEADSTAGE]      = stimSetLength
+	DC_DocumentChannelProperty(device, "channels", INDEP_HEADSTAGE, NaN, XOP_CHANNEL_TYPE_TTL, str=channels)
+	DC_DocumentChannelProperty(device, "stim sets", INDEP_HEADSTAGE, NaN, XOP_CHANNEL_TYPE_TTL, str=listOfSets)
+	DC_DocumentChannelProperty(device, "set sweep counts", INDEP_HEADSTAGE, NaN, XOP_CHANNEL_TYPE_TTL, str=setSweepCounts)
+	DC_DocumentChannelProperty(device, "set cycle counts", INDEP_HEADSTAGE, NaN, XOP_CHANNEL_TYPE_TTL, str=setCycleCounts)
+	DC_DocumentChannelProperty(device, "Indexing End stimset", INDEP_HEADSTAGE, NaN, XOP_CHANNEL_TYPE_TTL, str=indexingEndStimset)
+	DC_DocumentChannelProperty(device, "Stimset wave note", INDEP_HEADSTAGE, NaN, XOP_CHANNEL_TYPE_TTL, str=stimSetWaveNote)
+	DC_DocumentChannelProperty(device, "Stim Wave Checksum", INDEP_HEADSTAGE, NaN, XOP_CHANNEL_TYPE_TTL, str=stimSetChecksum)
+	DC_DocumentChannelProperty(device, "Stim set length", INDEP_HEADSTAGE, NaN, XOP_CHANNEL_TYPE_TTL, str=stimSetLength)
 End
 
 /// @brief Returns column number/step of the stimulus set, independent of the times the set is being cycled through

--- a/Packages/MIES/MIES_DataConfigurator.ipf
+++ b/Packages/MIES/MIES_DataConfigurator.ipf
@@ -1683,6 +1683,11 @@ Function DC_DocumentChannelProperty(device, entry, headstage, channelNumber, cha
 	WAVE/T sweepDataLNBKey    = GetSweepSettingsKeyWave(device)
 	WAVE/T sweepDataTxTLNBKey = GetSweepSettingsTextKeyWave(device)
 
+	if(channelType == XOP_CHANNEL_TYPE_TTL)
+		ASSERT(headstage == INDEP_HEADSTAGE, "sweepNB entry for TTL must target INDEP_HEADSTAGE")
+		entry = CreateTTLChannelLBNKey(entry, channelNumber)
+	endif
+
 	if(!ParamIsDefault(var))
 		colData = FindDimLabel(sweepDataLNB, COLS, entry)
 		colKey  = FindDimLabel(sweepDataLNBKey, COLS, entry)

--- a/Packages/MIES/MIES_DataConfigurator.ipf
+++ b/Packages/MIES/MIES_DataConfigurator.ipf
@@ -1328,7 +1328,7 @@ static Function [STRUCT DataConfigurationResult s] DC_GetConfiguration(string de
 	WAVE s.ADCList = GetADCListFromConfig(config)
 	WAVE s.TTLList = GetTTLListFromConfig(config)
 
-	s.numTTLEntries = DimSize(s.DACList, ROWS)
+	s.numTTLEntries = DimSize(s.TTLList, ROWS)
 
 	s.numDACEntries = DimSize(s.DACList, ROWS)
 	Make/D/FREE/N=(s.numDACEntries) s.insertStart, s.setLength, s.setColumn, s.headstageDAC, s.setCycleCount

--- a/Packages/MIES/MIES_DataConfigurator.ipf
+++ b/Packages/MIES/MIES_DataConfigurator.ipf
@@ -1676,6 +1676,7 @@ Function DC_DocumentChannelProperty(device, entry, headstage, channelNumber, cha
 	string ua_entry
 
 	ASSERT(ParamIsDefault(var) + ParamIsDefault(str) == 1, "Exactly one of var or str has to be supplied")
+	ASSERT(!IsEmpty(entry), "Entry must be non-empty")
 
 	WAVE sweepDataLNB         = GetSweepSettingsWave(device)
 	WAVE/T sweepDataTxTLNB    = GetSweepSettingsTextWave(device)

--- a/Packages/MIES/MIES_DataConfigurator.ipf
+++ b/Packages/MIES/MIES_DataConfigurator.ipf
@@ -1833,7 +1833,7 @@ static Function DC_ITC_MakeTTLWave(string device, STRUCT DataConfigurationResult
 			continue
 		endif
 
-		setLength[i] = num2istr(DimSize(s.TTLStimSet[i], ROWS))
+		setLength[i] = num2istr(s.TTLsetLength[i])
 		indexingEndStimSet[i] = allSetNamesIndexingEnd[i]
 		waveNote[i] = URLEncode(note(s.TTLstimSet[i]))
 		checksum[i] = num2istr(WB_GetStimsetChecksum(s.TTLstimSet[i], s.TTLsetName[i], DATA_ACQUISITION_MODE))
@@ -1880,7 +1880,7 @@ static Function DC_NI_MakeTTLWave(string device, STRUCT DataConfigurationResult 
 			continue
 		endif
 
-		setLength[i] = num2istr(DimSize(s.TTLStimSet[i], ROWS))
+		setLength[i] = num2istr(s.TTLsetLength[i])
 		setName[i] = s.TTLsetName[i]
 		setColumn[i] = num2istr(s.TTLsetColumn[i])
 		cycleCount[i] = num2istr(s.TTLcycleCount[i])

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -876,7 +876,7 @@ End
 ///
 /// @sa GetLastSettingChannel
 threadsafe static Function [WAVE/Z wv, variable index] GetLastSettingChannelInternal(WAVE numericalValues, WAVE values, variable sweepNo, string setting, variable channelNumber, variable channelType, variable entrySourceType)
-	string entryName
+	string entryName, settingTTL
 	variable headstage, indep
 
 	switch(channelType)
@@ -885,6 +885,21 @@ threadsafe static Function [WAVE/Z wv, variable index] GetLastSettingChannelInte
 			break
 		case XOP_CHANNEL_TYPE_ADC:
 			entryName = "ADC"
+			break
+		case XOP_CHANNEL_TYPE_TTL:
+			settingTTL = CreateTTLChannelLBNKey(setting, channelNumber)
+			WAVE/Z settings = GetLastSetting(values, sweepNo, settingTTL, entrySourceType)
+			if(WaveExists(settings))
+				return [settings, INDEP_HEADSTAGE]
+			endif
+
+			WAVE/Z settings = GetLastSetting(values, sweepNo, setting, entrySourceType)
+			if(WaveExists(settings))
+				return [settings, INDEP_HEADSTAGE]
+			endif
+
+			return [$"", NaN]
+
 			break
 		default:
 			ASSERT_TS(0, "Unsupported channelType")
@@ -5530,6 +5545,18 @@ threadsafe Function/S CreateLBNUnassocKey(setting, channelNumber, channelType)
 	endif
 
 	return key
+End
+
+/// @brief Create a LBN key for TTL channels
+threadsafe Function/S CreateTTLChannelLBNKey(string entry, variable channelNumber)
+
+	if(IsNaN(channelNumber))
+		return "TTL " + entry
+	endif
+
+	sprintf entry, "TTL %s Channel %d", entry, channelNumber
+
+	return entry
 End
 
 /// @brief Check if the given labnotebook entry is from an unassociated DA/AD channel

--- a/Packages/MIES/MIES_Structures.ipf
+++ b/Packages/MIES/MIES_Structures.ipf
@@ -533,12 +533,15 @@ Structure DataConfigurationResult
 
 	/// Stimulus set name
 	WAVE/T setName
+	WAVE/T TTLsetName
 
 	/// Stimulus set wave (2D)
 	WAVE/WAVE stimSet
+	WAVE/WAVE TTLstimSet
 
 	/// @sa DC_CalculateStimsetLength()
 	WAVE/D setLength
+	WAVE/D TTLsetLength
 
 	/// Headstage of DAC if associated, `NaN` iff unassociated
 	WAVE/D headstageDAC
@@ -546,7 +549,9 @@ Structure DataConfigurationResult
 	/// @sa DC_CalculateChannelColumnNo()
 	/// @{
 	WAVE/D setColumn
+	WAVE/D TTLsetColumn
 	WAVE/D setCycleCount
+	WAVE/D TTLcycleCount
 	/// @}
 
 	/// Offset in points where the stimulus set starts in the DAQ data wave

--- a/Packages/tests/Basic/UTF_Labnotebook.ipf
+++ b/Packages/tests/Basic/UTF_Labnotebook.ipf
@@ -716,13 +716,8 @@ static Function Test_GetHeadstageForChannel()
 	CHECK_EQUAL_VAR(hs, NaN)
 
 	channel = 6
-	try
-		hs = GetHeadstageForChannel(numericalValues, sweepNo, XOP_CHANNEL_TYPE_TTL, channel, DATA_ACQUISITION_MODE); AbortOnRTE
-		FAIL()
-	catch
-		PASS()
-		ClearRTError()
-	endtry
+	hs = GetHeadstageForChannel(numericalValues, sweepNo, XOP_CHANNEL_TYPE_TTL, channel, DATA_ACQUISITION_MODE)
+	CHECK_EQUAL_VAR(hs, INDEP_HEADSTAGE)
 	hs = GetHeadstageForChannel(numericalValues, sweepNo, XOP_CHANNEL_TYPE_DAC, channel, TEST_PULSE_MODE)
 	CHECK_EQUAL_VAR(hs, NaN)
 	hs = GetHeadstageForChannel(numericalValues, sweepNo, XOP_CHANNEL_TYPE_ADC, channel, UNKNOWN_MODE)

--- a/Packages/tests/HardwareBasic/UTF_BasicHardwareTests.ipf
+++ b/Packages/tests/HardwareBasic/UTF_BasicHardwareTests.ipf
@@ -364,8 +364,8 @@ End
 static Function UnassociatedChannelsAndTTLs_REENTRY([str])
 	string str
 
-	string device, sweeps, configs, unit, expectedStr
-	variable numEntries, i, j, k, numSweeps, numRacks, hardwareType
+	string device, sweeps, configs, unit, expectedStr, stimSetLengths2
+	variable numEntries, i, j, k, numSweeps, numRacks, hardwareType, index
 
 	numSweeps = 1
 
@@ -439,7 +439,16 @@ static Function UnassociatedChannelsAndTTLs_REENTRY([str])
 			WAVE/Z ttlStimSets = GetTTLLabnotebookEntry(textualValues, LABNOTEBOOK_TTL_STIMSETS, j)
 			WAVE/T/Z foundIndexingEndStimSets = GetLastSetting(textualValues, j, "TTL Indexing End stimset", DATA_ACQUISITION_MODE)
 			WAVE/T/Z stimWaveChecksums = GetLastSetting(textualValues, j, "TTL Stim Wave Checksum", DATA_ACQUISITION_MODE)
+
 			WAVE/Z stimSetLengths = GetLastSetting(textualValues, j, "TTL Stim set length", DATA_ACQUISITION_MODE)
+			WAVE/Z settings = $""
+			[settings, index] = GetLastSettingChannel(numericalValues, textualValues, j, "TTL Stim set length", 1, XOP_CHANNEL_TYPE_TTL, DATA_ACQUISITION_MODE)
+			CHECK_WAVE(settings, TEXT_WAVE)
+			CHECK_EQUAL_VAR(index, INDEP_HEADSTAGE)
+			WAVE/T settingsT = settings
+			stimSetLengths2 = settingsT[index]
+			WAVE/T stimSetLengthsT = stimSetLengths
+			CHECK_EQUAL_STR(stimSetLengths2, stimSetLengthsT[INDEP_HEADSTAGE])
 
 			switch(hardwareType)
 				case HARDWARE_ITC_DAC:
@@ -565,8 +574,6 @@ static Function UnassociatedChannelsAndTTLs_REENTRY([str])
 			// hardware agnostic TTL entries
 			WAVE/Z settings = GetLastSetting(textualValues, j, "TTL Stimset wave note", DATA_ACQUISITION_MODE)
 			CHECK_WAVE(settings, TEXT_WAVE)
-
-			Variable index
 
 			// fetch some labnotebook entries, the last channel is unassociated
 			for(k = 0; k < DimSize(ADCs, ROWS); k += 1)

--- a/Packages/tests/HardwareBasic/UTF_BasicHardwareTests.ipf
+++ b/Packages/tests/HardwareBasic/UTF_BasicHardwareTests.ipf
@@ -542,9 +542,9 @@ static Function UnassociatedChannelsAndTTLs_REENTRY([str])
 
 					// Stim set length
 					if(numRacks == 2)
-						CHECK_EQUAL_TEXTWAVES(stimSetLengths, {"", "", "", "", "", "", "", "", ";190001;;185001;;190001;;185001;"})
+						CHECK_EQUAL_TEXTWAVES(stimSetLengths, {"", "", "", "", "", "", "", "", ";38000;;37000;;38000;;37000;"})
 					else
-						CHECK_EQUAL_TEXTWAVES(stimSetLengths, {"", "", "", "", "", "", "", "", ";190001;;185001;;;;;"})
+						CHECK_EQUAL_TEXTWAVES(stimSetLengths, {"", "", "", "", "", "", "", "", ";38000;;37000;;;;;"})
 					endif
 
 					break
@@ -566,7 +566,7 @@ static Function UnassociatedChannelsAndTTLs_REENTRY([str])
 
 					CHECK_EQUAL_TEXTWAVES(foundIndexingEndStimSets, {"", "", "", "", "", "", "", "", ";- none -;;- none -;;- none -;;- none -;"})
 					CHECK(GrepString(stimWaveChecksums[INDEP_HEADSTAGE], ";[[:digit:]]+;;[[:digit:]]+;;[[:digit:]]+;;[[:digit:]]+;"))
-					CHECK_EQUAL_TEXTWAVES(stimSetLengths, {"", "", "", "", "", "", "", "", ";190001;;185001;;190001;;185001;"})
+					CHECK_EQUAL_TEXTWAVES(stimSetLengths, {"", "", "", "", "", "", "", "", ";158334;;154167;;158334;;154167;"})
 
 					break
 			endswitch


### PR DESCRIPTION
This PR updates the DataConfigurator module to gather more information for TTL channels that are used in [a future PR](https://github.com/AllenInstitute/MIES/pull/1791) to introduce epochs for TTL channels.

Fixes:
- s.numTTLEntries are actually the number of TTL entries now, were wrongly the number of DACEntries until now.
- the saved stim set length in the LNB for TTL were the non-decimated lengths. For all other channel types the decimated lengths are saved, this was also taken over for TTL now
- DC_ITC_MakeTTLWave was called for each rack and gathered some LNB information for all channels on every call

close https://github.com/AllenInstitute/MIES/issues/1796