### PR TITLE
CONF: Clear HS association on DAEphys window restore for HS w/o amp

### DIFF
--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -510,7 +510,7 @@ Function CONF_RestoreWindow(string fName, [string rigFile])
 		if(ClearRTError())
 			ASSERT(0, errMsg)
 		else
-			printf "Configuration restore aborted at file %s.", fName
+			printf "Configuration restore aborted at file %s.", fullFilePath
 			Abort
 		endif
 	endtry

--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -2143,12 +2143,12 @@ static Function CONF_GetAmplifierSettings(device)
 
 		ampSerial    = ChanAmpAssign[%AmpSerialNo][i]
 		ampChannelID = ChanAmpAssign[%AmpChannelID][i]
-		JSON_AddString(jsonID, jsonPath + EXPCONFIG_JSON_AMPTITLE, StringFromList(trunc(i / 2), EXPCONFIG_SETTINGS_AMPTITLE))
 
 		if(IsFinite(ampSerial) && IsFinite(ampChannelID))
 
 			JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_AMPSERIAL, ampSerial)
 			JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_AMPCHANNEL, ampChannelID)
+			JSON_AddString(jsonID, jsonPath + EXPCONFIG_JSON_AMPTITLE, StringFromList(trunc(i / 2), EXPCONFIG_SETTINGS_AMPTITLE))
 
 			jsonPath = basePath + "/" + EXPCONFIG_JSON_AMPBLOCK + "/" + EXPCONFIG_JSON_VCBLOCK
 			JSON_AddTreeObject(jsonID, jsonPath)

--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -164,9 +164,17 @@ static StrConstant EXPCONFIG_JSON_AMPSERIAL = "Serial"
 static StrConstant EXPCONFIG_JSON_AMPTITLE = "Title"
 static StrConstant EXPCONFIG_JSON_AMPCHANNEL = "Channel"
 static StrConstant EXPCONFIG_JSON_AMPVCDA = "DA"
+static StrConstant EXPCONFIG_JSON_AMPVCDAGAIN = "DA gain"
+static StrConstant EXPCONFIG_JSON_AMPVCDAUNIT = "DA unit"
 static StrConstant EXPCONFIG_JSON_AMPVCAD = "AD"
+static StrConstant EXPCONFIG_JSON_AMPVCADGAIN = "AD gain"
+static StrConstant EXPCONFIG_JSON_AMPVCADUNIT = "AD unit"
 static StrConstant EXPCONFIG_JSON_AMPICDA = "DA"
+static StrConstant EXPCONFIG_JSON_AMPICDAGAIN = "DA gain"
+static StrConstant EXPCONFIG_JSON_AMPICDAUNIT = "DA unit"
 static StrConstant EXPCONFIG_JSON_AMPICAD = "AD"
+static StrConstant EXPCONFIG_JSON_AMPICADGAIN = "AD gain"
+static StrConstant EXPCONFIG_JSON_AMPICADUNIT = "AD unit"
 static StrConstant EXPCONFIG_JSON_PRESSDEV = "Device"
 static StrConstant EXPCONFIG_JSON_PRESSDA = "DA"
 static StrConstant EXPCONFIG_JSON_PRESSAD = "AD"
@@ -2139,20 +2147,40 @@ static Function CONF_GetAmplifierSettings(device)
 
 		jsonPath = basePath + "/" + EXPCONFIG_JSON_AMPBLOCK
 		JSON_AddTreeObject(jsonID, jsonPath)
+
+		jsonPath = basePath + "/" + EXPCONFIG_JSON_AMPBLOCK + "/" + EXPCONFIG_JSON_VCBLOCK
+		JSON_AddTreeObject(jsonID, jsonPath)
 		jsonPath += "/"
+
+		JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_AMPVCDA, str2numsafe(GetPopupMenuString(device, "Popup_Settings_VC_DA")))
+		JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_AMPVCAD, str2numsafe(GetPopupMenuString(device, "Popup_Settings_VC_AD")))
+		JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_AMPVCDAGAIN, GetSetVariable(device, "setvar_Settings_VC_DAgain"))
+		JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_AMPVCADGAIN, GetSetVariable(device, "setvar_Settings_VC_ADgain"))
+		JSON_AddString(jsonID, jsonPath + EXPCONFIG_JSON_AMPVCDAUNIT, GetSetVariableString(device, "SetVar_Hardware_VC_DA_Unit"))
+		JSON_AddString(jsonID, jsonPath + EXPCONFIG_JSON_AMPVCADUNIT, GetSetVariableString(device, "SetVar_Hardware_VC_AD_Unit"))
+
+		jsonPath = basePath + "/" + EXPCONFIG_JSON_AMPBLOCK + "/" + EXPCONFIG_JSON_ICBLOCK
+		JSON_AddTreeObject(jsonID, jsonPath)
+		jsonPath += "/"
+
+		JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_AMPICDA, str2num(GetPopupMenuString(device, "Popup_Settings_IC_DA")))
+		JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_AMPICAD, str2num(GetPopupMenuString(device, "Popup_Settings_IC_AD")))
+		JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_AMPICDAGAIN, GetSetVariable(device, "setvar_Settings_IC_DAgain"))
+		JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_AMPICADGAIN, GetSetVariable(device, "setvar_Settings_IC_ADgain"))
+		JSON_AddString(jsonID, jsonPath + EXPCONFIG_JSON_AMPICDAUNIT, GetSetVariableString(device, "SetVar_Hardware_IC_DA_Unit"))
+		JSON_AddString(jsonID, jsonPath + EXPCONFIG_JSON_AMPICADUNIT, GetSetVariableString(device, "SetVar_Hardware_IC_AD_Unit"))
 
 		ampSerial    = ChanAmpAssign[%AmpSerialNo][i]
 		ampChannelID = ChanAmpAssign[%AmpChannelID][i]
-
 		if(IsFinite(ampSerial) && IsFinite(ampChannelID))
 
+			jsonPath = basePath + "/" + EXPCONFIG_JSON_AMPBLOCK + "/"
+
+			JSON_AddString(jsonID, jsonPath + EXPCONFIG_JSON_AMPTITLE, StringFromList(trunc(i / 2), EXPCONFIG_SETTINGS_AMPTITLE))
 			JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_AMPSERIAL, ampSerial)
 			JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_AMPCHANNEL, ampChannelID)
-			JSON_AddString(jsonID, jsonPath + EXPCONFIG_JSON_AMPTITLE, StringFromList(trunc(i / 2), EXPCONFIG_SETTINGS_AMPTITLE))
 
-			jsonPath = basePath + "/" + EXPCONFIG_JSON_AMPBLOCK + "/" + EXPCONFIG_JSON_VCBLOCK
-			JSON_AddTreeObject(jsonID, jsonPath)
-			jsonPath += "/"
+			jsonPath = basePath + "/" + EXPCONFIG_JSON_AMPBLOCK + "/" + EXPCONFIG_JSON_VCBLOCK + "/"
 
 			// read VC settings
 			DAP_ChangeHeadStageMode(device, V_CLAMP_MODE, i, DO_MCC_MIES_SYNCING)
@@ -2170,16 +2198,11 @@ static Function CONF_GetAmplifierSettings(device)
 			JSON_AddBoolean(jsonID, jsonPath + EXPCONFIG_JSON_AMP_RS_COMP_ENABLE, DAG_GetNumericalValue(device, "check_DatAcq_RsCompEnable"))
 			JSON_AddBoolean(jsonID, jsonPath + EXPCONFIG_JSON_AMP_COMP_CHAIN, DAG_GetNumericalValue(device, "check_DataAcq_Amp_Chain"))
 
-			JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_AMPVCDA, str2num(GetPopupMenuString(device, "Popup_Settings_VC_DA")))
-			JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_AMPVCAD, str2num(GetPopupMenuString(device, "Popup_Settings_VC_AD")))
-
 			// MCC settings without GUI control
 			JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_AMP_LPF, AI_SendToAmp(device, i, V_CLAMP_MODE, MCC_GETPRIMARYSIGNALLPF_FUNC, NaN))
 			JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_AMP_GAIN, AI_SendToAmp(device, i, V_CLAMP_MODE, MCC_GETPRIMARYSIGNALGAIN_FUNC, NaN))
 
-			jsonPath = basePath + "/" + EXPCONFIG_JSON_AMPBLOCK + "/" + EXPCONFIG_JSON_ICBLOCK
-			JSON_AddTreeObject(jsonID, jsonPath)
-			jsonPath += "/"
+			jsonPath = basePath + "/" + EXPCONFIG_JSON_AMPBLOCK + "/" + EXPCONFIG_JSON_ICBLOCK + "/"
 
 			// read IC settings
 			DAP_ChangeHeadStageMode(device, I_CLAMP_MODE, i, DO_MCC_MIES_SYNCING)
@@ -2200,9 +2223,6 @@ static Function CONF_GetAmplifierSettings(device)
 
 			JSON_AddVariable(jsonID,  jsonPath + EXPCONFIG_JSON_AMP_PIPETTE_OFFSET_IC, DAG_GetNumericalValue(device, "setvar_DataAcq_PipetteOffset_IC"))
 
-			JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_AMPICDA, str2num(GetPopupMenuString(device, "Popup_Settings_IC_DA")))
-			JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_AMPICAD, str2num(GetPopupMenuString(device, "Popup_Settings_IC_AD")))
-
 			// MCC settings without GUI control
 			JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_AMP_LPF, AI_SendToAmp(device, i, I_CLAMP_MODE, MCC_GETPRIMARYSIGNALLPF_FUNC, NaN))
 			JSON_AddVariable(jsonID, jsonPath + EXPCONFIG_JSON_AMP_GAIN, AI_SendToAmp(device, i, I_CLAMP_MODE, MCC_GETPRIMARYSIGNALGAIN_FUNC, NaN))
