### PR TITLE
CI: Disable report generation for release branches [ForwardPort on main]

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -64,6 +64,7 @@ jobs:
   GenerateReport:
     name: 📊 Generate Reports
     runs-on: [ self-hosted, Linux, Docker ]
+    if: github.ref_name == 'main'
     needs:
       - CallPR
     steps:


### PR DESCRIPTION
Report Generation does need the Cobertura files from the instrumentation run. This is not done for release branches and only for the main branch.

See: #1847, PR #1849