### PR TITLE
LBV_AddTagsForTextualLBNEntries: Output correct headstage

### DIFF
--- a/Packages/MIES/MIES_LogbookViewer.ipf
+++ b/Packages/MIES/MIES_LogbookViewer.ipf
@@ -792,7 +792,7 @@ static Function LBV_AddTagsForTextualLBNEntries(string graph, WAVE/T keys, WAVE/
 			endif
 
 			[s] = GetHeadstageColor(j)
-			sprintf tmp, "\\K(%d, %d, %d)%d:\\K(0, 0, 0)", s.red, s.green, s.blue, j + 1
+			sprintf tmp, "\\K(%d, %d, %d)%d:\\K(0, 0, 0)", s.red, s.green, s.blue, j
 			text = ReplaceString("\\", text, "\\\\")
 			tagString = tagString + tmp + text + "\r"
 		endfor


### PR DESCRIPTION
Broken since 7c3605b7 (Add support displaying textual labnotebook data, 2016-08-18).

It's hilarious how long this was plotted wrongly and nobody noticed.