@@ -2211,6 +2231,7 @@ static Function CONF_GetAmplifierSettings(device)
 				DAP_ChangeHeadStageMode(device, clampMode, i, DO_MCC_MIES_SYNCING)
 			endif
 		else
+			jsonPath = basePath + "/" + EXPCONFIG_JSON_AMPBLOCK + "/"
 			JSON_AddNull(jsonID, jsonPath + EXPCONFIG_JSON_AMPSERIAL)
 			JSON_AddNull(jsonID, jsonPath + EXPCONFIG_JSON_AMPCHANNEL)
 		endif

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -18,7 +18,7 @@
 Constant DAQ_CONFIG_WAVE_VERSION = 2
 
 /// Used to upgrade the GuiStateWave as well as the DA Ephys panel
-Constant DA_EPHYS_PANEL_VERSION           = 63
+Constant DA_EPHYS_PANEL_VERSION           = 64
 Constant DATA_SWEEP_BROWSER_PANEL_VERSION = 47
 Constant WAVEBUILDER_PANEL_VERSION        = 14
 Constant ANALYSISBROWSER_PANEL_VERSION    =  3

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -18,7 +18,7 @@
 Constant DAQ_CONFIG_WAVE_VERSION = 2
 
 /// Used to upgrade the GuiStateWave as well as the DA Ephys panel
-Constant DA_EPHYS_PANEL_VERSION           = 62
+Constant DA_EPHYS_PANEL_VERSION           = 63
 Constant DATA_SWEEP_BROWSER_PANEL_VERSION = 47
 Constant WAVEBUILDER_PANEL_VERSION        = 14
 Constant ANALYSISBROWSER_PANEL_VERSION    =  3

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -2495,7 +2495,7 @@ static Function DAP_CheckHeadStage(device, headStage, mode)
 	endif
 
 	if(!IsFinite(DACchannel) || !IsFinite(ADCchannel))
-		printf "(%s) Please select a valid DA and AD channel in \"DAC Channel and Device Associations\" in the Hardware tab.\r", device
+		printf "(%s) Please select a valid DA and AD channel in \"DAC Channel and Device Associations\" in the Hardware tab for headstage %d.\r", device, headstage
 		ControlWindowToFront()
 		return 1
 	endif

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -627,7 +627,6 @@ Function DAP_EphysPanelStartUpSettings()
 	SetControlUserData(device, "Check_Settings_BkgTP", "oldState", "")
 	SetControlUserData(device, "Check_Settings_BackgrndDataAcq", "oldState", "")
 	SetControlUserData(device, "check_Settings_TP_SaveTP", "oldState", "")
-	SetControlUserData(device, "check_Settings_SaveAmpSettings", "oldState", "")
 
 	CheckBox Check_Settings_BkgTP, WIN = $device,value= 1
 	CheckBox Check_Settings_BackgrndDataAcq, WIN = $device, value= 1
@@ -5076,8 +5075,6 @@ Function DAP_CheckProc_RequireAmplifier(cba) : CheckBoxControl
 			checked = cba.checked
 			device  = cba.win
 			DAG_Update(device, cba.ctrlName, val = checked)
-
-			AdaptDependentControls(device, "check_Settings_SaveAmpSettings", CHECKBOX_SELECTED, checked, DEP_CTRLS_SAME)
 			break
 	endswitch
 

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -4792,48 +4792,55 @@ static Function DAP_UpdateChanAmpAssignStorWv(device)
 	endif
 End
 
-static Function DAP_UpdateChanAmpAssignPanel(device)
-	string device
+/// @brief Update the Device Association Group in the Hardware Tab. The controls are set with the data from the
+///        channel-anmplifier-association wave.
+static Function DAP_UpdateChanAmpAssignPanel(string device)
 
-	variable HeadStageNo, channel, ampSerial, ampChannelID
-	string entry
+	variable headStageNo, channel, ampSerial, ampChannelID
+	string entry, channelStr
 
-	Wave ChanAmpAssign       = GetChanAmpAssign(device)
-	Wave/T ChanAmpAssignUnit = GetChanAmpAssignUnit(device)
+	WAVE chanAmpAssign       = GetChanAmpAssign(device)
+	WAVE/T chanAmpAssignUnit = GetChanAmpAssignUnit(device)
+	Duplicate/FREE chanAmpAssign, chanAmpAssignCpy
+	Duplicate/FREE/T chanAmpAssignUnit, chanAmpAssignUnitCpy
 
-	HeadStageNo = str2num(GetPopupMenuString(device,"Popup_Settings_HeadStage"))
+	headStageNo = str2num(GetPopupMenuString(device,"Popup_Settings_HeadStage"))
 
 	// VC DA settings
-	channel = ChanAmpAssign[%VC_DA][HeadStageNo]
-	Popupmenu Popup_Settings_VC_DA, win = $device, mode = (IsFinite(channel) ? channel : NUM_DA_TTL_CHANNELS) + 1
-	Setvariable setvar_Settings_VC_DAgain, win = $device, value = _num:ChanAmpAssign[%VC_DAGain][HeadStageNo]
-	Setvariable SetVar_Hardware_VC_DA_Unit, win = $device, value = _str:ChanAmpAssignUnit[%VC_DAUnit][HeadStageNo]
+	channel = chanAmpAssignCpy[%VC_DA][headStageNo]
+	channelStr = SelectString(IsFinite(channel), NONE, num2str(channel))
+	PGC_SetAndActivateControl(device, "Popup_Settings_VC_DA", str = channelStr)
+	PGC_SetAndActivateControl(device, "setvar_Settings_VC_DAgain", val = chanAmpAssignCpy[%VC_DAGain][headStageNo])
+	PGC_SetAndActivateControl(device, "SetVar_Hardware_VC_DA_Unit", str = chanAmpAssignUnitCpy[%VC_DAUnit][headStageNo])
 
 	// VC AD settings
-	channel = ChanAmpAssign[%VC_AD][HeadStageNo]
-	Popupmenu Popup_Settings_VC_AD, win = $device, mode = (IsFinite(channel) ? channel : NUM_MAX_CHANNELS) + 1
-	Setvariable setvar_Settings_VC_ADgain, win = $device, value = _num:ChanAmpAssign[%VC_ADGain][HeadStageNo]
-	Setvariable SetVar_Hardware_VC_AD_Unit, win = $device, value = _str:ChanAmpAssignUnit[%VC_ADUnit][HeadStageNo]
+	channel = chanAmpAssignCpy[%VC_AD][headStageNo]
+	channelStr = SelectString(IsFinite(channel), NONE, num2str(channel))
+	PGC_SetAndActivateControl(device, "Popup_Settings_VC_AD", str = channelStr)
+	PGC_SetAndActivateControl(device, "setvar_Settings_VC_ADgain", val = chanAmpAssignCpy[%VC_ADGain][headStageNo])
+	PGC_SetAndActivateControl(device, "SetVar_Hardware_VC_AD_Unit", str = chanAmpAssignUnitCpy[%VC_ADUnit][headStageNo])
 
 	// IC DA settings
-	channel = ChanAmpAssign[%IC_DA][HeadStageNo]
-	Popupmenu Popup_Settings_IC_DA, win = $device, mode = (IsFinite(channel) ? channel : NUM_DA_TTL_CHANNELS) + 1
-	Setvariable setvar_Settings_IC_DAgain, win = $device, value = _num:ChanAmpAssign[%IC_DAGain][HeadStageNo]
-	Setvariable SetVar_Hardware_IC_DA_Unit, win = $device, value = _str:ChanAmpAssignUnit[%IC_DAUnit][HeadStageNo]
+	channel = chanAmpAssignCpy[%IC_DA][headStageNo]
+	channelStr = SelectString(IsFinite(channel), NONE, num2str(channel))
+	PGC_SetAndActivateControl(device, "Popup_Settings_IC_DA", str = channelStr)
+	PGC_SetAndActivateControl(device, "setvar_Settings_IC_DAgain", val = chanAmpAssignCpy[%IC_DAGain][headStageNo])
+	PGC_SetAndActivateControl(device, "SetVar_Hardware_IC_DA_Unit", str = chanAmpAssignUnitCpy[%IC_DAUnit][headStageNo])
 
 	// IC AD settings
-	channel = ChanAmpAssign[%IC_AD][HeadStageNo]
-	Popupmenu  Popup_Settings_IC_AD, win = $device, mode = (IsFinite(channel) ? channel : NUM_MAX_CHANNELS) + 1
-	Setvariable setvar_Settings_IC_ADgain, win = $device, value = _num:ChanAmpAssign[%IC_ADGain][HeadStageNo]
-	Setvariable SetVar_Hardware_IC_AD_Unit, win = $device, value = _str:ChanAmpAssignUnit[%IC_ADUnit][HeadStageNo]
+	channel = chanAmpAssignCpy[%IC_AD][headStageNo]
+	channelStr = SelectString(IsFinite(channel), NONE, num2str(channel))
+	PGC_SetAndActivateControl(device, "Popup_Settings_IC_AD", str = channelStr)
+	PGC_SetAndActivateControl(device, "setvar_Settings_IC_ADgain", val = chanAmpAssignCpy[%IC_ADGain][headStageNo])
+	PGC_SetAndActivateControl(device, "SetVar_Hardware_IC_AD_Unit", str = chanAmpAssignUnitCpy[%IC_ADUnit][headStageNo])
 
-	ampSerial    = ChanAmpAssign[%AmpSerialNo][HeadStageNo]
-	ampChannelID = ChanAmpAssign[%AmpChannelID][HeadStageNo]
+	ampSerial    = chanAmpAssignCpy[%AmpSerialNo][headStageNo]
+	ampChannelID = chanAmpAssignCpy[%AmpChannelID][headStageNo]
 	if(isFinite(ampSerial) && isFinite(ampChannelID))
 		entry = DAP_GetAmplifierDef(ampSerial, ampChannelID)
