### PR TITLE
DC: Bugfix Use actual mode DAQOrTP in TTL stimset setup

### DIFF
--- a/Packages/MIES/MIES_DataConfigurator.ipf
+++ b/Packages/MIES/MIES_DataConfigurator.ipf
@@ -1534,7 +1534,7 @@ static Function DC_SetupConfigurationTTLstimSets(string device, STRUCT DataConfi
 	variable i, col, setCycleCount
 
 	WAVE/T allSetNames = DAG_GetChannelTextual(device, CHANNEL_TYPE_TTL, CHANNEL_CONTROL_WAVE)
-	WAVE statusTTLFiltered = DC_GetFilteredChannelState(device, DATA_ACQUISITION_MODE, CHANNEL_TYPE_TTL)
+	WAVE statusTTLFiltered = DC_GetFilteredChannelState(device, s.dataAcqOrTP, CHANNEL_TYPE_TTL)
 
 	for(i = 0; i < NUM_DA_TTL_CHANNELS; i += 1)
 		if(!statusTTLFiltered[i])
@@ -1542,7 +1542,8 @@ static Function DC_SetupConfigurationTTLstimSets(string device, STRUCT DataConfi
 		endif
 		s.TTLsetName[i] = allSetNames[i]
 		s.TTLstimSet[i] = WB_CreateAndGetStimSet(s.TTLsetName[i])
-		s.TTLsetLength[i] = DC_CalculateStimsetLength(s.TTLstimSet[i], device, DATA_ACQUISITION_MODE)
+		ASSERT(WaveExists(s.TTLstimSet[i]), "Can't retrieve TTL stimset " + s.TTLsetName[i])
+		s.TTLsetLength[i] = DC_CalculateStimsetLength(s.TTLstimSet[i], device,  s.dataAcqOrTP)
 
 		[col, setCycleCount] = DC_CalculateChannelColumnNo(device, s.TTLsetName[i], i, CHANNEL_TYPE_TTL)
 		s.TTLsetColumn[i] = col

--- a/Packages/tests/HardwareBasic/UTF_BasicHardwareTests.ipf
+++ b/Packages/tests/HardwareBasic/UTF_BasicHardwareTests.ipf
@@ -2251,3 +2251,22 @@ static Function RandomAcq_REENTRY([string str])
 	Sort maxDA, maxDA
 	CHECK_EQUAL_WAVES(maxDA, {1, 2, 3})
 End
+
+static Function CheckIfNoTTLonTP_preAcq(string device)
+
+	PGC_SetAndActivateControl(device, GetPanelControl(0, CHANNEL_TYPE_TTL, CHANNEL_CONTROL_CHECK), val = 1)
+End
+
+// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+static Function CheckIfNoTTLonTP([string str])
+
+	STRUCT DAQSettings s
+	InitDAQSettingsFromString(s, "MD1_RA1_I0_L0_BKG1_TP1"                     + \
+										"__HS0_DA0_AD0_CM:VC:_ST:StimulusSetA_DA_0:")
+	AcquireData_NG(s, str)
+	CtrlNamedBackGround StopTPAfterSomeTime, start=(ticks + 60 * 3), period=60, proc=StopTP_IGNORE
+End
+
+static Function CheckIfNoTTLonTP_REENTRY([string str])
+	PASS()
+End


### PR DESCRIPTION
previously always DATA_ACQUISITION_MODE was set, which resulted in an attempt to setup a stimset for a activated TTL channel when TP was run. However, there should be no TTL channel setup for TP even when the channel is activated for DAQ.

Since:
0530ff40 (DC: Add more DataConfigurationResult structure fields for TTL and fill them, 2023-07-04)
