### PR TITLE
CI: Disable report generation for release branches

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -64,6 +64,7 @@ jobs:
   GenerateReport:
     name: 📊 Generate Reports
     runs-on: [ self-hosted, Linux, Docker ]
+    if: github.ref_name == 'main'
     needs:
       - CallPR
     steps:


### PR DESCRIPTION
Report Generation does need the Cobertura files from the instrumentation run. This is not done for release branches and only for the main branch.

Close: #1847

Thanks for opening a PR in MIES :sparkles:!

- Code can only be merged if the continous integration tests pass
- [x] Please ensure that the branch is named correctly. See
  [here](https://alleninstitute.github.io/MIES/developers.html#branch-naming-scheme) for the detailed explanation.