-		Popupmenu popup_Settings_Amplifier, win = $device, popmatch=entry
+		PGC_SetAndActivateControl(device, "popup_Settings_Amplifier", str = entry)
 	else
-		Popupmenu popup_Settings_Amplifier, win = $device, popmatch=NONE
+		PGC_SetAndActivateControl(device, "popup_Settings_Amplifier", str = NONE)
 	endif
 End
 

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -4415,6 +4415,7 @@ Function DAP_LockDevice(string win)
 
 	DoWindow/W=$win/C $deviceLocked
 
+	KillOrMoveToTrash(wv = GetChannelClampMode(deviceLocked))
 	KillOrMoveToTrash(wv = GetDA_EphysGuiStateNum(deviceLocked))
 	KillOrMoveToTrash(wv = GetDA_EphysGuiStateTxT(deviceLocked))
 	// initial fill of the GUI state wave

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -4762,18 +4762,18 @@ static Function DAP_UpdateChanAmpAssignStorWv(device)
 	HeadStageNo = str2num(GetPopupMenuString(device,"Popup_Settings_HeadStage"))
 
 	// Assigns V-clamp settings for a particular headstage
-	ChanAmpAssign[%VC_DA][HeadStageNo]     = str2num(GetPopupMenuString(device, "Popup_Settings_VC_DA"))
+	ChanAmpAssign[%VC_DA][HeadStageNo]     = str2numSafe(GetPopupMenuString(device, "Popup_Settings_VC_DA"))
 	ChanAmpAssign[%VC_DAGain][HeadStageNo] = GetSetVariable(device, "setvar_Settings_VC_DAgain")
 	ChanAmpAssignUnit[%VC_DAUnit][HeadStageNo]      = GetSetVariableString(device, "SetVar_Hardware_VC_DA_Unit")
-	ChanAmpAssign[%VC_AD][HeadStageNo]     = str2num(GetPopupMenuString(device, "Popup_Settings_VC_AD"))
+	ChanAmpAssign[%VC_AD][HeadStageNo]     = str2numSafe(GetPopupMenuString(device, "Popup_Settings_VC_AD"))
 	ChanAmpAssign[%VC_ADGain][HeadStageNo] = GetSetVariable(device, "setvar_Settings_VC_ADgain")
 	ChanAmpAssignUnit[%VC_ADUnit][HeadStageNo]      = GetSetVariableString(device, "SetVar_Hardware_VC_AD_Unit")
 
 	//Assigns I-clamp settings for a particular headstage
-	ChanAmpAssign[%IC_DA][HeadStageNo]     = str2num(GetPopupMenuString(device, "Popup_Settings_IC_DA"))
+	ChanAmpAssign[%IC_DA][HeadStageNo]     = str2numSafe(GetPopupMenuString(device, "Popup_Settings_IC_DA"))
 	ChanAmpAssign[%IC_DAGain][HeadStageNo] = GetSetVariable(device, "setvar_Settings_IC_DAgain")
 	ChanAmpAssignUnit[%IC_DAUnit][HeadStageNo]      = GetSetVariableString(device, "SetVar_Hardware_IC_DA_Unit")
-	ChanAmpAssign[%IC_AD][HeadStageNo]     = str2num(GetPopupMenuString(device, "Popup_Settings_IC_AD"))
+	ChanAmpAssign[%IC_AD][HeadStageNo]     = str2numSafe(GetPopupMenuString(device, "Popup_Settings_IC_AD"))
 	ChanAmpAssign[%IC_ADGain][HeadStageNo] = GetSetVariable(device, "setvar_Settings_IC_ADgain")
 	ChanAmpAssignUnit[%IC_ADUnit][HeadStageNo]      = GetSetVariableString(device, "SetVar_Hardware_IC_AD_Unit")
 
@@ -4805,7 +4805,7 @@ static Function DAP_UpdateChanAmpAssignPanel(device)
 
 	// VC DA settings
 	channel = ChanAmpAssign[%VC_DA][HeadStageNo]
-	Popupmenu Popup_Settings_VC_DA, win = $device, mode = (IsFinite(channel) ? channel : NUM_MAX_CHANNELS) + 1
+	Popupmenu Popup_Settings_VC_DA, win = $device, mode = (IsFinite(channel) ? channel : NUM_DA_TTL_CHANNELS) + 1
 	Setvariable setvar_Settings_VC_DAgain, win = $device, value = _num:ChanAmpAssign[%VC_DAGain][HeadStageNo]
 	Setvariable SetVar_Hardware_VC_DA_Unit, win = $device, value = _str:ChanAmpAssignUnit[%VC_DAUnit][HeadStageNo]
 
@@ -4817,7 +4817,7 @@ static Function DAP_UpdateChanAmpAssignPanel(device)
 
 	// IC DA settings
 	channel = ChanAmpAssign[%IC_DA][HeadStageNo]
-	Popupmenu Popup_Settings_IC_DA, win = $device, mode = (IsFinite(channel) ? channel : NUM_MAX_CHANNELS) + 1
+	Popupmenu Popup_Settings_IC_DA, win = $device, mode = (IsFinite(channel) ? channel : NUM_DA_TTL_CHANNELS) + 1
 	Setvariable setvar_Settings_IC_DAgain, win = $device, value = _num:ChanAmpAssign[%IC_DAGain][HeadStageNo]
 	Setvariable SetVar_Hardware_IC_DA_Unit, win = $device, value = _str:ChanAmpAssignUnit[%IC_DAUnit][HeadStageNo]
 

--- a/Packages/MIES/MIES_DAEphys_Macro.ipf
+++ b/Packages/MIES/MIES_DAEphys_Macro.ipf
@@ -273,7 +273,7 @@ Window DA_Ephys() : Panel
 	CheckBox Check_AD_11,userdata(ResizeControlsInfo)+=A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
 	CheckBox Check_AD_11,userdata(ControlArray)="Check_AD"
 	CheckBox Check_AD_11,userdata(ControlArrayIndex)="11",value=0,side=1
