### PR TITLE
GetAllFilesRecursivelyFromPath: Fix returning empty results at the end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ CheckIfConfigurationRestoresMCCFilterGain.json
 
 # Renamed experiments during tests
 Packages/tests/**/20*.pxp
+
+Packages/tests/Basic/test*

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -2867,7 +2867,7 @@ Function/S GetAllFilesRecursivelyFromPath(pathName, [extension])
 		KillPath/Z $subFolderPathName
 
 		if(!isEmpty(files))
-			allFiles = AddListItem(files, allFiles, FILE_LIST_SEP, Inf)
+			allFiles = AddListItem(RemoveEnding(files, FILE_LIST_SEP), allFiles, FILE_LIST_SEP, Inf)
 		endif
 	endfor
 

--- a/Packages/tests/Basic/UTF_Utils.ipf
+++ b/Packages/tests/Basic/UTF_Utils.ipf
@@ -7202,3 +7202,38 @@ static Function TestUpperCaseFirstChar()
 	CHECK_EQUAL_STR(UpperCaseFirstChar("a1a"), "A1a")
 	CHECK_EQUAL_STR(UpperCaseFirstChar("b"), "B")
 End
+
+static Function TestGetAllFilesRecursivelyFromPath()
+
+	string folder, symbPath, list
+
+	folder = GetFolder(FunctionPath("")) + "testFolder:"
+
+	symbPath = GetUniqueSymbolicPath()
+	NewPath/Q/O/C/Z $symbPath, folder
+	CHECK(!V_Flag)
+
+	CreateFolderOnDisk(folder + "b:")
+	CreateFolderOnDisk(folder + "c:")
+
+	SaveTextFile("", folder + "file.txt")
+	SaveTextFile("", folder + "b:file1.txt")
+	SaveTextFile("", folder + "c:file2.txt")
+
+	CreateAliasShortcut/Z/P=$symbPath "file.txt" "alias.txt"
+	CHECK(!V_flag)
+
+	list = GetAllFilesRecursivelyFromPath(symbPath, extension = ".txt")
+	CHECK_PROPER_STR(list)
+
+	WAVE/T result = ListToTextWave(list, FILE_LIST_SEP)
+	result[] = RemovePrefix(result[p], start = folder)
+	CHECK_EQUAL_TEXTWAVES(result, {"file.txt", "b:file1.txt", "c:file2.txt"})
+
+	// no matches
+	list = GetAllFilesRecursivelyFromPath(symbPath, extension = ".abc")
+	CHECK_EMPTY_STR(list)
+
+	KillPath $symbPath
+	CHECK_NO_RTE()
+End


### PR DESCRIPTION
Since the bugfix in 3b9e1c5a (bugfix: GetAllFilesRecursivelyFromPath use reliable name retrieval, 2023-05-22) the list of returned files contained an empty entry at the end.

Remove that and also add tests.

Will merge once CI passes.