### PR TITLE
Bugfix AcquireData_NG ignored TTL channels 4-7 in setup for NI HW

### DIFF
--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -4710,10 +4710,10 @@ threadsafe static Function/WAVE GetTTLChannelsOrBits(WAVE numericalValues, WAVE 
 
 	if(WaveExists(ttlChannels))
 		// NI hardware
-		return ListToNumericWave(ttlChannels[index], ";", type = IGOR_TYPE_32BIT_FLOAT)
+		return ListToNumericWave(ttlChannels[index], ";")
 	elseif(WaveExists(ttlBitsRackZero) || WaveExists(ttlBitsRackOne))
 		// ITC hardware
-		Make/FREE/Y=(IGOR_TYPE_32BIT_FLOAT)/N=(NUM_DA_TTL_CHANNELS) entries = NaN
+		Make/FREE/D/N=(NUM_DA_TTL_CHANNELS) entries = NaN
 
 		if(WaveExists(ttlBitsRackZero))
 			HW_ITC_GetRackRange(RACK_ZERO, first, last)

--- a/Packages/tests/UTF_HardwareHelperFunctions.ipf
+++ b/Packages/tests/UTF_HardwareHelperFunctions.ipf
@@ -1480,9 +1480,9 @@ Function AcquireData_NG(STRUCT DAQSettings &s, string device)
 		endif
 
 		if(i >= NUM_ITC_TTL_BITS_PER_RACK                 \
-		   && (GetHardwareType(device) == HARDWARE_NI_DAC \
-		       || HW_ITC_GetNumberOfRacks(device) < 2))
-			// ignore unavailable TTLs
+		   && GetHardwareType(device) == HARDWARE_ITC_DAC \
+			   && HW_ITC_GetNumberOfRacks(device) < 2)
+			// ignore unavailable TTLs on single-rack ITC setup
 			continue
 		endif
 


### PR DESCRIPTION
Also adapted the TTL test UnassociatedChannelsAndTTLs to check against the correct setup.