-	SetVariable Gain_AD_00,pos={46.00,75.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
+	SetVariable Gain_AD_00,pos={43.00,75.00},size={58.00,18.00},bodyWidth=58,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_00,userdata(tabnum)="2",userdata(tabcontrol)="ADC"
 	SetVariable Gain_AD_00,userdata(ResizeControlsInfo)=A"!!,DW!!#?O!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_00,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
@@ -281,7 +281,7 @@ Window DA_Ephys() : Panel
 	SetVariable Gain_AD_00,userdata(ControlArray)="Gain_AD"
 	SetVariable Gain_AD_00,userdata(ControlArrayIndex)="0"
 	SetVariable Gain_AD_00,limits={0,inf,1},value=_NUM:0
-	SetVariable Gain_AD_01,pos={46.00,120.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
+	SetVariable Gain_AD_01,pos={43.00,120.00},size={58.00,18.00},bodyWidth=58,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_01,userdata(tabnum)="2",userdata(tabcontrol)="ADC"
 	SetVariable Gain_AD_01,userdata(ResizeControlsInfo)=A"!!,DW!!#@V!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_01,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
@@ -289,7 +289,7 @@ Window DA_Ephys() : Panel
 	SetVariable Gain_AD_01,userdata(ControlArray)="Gain_AD"
 	SetVariable Gain_AD_01,userdata(ControlArrayIndex)="1"
 	SetVariable Gain_AD_01,limits={0,inf,1},value=_NUM:0
-	SetVariable Gain_AD_02,pos={46.00,165.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
+	SetVariable Gain_AD_02,pos={43.00,165.00},size={58.00,18.00},bodyWidth=58,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_02,userdata(tabnum)="2",userdata(tabcontrol)="ADC"
 	SetVariable Gain_AD_02,userdata(ResizeControlsInfo)=A"!!,DW!!#A6!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_02,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
@@ -297,7 +297,7 @@ Window DA_Ephys() : Panel
 	SetVariable Gain_AD_02,userdata(ControlArray)="Gain_AD"
 	SetVariable Gain_AD_02,userdata(ControlArrayIndex)="2"
 	SetVariable Gain_AD_02,limits={0,inf,1},value=_NUM:0
-	SetVariable Gain_AD_03,pos={46.00,213.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
+	SetVariable Gain_AD_03,pos={43.00,213.00},size={58.00,18.00},bodyWidth=58,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_03,userdata(tabnum)="2",userdata(tabcontrol)="ADC"
 	SetVariable Gain_AD_03,userdata(ResizeControlsInfo)=A"!!,DW!!#Ae!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_03,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
@@ -305,7 +305,7 @@ Window DA_Ephys() : Panel
 	SetVariable Gain_AD_03,userdata(ControlArray)="Gain_AD"
 	SetVariable Gain_AD_03,userdata(ControlArrayIndex)="3"
 	SetVariable Gain_AD_03,limits={0,inf,1},value=_NUM:0
-	SetVariable Gain_AD_04,pos={46.00,258.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
+	SetVariable Gain_AD_04,pos={43.00,258.00},size={58.00,18.00},bodyWidth=58,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_04,userdata(tabnum)="2",userdata(tabcontrol)="ADC"
 	SetVariable Gain_AD_04,userdata(ResizeControlsInfo)=A"!!,DW!!#B<!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_04,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
@@ -313,7 +313,7 @@ Window DA_Ephys() : Panel
 	SetVariable Gain_AD_04,userdata(ControlArray)="Gain_AD"
 	SetVariable Gain_AD_04,userdata(ControlArrayIndex)="4"
 	SetVariable Gain_AD_04,limits={0,inf,1},value=_NUM:0
-	SetVariable Gain_AD_05,pos={46.00,306.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
+	SetVariable Gain_AD_05,pos={43.00,306.00},size={58.00,18.00},bodyWidth=58,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_05,userdata(tabnum)="2",userdata(tabcontrol)="ADC"
 	SetVariable Gain_AD_05,userdata(ResizeControlsInfo)=A"!!,DW!!#BSJ,ho,!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_05,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
@@ -321,7 +321,7 @@ Window DA_Ephys() : Panel
 	SetVariable Gain_AD_05,userdata(ControlArray)="Gain_AD"
 	SetVariable Gain_AD_05,userdata(ControlArrayIndex)="5"
 	SetVariable Gain_AD_05,limits={0,inf,1},value=_NUM:0
-	SetVariable Gain_AD_06,pos={46.00,351.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
+	SetVariable Gain_AD_06,pos={43.00,351.00},size={58.00,18.00},bodyWidth=58,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_06,userdata(tabnum)="2",userdata(tabcontrol)="ADC"
 	SetVariable Gain_AD_06,userdata(ResizeControlsInfo)=A"!!,DW!!#BjJ,ho,!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_06,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
@@ -329,7 +329,7 @@ Window DA_Ephys() : Panel
 	SetVariable Gain_AD_06,userdata(ControlArray)="Gain_AD"
 	SetVariable Gain_AD_06,userdata(ControlArrayIndex)="6"
 	SetVariable Gain_AD_06,limits={0,inf,1},value=_NUM:0
-	SetVariable Gain_AD_07,pos={46.00,399.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
+	SetVariable Gain_AD_07,pos={43.00,399.00},size={58.00,18.00},bodyWidth=58,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_07,userdata(tabnum)="2",userdata(tabcontrol)="ADC"
 	SetVariable Gain_AD_07,userdata(ResizeControlsInfo)=A"!!,DW!!#C-!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_07,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
@@ -337,7 +337,7 @@ Window DA_Ephys() : Panel
 	SetVariable Gain_AD_07,userdata(ControlArray)="Gain_AD"
 	SetVariable Gain_AD_07,userdata(ControlArrayIndex)="7"
 	SetVariable Gain_AD_07,limits={0,inf,1},value=_NUM:0
-	SetVariable Gain_AD_08,pos={226.00,75.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
+	SetVariable Gain_AD_08,pos={223.00,75.00},size={58.00,18.00},bodyWidth=58,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_08,userdata(tabnum)="2",userdata(tabcontrol)="ADC"
 	SetVariable Gain_AD_08,userdata(ResizeControlsInfo)=A"!!,Gu!!#?O!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_08,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
@@ -345,7 +345,7 @@ Window DA_Ephys() : Panel
 	SetVariable Gain_AD_08,userdata(ControlArray)="Gain_AD"
 	SetVariable Gain_AD_08,userdata(ControlArrayIndex)="8"
 	SetVariable Gain_AD_08,limits={0,inf,1},value=_NUM:0
-	SetVariable Gain_AD_09,pos={226.00,120.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
+	SetVariable Gain_AD_09,pos={223.00,120.00},size={58.00,18.00},bodyWidth=58,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_09,userdata(tabnum)="2",userdata(tabcontrol)="ADC"
 	SetVariable Gain_AD_09,userdata(ResizeControlsInfo)=A"!!,Gu!!#@V!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_09,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
@@ -353,7 +353,7 @@ Window DA_Ephys() : Panel
 	SetVariable Gain_AD_09,userdata(ControlArray)="Gain_AD"
 	SetVariable Gain_AD_09,userdata(ControlArrayIndex)="9"
 	SetVariable Gain_AD_09,limits={0,inf,1},value=_NUM:0
-	SetVariable Gain_AD_10,pos={226.00,165.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
+	SetVariable Gain_AD_10,pos={223.00,165.00},size={58.00,18.00},bodyWidth=58,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_10,userdata(tabnum)="2",userdata(tabcontrol)="ADC"
 	SetVariable Gain_AD_10,userdata(ResizeControlsInfo)=A"!!,Gu!!#A6!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_10,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
@@ -361,7 +361,7 @@ Window DA_Ephys() : Panel
 	SetVariable Gain_AD_10,userdata(ControlArray)="Gain_AD"
 	SetVariable Gain_AD_10,userdata(ControlArrayIndex)="10"
 	SetVariable Gain_AD_10,limits={0,inf,1},value=_NUM:0
-	SetVariable Gain_AD_11,pos={226.00,213.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
+	SetVariable Gain_AD_11,pos={223.00,213.00},size={58.00,18.00},bodyWidth=58,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_11,userdata(tabnum)="2",userdata(tabcontrol)="ADC"
 	SetVariable Gain_AD_11,userdata(ResizeControlsInfo)=A"!!,Gu!!#Ae!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_11,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
@@ -369,7 +369,7 @@ Window DA_Ephys() : Panel
 	SetVariable Gain_AD_11,userdata(ControlArray)="Gain_AD"
 	SetVariable Gain_AD_11,userdata(ControlArrayIndex)="11"
 	SetVariable Gain_AD_11,limits={0,inf,1},value=_NUM:0
-	SetVariable Gain_AD_12,pos={226.00,258.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
+	SetVariable Gain_AD_12,pos={223.00,258.00},size={58.00,18.00},bodyWidth=58,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_12,userdata(tabnum)="2",userdata(tabcontrol)="ADC"
 	SetVariable Gain_AD_12,userdata(ResizeControlsInfo)=A"!!,Gu!!#B<!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_12,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
@@ -398,7 +398,7 @@ Window DA_Ephys() : Panel
 	CheckBox Check_AD_15,userdata(ResizeControlsInfo)+=A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
 	CheckBox Check_AD_15,userdata(ControlArray)="Check_AD"
 	CheckBox Check_AD_15,userdata(ControlArrayIndex)="15",value=0,side=1
-	SetVariable Gain_AD_13,pos={226.00,306.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
+	SetVariable Gain_AD_13,pos={223.00,306.00},size={58.00,18.00},bodyWidth=58,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_13,userdata(tabnum)="2",userdata(tabcontrol)="ADC"
 	SetVariable Gain_AD_13,userdata(ResizeControlsInfo)=A"!!,Gu!!#BSJ,ho,!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_13,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
@@ -406,7 +406,7 @@ Window DA_Ephys() : Panel
 	SetVariable Gain_AD_13,userdata(ControlArray)="Gain_AD"
 	SetVariable Gain_AD_13,userdata(ControlArrayIndex)="13"
 	SetVariable Gain_AD_13,limits={0,inf,1},value=_NUM:0
-	SetVariable Gain_AD_14,pos={226.00,351.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
+	SetVariable Gain_AD_14,pos={223.00,351.00},size={58.00,18.00},bodyWidth=58,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_14,userdata(tabnum)="2",userdata(tabcontrol)="ADC"
 	SetVariable Gain_AD_14,userdata(ResizeControlsInfo)=A"!!,Gu!!#BjJ,ho,!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_14,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
@@ -414,7 +414,7 @@ Window DA_Ephys() : Panel
 	SetVariable Gain_AD_14,userdata(ControlArray)="Gain_AD"
 	SetVariable Gain_AD_14,userdata(ControlArrayIndex)="14"
 	SetVariable Gain_AD_14,limits={0,inf,1},value=_NUM:0
-	SetVariable Gain_AD_15,pos={226.00,399.00},size={50.00,18.00},bodyWidth=50,disable=1,proc=DAP_SetVar_UpdateGuiState
+	SetVariable Gain_AD_15,pos={223.00,399.00},size={58.00,18.00},bodyWidth=58,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_AD_15,userdata(tabnum)="2",userdata(tabcontrol)="ADC"
 	SetVariable Gain_AD_15,userdata(ResizeControlsInfo)=A"!!,Gu!!#C-!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_AD_15,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
@@ -478,7 +478,7 @@ Window DA_Ephys() : Panel
 	CheckBox Check_DA_07,userdata(ResizeControlsInfo)+=A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
 	CheckBox Check_DA_07,userdata(ControlArray)="Check_DA"
 	CheckBox Check_DA_07,userdata(ControlArrayIndex)="7",value=0,side=1
-	SetVariable Gain_DA_00,pos={48.00,75.00},size={48.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
+	SetVariable Gain_DA_00,pos={43.00,75.00},size={58.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_DA_00,userdata(tabnum)="1",userdata(tabcontrol)="ADC"
 	SetVariable Gain_DA_00,userdata(ResizeControlsInfo)=A"!!,DW!!#?O!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_DA_00,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
@@ -486,7 +486,7 @@ Window DA_Ephys() : Panel
 	SetVariable Gain_DA_00,userdata(ControlArray)="Gain_DA"
 	SetVariable Gain_DA_00,userdata(ControlArrayIndex)="0"
 	SetVariable Gain_DA_00,limits={0,inf,1},value=_NUM:0
-	SetVariable Gain_DA_01,pos={48.00,120.00},size={48.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
+	SetVariable Gain_DA_01,pos={43.00,120.00},size={58.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_DA_01,userdata(tabnum)="1",userdata(tabcontrol)="ADC"
 	SetVariable Gain_DA_01,userdata(ResizeControlsInfo)=A"!!,DW!!#@V!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_DA_01,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
@@ -494,7 +494,7 @@ Window DA_Ephys() : Panel
 	SetVariable Gain_DA_01,userdata(ControlArray)="Gain_DA"
 	SetVariable Gain_DA_01,userdata(ControlArrayIndex)="1"
 	SetVariable Gain_DA_01,limits={0,inf,1},value=_NUM:0
-	SetVariable Gain_DA_02,pos={48.00,165.00},size={48.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
+	SetVariable Gain_DA_02,pos={43.00,165.00},size={58.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_DA_02,userdata(tabnum)="1",userdata(tabcontrol)="ADC"
 	SetVariable Gain_DA_02,userdata(ResizeControlsInfo)=A"!!,DW!!#A6!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_DA_02,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
@@ -502,7 +502,7 @@ Window DA_Ephys() : Panel
 	SetVariable Gain_DA_02,userdata(ControlArray)="Gain_DA"
 	SetVariable Gain_DA_02,userdata(ControlArrayIndex)="2"
 	SetVariable Gain_DA_02,limits={0,inf,1},value=_NUM:0
-	SetVariable Gain_DA_03,pos={48.00,213.00},size={48.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
+	SetVariable Gain_DA_03,pos={43.00,213.00},size={58.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_DA_03,userdata(tabnum)="1",userdata(tabcontrol)="ADC"
 	SetVariable Gain_DA_03,userdata(ResizeControlsInfo)=A"!!,DW!!#Ae!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_DA_03,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
@@ -510,7 +510,7 @@ Window DA_Ephys() : Panel
 	SetVariable Gain_DA_03,userdata(ControlArray)="Gain_DA"
 	SetVariable Gain_DA_03,userdata(ControlArrayIndex)="3"
 	SetVariable Gain_DA_03,limits={0,inf,1},value=_NUM:0
-	SetVariable Gain_DA_04,pos={48.00,258.00},size={48.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
+	SetVariable Gain_DA_04,pos={43.00,258.00},size={58.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_DA_04,userdata(tabnum)="1",userdata(tabcontrol)="ADC"
 	SetVariable Gain_DA_04,userdata(ResizeControlsInfo)=A"!!,DW!!#B<!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_DA_04,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
@@ -518,7 +518,7 @@ Window DA_Ephys() : Panel
 	SetVariable Gain_DA_04,userdata(ControlArray)="Gain_DA"
 	SetVariable Gain_DA_04,userdata(ControlArrayIndex)="4"
 	SetVariable Gain_DA_04,limits={0,inf,1},value=_NUM:0
-	SetVariable Gain_DA_05,pos={48.00,306.00},size={48.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
+	SetVariable Gain_DA_05,pos={43.00,306.00},size={58.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_DA_05,userdata(tabnum)="1",userdata(tabcontrol)="ADC"
 	SetVariable Gain_DA_05,userdata(ResizeControlsInfo)=A"!!,DW!!#BSJ,ho,!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_DA_05,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
@@ -526,7 +526,7 @@ Window DA_Ephys() : Panel
 	SetVariable Gain_DA_05,userdata(ControlArray)="Gain_DA"
 	SetVariable Gain_DA_05,userdata(ControlArrayIndex)="5"
 	SetVariable Gain_DA_05,limits={0,inf,1},value=_NUM:0
-	SetVariable Gain_DA_06,pos={48.00,351.00},size={48.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
+	SetVariable Gain_DA_06,pos={43.00,351.00},size={58.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_DA_06,userdata(tabnum)="1",userdata(tabcontrol)="ADC"
 	SetVariable Gain_DA_06,userdata(ResizeControlsInfo)=A"!!,DW!!#BjJ,ho,!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_DA_06,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
@@ -534,7 +534,7 @@ Window DA_Ephys() : Panel
 	SetVariable Gain_DA_06,userdata(ControlArray)="Gain_DA"
 	SetVariable Gain_DA_06,userdata(ControlArrayIndex)="6"
 	SetVariable Gain_DA_06,limits={0,inf,1},value=_NUM:0
-	SetVariable Gain_DA_07,pos={48.00,399.00},size={48.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
+	SetVariable Gain_DA_07,pos={43.00,399.00},size={58.00,18.00},disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable Gain_DA_07,userdata(tabnum)="1",userdata(tabcontrol)="ADC"
 	SetVariable Gain_DA_07,userdata(ResizeControlsInfo)=A"!!,DW!!#C-!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable Gain_DA_07,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
@@ -912,16 +912,16 @@ Window DA_Ephys() : Panel
 	ValDisplay ValDisp_DataAcq_SamplingInt,valueBackColor=(0,0,0)
 	ValDisplay ValDisp_DataAcq_SamplingInt,limits={0,0,0},barmisc={0,1000}
 	ValDisplay ValDisp_DataAcq_SamplingInt,value=_NUM:0
-	SetVariable SetVar_Sweep,pos={210.00,534.00},size={75.00,35.00},bodyWidth=75,disable=1,noEdit=1,proc=DAP_SetVar_UpdateGuiState
+	SetVariable SetVar_Sweep,pos={210.00,534.00},size={75.00,35.00},bodyWidth=75,disable=1,proc=DAP_SetVar_UpdateGuiState
 	SetVariable SetVar_Sweep,help={"Shows the sweep number of the next acquired sweep. Can not be changed."}
 	SetVariable SetVar_Sweep,userdata(tabnum)="0",userdata(tabcontrol)="ADC"
 	SetVariable SetVar_Sweep,userdata(ResizeControlsInfo)=A"!!,Gc!!#Cj!!#?O!!#=oz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	SetVariable SetVar_Sweep,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	SetVariable SetVar_Sweep,userdata(ResizeControlsInfo)+=A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	SetVariable SetVar_Sweep,fSize=24,fStyle=1,valueColor=(65535,65535,65535)
-	SetVariable SetVar_Sweep,valueBackColor=(0,0,0),limits={0,inf,0},value=_NUM:0
 	SetVariable SetVar_Sweep,userdata(Config_DontRestore)="1"
-	SetVariable SetVar_Sweep,userdata(Config_DontSave)="1"
+	SetVariable SetVar_Sweep,userdata(Config_DontSave)="1",fSize=24,fStyle=1
+	SetVariable SetVar_Sweep,valueColor=(65535,65535,65535),valueBackColor=(0,0,0)
+	SetVariable SetVar_Sweep,limits={0,inf,0},value=_NUM:0,noedit=1
 	CheckBox Check_Settings_UseDoublePrec,pos={246.00,258.00},size={161.00,15.00},disable=1,proc=DAP_CheckProc_UpdateGuiState
 	CheckBox Check_Settings_UseDoublePrec,title="Use Double Precision Floats"
 	CheckBox Check_Settings_UseDoublePrec,help={"Enable the saving of the raw data in double precision. If unchecked the raw data will be saved in single precision, which should be good enough for most use cases"}
@@ -1476,7 +1476,7 @@ Window DA_Ephys() : Panel
 	PopupMenu Popup_Settings_IC_AD,userdata(Config_DontRestore)="1"
 	PopupMenu Popup_Settings_IC_AD,userdata(Config_DontSave)="1"
 	PopupMenu Popup_Settings_IC_AD,mode=1,popvalue="0",value=#"\"0;1;2;3;4;5;6;7;8;9;10;11;12;13;14;15\""
-	SetVariable setvar_Settings_VC_DAgain,pos={105.00,411.00},size={48.00,18.00},proc=DAP_SetVarProc_CAA
+	SetVariable setvar_Settings_VC_DAgain,pos={105.00,411.00},size={58.00,18.00},proc=DAP_SetVarProc_CAA
 	SetVariable setvar_Settings_VC_DAgain,userdata(tabnum)="6"
 	SetVariable setvar_Settings_VC_DAgain,userdata(tabcontrol)="ADC"
 	SetVariable setvar_Settings_VC_DAgain,userdata(ResizeControlsInfo)=A"!!,F;!!#C3J,ho,!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
@@ -1485,7 +1485,7 @@ Window DA_Ephys() : Panel
 	SetVariable setvar_Settings_VC_DAgain,userdata(Config_DontRestore)="1"
 	SetVariable setvar_Settings_VC_DAgain,userdata(Config_DontSave)="1"
 	SetVariable setvar_Settings_VC_DAgain,value=_NUM:20
-	SetVariable setvar_Settings_VC_ADgain,pos={105.00,438.00},size={48.00,18.00},proc=DAP_SetVarProc_CAA
+	SetVariable setvar_Settings_VC_ADgain,pos={105.00,438.00},size={58.00,18.00},proc=DAP_SetVarProc_CAA
 	SetVariable setvar_Settings_VC_ADgain,userdata(tabnum)="6"
 	SetVariable setvar_Settings_VC_ADgain,userdata(tabcontrol)="ADC"
 	SetVariable setvar_Settings_VC_ADgain,userdata(ResizeControlsInfo)=A"!!,F;!!#C@!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
@@ -1494,7 +1494,7 @@ Window DA_Ephys() : Panel
 	SetVariable setvar_Settings_VC_ADgain,userdata(Config_DontRestore)="1"
 	SetVariable setvar_Settings_VC_ADgain,userdata(Config_DontSave)="1"
 	SetVariable setvar_Settings_VC_ADgain,value=_NUM:0.00999999977648258
-	SetVariable setvar_Settings_IC_ADgain,pos={285.00,438.00},size={48.00,18.00},proc=DAP_SetVarProc_CAA
+	SetVariable setvar_Settings_IC_ADgain,pos={282.00,438.00},size={58.00,18.00},proc=DAP_SetVarProc_CAA
 	SetVariable setvar_Settings_IC_ADgain,userdata(tabnum)="6"
 	SetVariable setvar_Settings_IC_ADgain,userdata(tabcontrol)="ADC"
 	SetVariable setvar_Settings_IC_ADgain,userdata(ResizeControlsInfo)=A"!!,HJJ,hsk!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
@@ -1530,7 +1530,7 @@ Window DA_Ephys() : Panel
 	PopupMenu Popup_Settings_IC_DA,userdata(Config_DontRestore)="1"
 	PopupMenu Popup_Settings_IC_DA,userdata(Config_DontSave)="1"
 	PopupMenu Popup_Settings_IC_DA,mode=1,popvalue="0",value=#"\"0;1;2;3;4;5;6;7\""
-	SetVariable setvar_Settings_IC_DAgain,pos={288.00,411.00},size={48.00,18.00},proc=DAP_SetVarProc_CAA
+	SetVariable setvar_Settings_IC_DAgain,pos={282.00,411.00},size={58.00,18.00},proc=DAP_SetVarProc_CAA
 	SetVariable setvar_Settings_IC_DAgain,userdata(tabnum)="6"
 	SetVariable setvar_Settings_IC_DAgain,userdata(tabcontrol)="ADC"
 	SetVariable setvar_Settings_IC_DAgain,userdata(ResizeControlsInfo)=A"!!,HK!!#C3J,ho,!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
@@ -2359,7 +2359,7 @@ Window DA_Ephys() : Panel
 	SetVariable SetVar_Hardware_VC_DA_Unit,userdata(Config_DontRestore)="1"
 	SetVariable SetVar_Hardware_VC_DA_Unit,userdata(Config_DontSave)="1"
 	SetVariable SetVar_Hardware_VC_DA_Unit,value=_STR:"mV"
-	SetVariable SetVar_Hardware_IC_DA_Unit,pos={342.00,414.00},size={30.00,18.00},proc=DAP_SetVarProc_CAA
+	SetVariable SetVar_Hardware_IC_DA_Unit,pos={342.00,411.00},size={30.00,18.00},proc=DAP_SetVarProc_CAA
 	SetVariable SetVar_Hardware_IC_DA_Unit,userdata(tabnum)="6"
 	SetVariable SetVar_Hardware_IC_DA_Unit,userdata(tabcontrol)="ADC"
 	SetVariable SetVar_Hardware_IC_DA_Unit,userdata(ResizeControlsInfo)=A"!!,Hg!!#C4!!#=S!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
@@ -2869,7 +2869,7 @@ Window DA_Ephys() : Panel
 	TitleBox Title_DataAcq_CN,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	TitleBox Title_DataAcq_CN,userdata(ResizeControlsInfo)+=A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
 	TitleBox Title_DataAcq_CN,frame=0
-	Slider slider_DataAcq_ActiveHeadstage,pos={128.00,123.00},size={255.00,22.00},disable=1,proc=DAP_SliderProc_MIESHeadStage
+	Slider slider_DataAcq_ActiveHeadstage,pos={128.00,123.00},size={255.00,16.00},disable=1,proc=DAP_SliderProc_MIESHeadStage
 	Slider slider_DataAcq_ActiveHeadstage,userdata(tabnum)="0"
 	Slider slider_DataAcq_ActiveHeadstage,userdata(tabcontrol)="ADC"
 	Slider slider_DataAcq_ActiveHeadstage,userdata(Config_DontRestore)="1"

--- a/Packages/MIES/MIES_DAEphys_Macro.ipf
+++ b/Packages/MIES/MIES_DAEphys_Macro.ipf
@@ -1449,7 +1449,7 @@ Window DA_Ephys() : Panel
 	TitleBox Title_DataAcq_IE0,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	TitleBox Title_DataAcq_IE0,userdata(ResizeControlsInfo)+=A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
 	TitleBox Title_DataAcq_IE0,frame=0
-	PopupMenu Popup_Settings_VC_DA,pos={45.00,411.00},size={47.00,19.00},proc=DAP_PopMenuProc_CAA
+	PopupMenu Popup_Settings_VC_DA,pos={25.00,411.00},size={47.00,19.00},proc=DAP_PopMenuProc_CAA
 	PopupMenu Popup_Settings_VC_DA,title="DA",userdata(tabnum)="6"
 	PopupMenu Popup_Settings_VC_DA,userdata(tabcontrol)="ADC"
 	PopupMenu Popup_Settings_VC_DA,userdata(ResizeControlsInfo)=A"!!,DG!!#C2J,hnu!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
@@ -1457,8 +1457,8 @@ Window DA_Ephys() : Panel
 	PopupMenu Popup_Settings_VC_DA,userdata(ResizeControlsInfo)+=A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
 	PopupMenu Popup_Settings_VC_DA,userdata(Config_DontRestore)="1"
 	PopupMenu Popup_Settings_VC_DA,userdata(Config_DontSave)="1"
-	PopupMenu Popup_Settings_VC_DA,mode=1,popvalue="0",value=#"\"0;1;2;3;4;5;6;7\""
-	PopupMenu Popup_Settings_VC_AD,pos={45.00,435.00},size={47.00,19.00},proc=DAP_PopMenuProc_CAA
+	PopupMenu Popup_Settings_VC_DA,mode=1,popvalue="0",value=#"\"0;1;2;3;4;5;6;7;- none -\""
+	PopupMenu Popup_Settings_VC_AD,pos={25.00,438.00},size={47.00,19.00},proc=DAP_PopMenuProc_CAA
 	PopupMenu Popup_Settings_VC_AD,title="AD",userdata(tabnum)="6"
 	PopupMenu Popup_Settings_VC_AD,userdata(tabcontrol)="ADC"
 	PopupMenu Popup_Settings_VC_AD,userdata(ResizeControlsInfo)=A"!!,DG!!#C?!!#>J!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
@@ -1466,8 +1466,8 @@ Window DA_Ephys() : Panel
 	PopupMenu Popup_Settings_VC_AD,userdata(ResizeControlsInfo)+=A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
 	PopupMenu Popup_Settings_VC_AD,userdata(Config_DontRestore)="1"
 	PopupMenu Popup_Settings_VC_AD,userdata(Config_DontSave)="1"
-	PopupMenu Popup_Settings_VC_AD,mode=1,popvalue="0",value=#"\"0;1;2;3;4;5;6;7;8;9;10;11;12;13;14;15\""
-	PopupMenu Popup_Settings_IC_AD,pos={225.00,434.00},size={47.00,19.00},proc=DAP_PopMenuProc_CAA
+	PopupMenu Popup_Settings_VC_AD,mode=1,popvalue="0",value=#"\"0;1;2;3;4;5;6;7;8;9;10;11;12;13;14;15;- none -\""
+	PopupMenu Popup_Settings_IC_AD,pos={225.00,438.00},size={47.00,19.00},proc=DAP_PopMenuProc_CAA
 	PopupMenu Popup_Settings_IC_AD,title="AD",userdata(tabnum)="6"
 	PopupMenu Popup_Settings_IC_AD,userdata(tabcontrol)="ADC"
 	PopupMenu Popup_Settings_IC_AD,userdata(ResizeControlsInfo)=A"!!,Gr!!#C?!!#>J!!#<Pz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
@@ -1475,8 +1475,8 @@ Window DA_Ephys() : Panel
 	PopupMenu Popup_Settings_IC_AD,userdata(ResizeControlsInfo)+=A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
 	PopupMenu Popup_Settings_IC_AD,userdata(Config_DontRestore)="1"
 	PopupMenu Popup_Settings_IC_AD,userdata(Config_DontSave)="1"
-	PopupMenu Popup_Settings_IC_AD,mode=1,popvalue="0",value=#"\"0;1;2;3;4;5;6;7;8;9;10;11;12;13;14;15\""
-	SetVariable setvar_Settings_VC_DAgain,pos={105.00,411.00},size={58.00,18.00},proc=DAP_SetVarProc_CAA
+	PopupMenu Popup_Settings_IC_AD,mode=1,popvalue="0",value=#"\"0;1;2;3;4;5;6;7;8;9;10;11;12;13;14;15;- none -\""
+	SetVariable setvar_Settings_VC_DAgain,pos={110.00,411.00},size={58.00,18.00},proc=DAP_SetVarProc_CAA
 	SetVariable setvar_Settings_VC_DAgain,userdata(tabnum)="6"
 	SetVariable setvar_Settings_VC_DAgain,userdata(tabcontrol)="ADC"
 	SetVariable setvar_Settings_VC_DAgain,userdata(ResizeControlsInfo)=A"!!,F;!!#C3J,ho,!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
@@ -1485,7 +1485,7 @@ Window DA_Ephys() : Panel
 	SetVariable setvar_Settings_VC_DAgain,userdata(Config_DontRestore)="1"
 	SetVariable setvar_Settings_VC_DAgain,userdata(Config_DontSave)="1"
 	SetVariable setvar_Settings_VC_DAgain,value=_NUM:20
-	SetVariable setvar_Settings_VC_ADgain,pos={105.00,438.00},size={58.00,18.00},proc=DAP_SetVarProc_CAA
+	SetVariable setvar_Settings_VC_ADgain,pos={110.00,438.00},size={58.00,18.00},proc=DAP_SetVarProc_CAA
 	SetVariable setvar_Settings_VC_ADgain,userdata(tabnum)="6"
 	SetVariable setvar_Settings_VC_ADgain,userdata(tabcontrol)="ADC"
 	SetVariable setvar_Settings_VC_ADgain,userdata(ResizeControlsInfo)=A"!!,F;!!#C@!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
@@ -1494,7 +1494,7 @@ Window DA_Ephys() : Panel
 	SetVariable setvar_Settings_VC_ADgain,userdata(Config_DontRestore)="1"
 	SetVariable setvar_Settings_VC_ADgain,userdata(Config_DontSave)="1"
 	SetVariable setvar_Settings_VC_ADgain,value=_NUM:0.00999999977648258
-	SetVariable setvar_Settings_IC_ADgain,pos={282.00,438.00},size={58.00,18.00},proc=DAP_SetVarProc_CAA
+	SetVariable setvar_Settings_IC_ADgain,pos={311.00,438.00},size={58.00,18.00},proc=DAP_SetVarProc_CAA
 	SetVariable setvar_Settings_IC_ADgain,userdata(tabnum)="6"
 	SetVariable setvar_Settings_IC_ADgain,userdata(tabcontrol)="ADC"
 	SetVariable setvar_Settings_IC_ADgain,userdata(ResizeControlsInfo)=A"!!,HJJ,hsk!!#>V!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
@@ -1529,8 +1529,8 @@ Window DA_Ephys() : Panel
 	PopupMenu Popup_Settings_IC_DA,userdata(ResizeControlsInfo)+=A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
 	PopupMenu Popup_Settings_IC_DA,userdata(Config_DontRestore)="1"
 	PopupMenu Popup_Settings_IC_DA,userdata(Config_DontSave)="1"
-	PopupMenu Popup_Settings_IC_DA,mode=1,popvalue="0",value=#"\"0;1;2;3;4;5;6;7\""
-	SetVariable setvar_Settings_IC_DAgain,pos={282.00,411.00},size={58.00,18.00},proc=DAP_SetVarProc_CAA
+	PopupMenu Popup_Settings_IC_DA,mode=1,popvalue="0",value=#"\"0;1;2;3;4;5;6;7;- none -\""
+	SetVariable setvar_Settings_IC_DAgain,pos={311.00,411.00},size={58.00,18.00},proc=DAP_SetVarProc_CAA
 	SetVariable setvar_Settings_IC_DAgain,userdata(tabnum)="6"
 	SetVariable setvar_Settings_IC_DAgain,userdata(tabcontrol)="ADC"
 	SetVariable setvar_Settings_IC_DAgain,userdata(ResizeControlsInfo)=A"!!,HK!!#C3J,ho,!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
@@ -1539,14 +1539,14 @@ Window DA_Ephys() : Panel
 	SetVariable setvar_Settings_IC_DAgain,userdata(Config_DontRestore)="1"
 	SetVariable setvar_Settings_IC_DAgain,userdata(Config_DontSave)="1"
 	SetVariable setvar_Settings_IC_DAgain,value=_NUM:400
-	TitleBox Title_settings_Hardware_VC,pos={57.00,393.00},size={47.00,15.00}
+	TitleBox Title_settings_Hardware_VC,pos={23.00,393.00},size={47.00,15.00}
 	TitleBox Title_settings_Hardware_VC,title="V-Clamp",userdata(tabnum)="6"
 	TitleBox Title_settings_Hardware_VC,userdata(tabcontrol)="ADC"
 	TitleBox Title_settings_Hardware_VC,userdata(ResizeControlsInfo)=A"!!,Ds!!#C*J,hnu!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	TitleBox Title_settings_Hardware_VC,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	TitleBox Title_settings_Hardware_VC,userdata(ResizeControlsInfo)+=A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
 	TitleBox Title_settings_Hardware_VC,frame=0
-	TitleBox Title_settings_ChanlAssign_IC,pos={237.00,393.00},size={43.00,15.00}
+	TitleBox Title_settings_ChanlAssign_IC,pos={225.00,393.00},size={43.00,15.00}
 	TitleBox Title_settings_ChanlAssign_IC,title="I-Clamp",userdata(tabnum)="6"
 	TitleBox Title_settings_ChanlAssign_IC,userdata(tabcontrol)="ADC"
 	TitleBox Title_settings_ChanlAssign_IC,userdata(ResizeControlsInfo)=A"!!,H*!!#C*J,hne!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
@@ -2350,7 +2350,7 @@ Window DA_Ephys() : Panel
 	SetVariable SetVar_DataAcq_TPAmplitudeIC,userdata(ResizeControlsInfo)+=A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
 	SetVariable SetVar_DataAcq_TPAmplitudeIC,userdata(Config_GroupPath)="Test Pulse"
 	SetVariable SetVar_DataAcq_TPAmplitudeIC,value=_NUM:-50
-	SetVariable SetVar_Hardware_VC_DA_Unit,pos={165.00,411.00},size={30.00,18.00},proc=DAP_SetVarProc_CAA
+	SetVariable SetVar_Hardware_VC_DA_Unit,pos={169.00,411.00},size={30.00,18.00},proc=DAP_SetVarProc_CAA
 	SetVariable SetVar_Hardware_VC_DA_Unit,userdata(tabnum)="6"
 	SetVariable SetVar_Hardware_VC_DA_Unit,userdata(tabcontrol)="ADC"
 	SetVariable SetVar_Hardware_VC_DA_Unit,userdata(ResizeControlsInfo)=A"!!,G5!!#C3J,hn)!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
@@ -2359,7 +2359,7 @@ Window DA_Ephys() : Panel
 	SetVariable SetVar_Hardware_VC_DA_Unit,userdata(Config_DontRestore)="1"
 	SetVariable SetVar_Hardware_VC_DA_Unit,userdata(Config_DontSave)="1"
 	SetVariable SetVar_Hardware_VC_DA_Unit,value=_STR:"mV"
-	SetVariable SetVar_Hardware_IC_DA_Unit,pos={342.00,411.00},size={30.00,18.00},proc=DAP_SetVarProc_CAA
+	SetVariable SetVar_Hardware_IC_DA_Unit,pos={374.00,411.00},size={30.00,18.00},proc=DAP_SetVarProc_CAA
 	SetVariable SetVar_Hardware_IC_DA_Unit,userdata(tabnum)="6"
 	SetVariable SetVar_Hardware_IC_DA_Unit,userdata(tabcontrol)="ADC"
 	SetVariable SetVar_Hardware_IC_DA_Unit,userdata(ResizeControlsInfo)=A"!!,Hg!!#C4!!#=S!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
@@ -2368,7 +2368,7 @@ Window DA_Ephys() : Panel
 	SetVariable SetVar_Hardware_IC_DA_Unit,userdata(Config_DontRestore)="1"
 	SetVariable SetVar_Hardware_IC_DA_Unit,userdata(Config_DontSave)="1"
 	SetVariable SetVar_Hardware_IC_DA_Unit,value=_STR:"pA"
-	SetVariable SetVar_Hardware_VC_AD_Unit,pos={186.00,438.00},size={30.00,18.00},proc=DAP_SetVarProc_CAA
+	SetVariable SetVar_Hardware_VC_AD_Unit,pos={191.00,438.00},size={30.00,18.00},proc=DAP_SetVarProc_CAA
 	SetVariable SetVar_Hardware_VC_AD_Unit,userdata(tabnum)="6"
 	SetVariable SetVar_Hardware_VC_AD_Unit,userdata(tabcontrol)="ADC"
 	SetVariable SetVar_Hardware_VC_AD_Unit,userdata(ResizeControlsInfo)=A"!!,GJ!!#C@!!#=S!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
@@ -2377,7 +2377,7 @@ Window DA_Ephys() : Panel
 	SetVariable SetVar_Hardware_VC_AD_Unit,userdata(Config_DontRestore)="1"
 	SetVariable SetVar_Hardware_VC_AD_Unit,userdata(Config_DontSave)="1"
 	SetVariable SetVar_Hardware_VC_AD_Unit,value=_STR:"pA"
-	SetVariable SetVar_Hardware_IC_AD_Unit,pos={366.00,438.00},size={30.00,18.00},proc=DAP_SetVarProc_CAA
+	SetVariable SetVar_Hardware_IC_AD_Unit,pos={395.00,438.00},size={30.00,18.00},proc=DAP_SetVarProc_CAA
 	SetVariable SetVar_Hardware_IC_AD_Unit,userdata(tabnum)="6"
 	SetVariable SetVar_Hardware_IC_AD_Unit,userdata(tabcontrol)="ADC"
 	SetVariable SetVar_Hardware_IC_AD_Unit,userdata(ResizeControlsInfo)=A"!!,HrJ,hsk!!#=S!!#<Hz!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
@@ -2386,28 +2386,28 @@ Window DA_Ephys() : Panel
 	SetVariable SetVar_Hardware_IC_AD_Unit,userdata(Config_DontRestore)="1"
 	SetVariable SetVar_Hardware_IC_AD_Unit,userdata(Config_DontSave)="1"
 	SetVariable SetVar_Hardware_IC_AD_Unit,value=_STR:"mV"
-	TitleBox Title_Hardware_VC_gain,pos={105.00,393.00},size={23.00,15.00}
+	TitleBox Title_Hardware_VC_gain,pos={110.00,393.00},size={23.00,15.00}
 	TitleBox Title_Hardware_VC_gain,title="gain",userdata(tabnum)="6"
 	TitleBox Title_Hardware_VC_gain,userdata(tabcontrol)="ADC"
 	TitleBox Title_Hardware_VC_gain,userdata(ResizeControlsInfo)=A"!!,F;!!#C*J,hmF!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	TitleBox Title_Hardware_VC_gain,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	TitleBox Title_Hardware_VC_gain,userdata(ResizeControlsInfo)+=A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
 	TitleBox Title_Hardware_VC_gain,frame=0
-	TitleBox Title_Hardware_VC_unit,pos={183.00,393.00},size={21.00,15.00}
+	TitleBox Title_Hardware_VC_unit,pos={170.00,393.00},size={21.00,15.00}
 	TitleBox Title_Hardware_VC_unit,title="unit",userdata(tabnum)="6"
 	TitleBox Title_Hardware_VC_unit,userdata(tabcontrol)="ADC"
 	TitleBox Title_Hardware_VC_unit,userdata(ResizeControlsInfo)=A"!!,GG!!#C*J,hm6!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	TitleBox Title_Hardware_VC_unit,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	TitleBox Title_Hardware_VC_unit,userdata(ResizeControlsInfo)+=A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
 	TitleBox Title_Hardware_VC_unit,frame=0
-	TitleBox Title_Hardware_IC_gain,pos={288.00,393.00},size={23.00,15.00}
+	TitleBox Title_Hardware_IC_gain,pos={311.00,393.00},size={23.00,15.00}
 	TitleBox Title_Hardware_IC_gain,title="gain",userdata(tabnum)="6"
 	TitleBox Title_Hardware_IC_gain,userdata(tabcontrol)="ADC"
 	TitleBox Title_Hardware_IC_gain,userdata(ResizeControlsInfo)=A"!!,HKJ,hsUJ,hmF!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	TitleBox Title_Hardware_IC_gain,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	TitleBox Title_Hardware_IC_gain,userdata(ResizeControlsInfo)+=A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
 	TitleBox Title_Hardware_IC_gain,frame=0
-	TitleBox Title_Hardware_IC_unit,pos={345.00,393.00},size={21.00,15.00}
+	TitleBox Title_Hardware_IC_unit,pos={363.00,393.00},size={21.00,15.00}
 	TitleBox Title_Hardware_IC_unit,title="unit",userdata(tabnum)="6"
 	TitleBox Title_Hardware_IC_unit,userdata(tabcontrol)="ADC"
 	TitleBox Title_Hardware_IC_unit,userdata(ResizeControlsInfo)=A"!!,HgJ,hsUJ,hm6!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
@@ -2671,35 +2671,35 @@ Window DA_Ephys() : Panel
 	TitleBox Title_AD_Unit1,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	TitleBox Title_AD_Unit1,userdata(ResizeControlsInfo)+=A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
 	TitleBox Title_AD_Unit1,frame=0,fStyle=1
-	TitleBox Title_Hardware_VC_DA_Div,pos={198.00,414.00},size={15.00,15.00}
+	TitleBox Title_Hardware_VC_DA_Div,pos={202.00,414.00},size={15.00,15.00}
 	TitleBox Title_Hardware_VC_DA_Div,title="/ V",userdata(tabnum)="6"
 	TitleBox Title_Hardware_VC_DA_Div,userdata(tabcontrol)="ADC"
 	TitleBox Title_Hardware_VC_DA_Div,userdata(ResizeControlsInfo)=A"!!,GW!!#C4J,hlS!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	TitleBox Title_Hardware_VC_DA_Div,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	TitleBox Title_Hardware_VC_DA_Div,userdata(ResizeControlsInfo)+=A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
 	TitleBox Title_Hardware_VC_DA_Div,frame=0
-	TitleBox Title_Hardware_IC_DA_Div,pos={375.00,414.00},size={15.00,15.00}
+	TitleBox Title_Hardware_IC_DA_Div,pos={402.00,414.00},size={15.00,15.00}
 	TitleBox Title_Hardware_IC_DA_Div,title="/ V",userdata(tabnum)="6"
 	TitleBox Title_Hardware_IC_DA_Div,userdata(tabcontrol)="ADC"
 	TitleBox Title_Hardware_IC_DA_Div,userdata(ResizeControlsInfo)=A"!!,I\"!!#C4J,hlS!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	TitleBox Title_Hardware_IC_DA_Div,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	TitleBox Title_Hardware_IC_DA_Div,userdata(ResizeControlsInfo)+=A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
 	TitleBox Title_Hardware_IC_DA_Div,frame=0
-	TitleBox Title_Hardware_IC_AD_Div,pos={348.00,438.00},size={15.00,15.00}
+	TitleBox Title_Hardware_IC_AD_Div,pos={375.00,438.00},size={15.00,15.00}
 	TitleBox Title_Hardware_IC_AD_Div,title="V /",userdata(tabnum)="6"
 	TitleBox Title_Hardware_IC_AD_Div,userdata(tabcontrol)="ADC"
 	TitleBox Title_Hardware_IC_AD_Div,userdata(ResizeControlsInfo)=A"!!,HiJ,hsl!!#<(!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	TitleBox Title_Hardware_IC_AD_Div,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	TitleBox Title_Hardware_IC_AD_Div,userdata(ResizeControlsInfo)+=A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
 	TitleBox Title_Hardware_IC_AD_Div,frame=0
-	TitleBox Title_Hardware_IC_AD_Div1,pos={165.00,438.00},size={15.00,15.00}
+	TitleBox Title_Hardware_IC_AD_Div1,pos={170.00,438.00},size={15.00,15.00}
 	TitleBox Title_Hardware_IC_AD_Div1,title="V /",userdata(tabnum)="6"
 	TitleBox Title_Hardware_IC_AD_Div1,userdata(tabcontrol)="ADC"
 	TitleBox Title_Hardware_IC_AD_Div1,userdata(ResizeControlsInfo)=A"!!,G7!!#CA!!#<(!!#<(z!!#](Aon\"Qzzzzzzzzzzzzzz!!#](Aon\"Qzz"
 	TitleBox Title_Hardware_IC_AD_Div1,userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Duafnzzzzzzzzzzz"
 	TitleBox Title_Hardware_IC_AD_Div1,userdata(ResizeControlsInfo)+=A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
 	TitleBox Title_Hardware_IC_AD_Div1,frame=0
-	GroupBox GroupBox_Hardware_Associations,pos={24.00,303.00},size={444.00,348.00}
+	GroupBox GroupBox_Hardware_Associations,pos={13.00,303.00},size={463.00,348.00}
 	GroupBox GroupBox_Hardware_Associations,title="DAC Channel and Device Associations"
 	GroupBox GroupBox_Hardware_Associations,userdata(tabnum)="6"
 	GroupBox GroupBox_Hardware_Associations,userdata(tabcontrol)="ADC"
@@ -3082,7 +3082,7 @@ Window DA_Ephys() : Panel
 	Button button_DataAcq_FastComp_VC,userdata(ResizeControlsInfo)+=A"zzz!!#u:Duafnzzzzzzzzzzzzzz!!!"
 	Button button_DataAcq_FastComp_VC,userdata(Config_DontRestore)="1"
 	Button button_DataAcq_FastComp_VC,userdata(Config_DontSave)="1"
-	Button button_Hardware_AutoGainAndUnit,pos={399.00,408.00},size={39.00,45.00},proc=DAP_ButtonProc_AutoFillGain
+	Button button_Hardware_AutoGainAndUnit,pos={428.00,408.00},size={39.00,45.00},proc=DAP_ButtonProc_AutoFillGain
 	Button button_Hardware_AutoGainAndUnit,title="Auto\rFill"
 	Button button_Hardware_AutoGainAndUnit,help={"Queries the MultiClamp Commander for the gains of all connected amplifiers of this device."}
 	Button button_Hardware_AutoGainAndUnit,userdata(tabnum)="6"

--- a/Packages/tests/HardwareBasic/UTF_BasicHardwareTests.ipf
+++ b/Packages/tests/HardwareBasic/UTF_BasicHardwareTests.ipf
@@ -2064,7 +2064,7 @@ static Function AcquireWithoutAmplifier_REENTRY([string str])
 	CHECK_EQUAL_WAVES(requireAmplifier, {NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, CHECKBOX_UNSELECTED}, mode = WAVE_DATA)
 
 	WAVE/Z saveAmpSettings = GetLastSetting(numericalValues, sweepNo, "Save amplifier settings", DATA_ACQUISITION_MODE)
-	CHECK_EQUAL_WAVES(saveAmpSettings, {NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, CHECKBOX_UNSELECTED}, mode = WAVE_DATA)
+	CHECK_EQUAL_WAVES(saveAmpSettings, {NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, CHECKBOX_SELECTED}, mode = WAVE_DATA)
 End
 
 // UTF_TD_GENERATOR GetITCDevices

--- a/Packages/tests/HardwareBasic/UTF_TestPulseAndTPDuringDAQ.ipf
+++ b/Packages/tests/HardwareBasic/UTF_TestPulseAndTPDuringDAQ.ipf
@@ -988,8 +988,6 @@ static Function WaitAndCheckStoredTPs_IGNORE(device, expectedNumTPchannels)
 	endfor
 End
 
-static Constant TP_DURATION_S = 5
-
 static Function CheckThatTPsCanBeFound_PreAcq(device)
 	string device
 

--- a/Packages/tests/UTF_Constants.ipf
+++ b/Packages/tests/UTF_Constants.ipf
@@ -5,3 +5,4 @@
 
 Constant PSQ_TEST_HEADSTAGE = 2
 StrConstant ZSTD_SUFFIX     = ".zst"
+Constant TP_DURATION_S = 5

--- a/Packages/tests/UTF_HelperFunctions.ipf
+++ b/Packages/tests/UTF_HelperFunctions.ipf
@@ -38,8 +38,8 @@ End
 
 Function FixupJSONConfigImplRig(variable jsonId)
 
-	string serialNumStr
-	variable serialNum
+	string serialNumStr, jsonPath
+	variable serialNum, i
 
 	// replace stored serial number with present serial number
 	AI_FindConnectedAmps()
@@ -53,8 +53,14 @@ Function FixupJSONConfigImplRig(variable jsonId)
 		serialNum = str2num(serialNumStr)
 	endif
 
-	JSON_SetVariable(jsonID, "/Common configuration data/Headstage Association/0/Amplifier/Serial", serialNum)
-	JSON_SetVariable(jsonID, "/Common configuration data/Headstage Association/1/Amplifier/Serial", serialNum)
+	for(i = 0; i < NUM_HEADSTAGES; i += 1)
+		sprintf jsonPath, "/Common configuration data/Headstage Association/%d/Amplifier/Serial", i
+		if(!JSON_Exists(jsonID, jsonPath))
+			continue
+		endif
+
+		JSON_SetVariable(jsonID, jsonPath, serialNum)
+	endfor
 End
 
 Function FixupJSONConfigImpl(variable jsonId, string device)

--- a/Packages/tests/UTF_HelperFunctions.ipf
+++ b/Packages/tests/UTF_HelperFunctions.ipf
@@ -58,6 +58,9 @@ Function FixupJSONConfigImplRig(variable jsonId)
 		if(!JSON_Exists(jsonID, jsonPath))
 			continue
 		endif
+		if(JSON_GetType(jsonID, jsonPath) == JSON_NULL)
+			continue
+		endif
 
 		JSON_SetVariable(jsonID, jsonPath, serialNum)
 	endfor


### PR DESCRIPTION
- Previously the on restore the amplifiers were set plain by headstage. The default configuration of the DAEphys panel is that unless "Clear Associations" is clicked all HS are associated. Also MIES implements that associated HS need to have an amplifier set.

  On saving the DAEphys window there is no GUI control that state explicitly if a HS is associated or not.

  Solution: We assume that the headstages without a set amplifier are unassociated and clear the association for these HS.

since introduction of configuration module

close https://github.com/AllenInstitute/MIES/issues/1763
close https://github.com/AllenInstitute/MIES/issues/1811