### PR TITLE
ConvertXOPErrorCode: Fix it for the general case

### DIFF
--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -6662,15 +6662,17 @@ End
 /// @brief Remove the volatile part of the XOP error code
 ///
 /// The result is constant and can therefore be compared with constants.
-threadsafe Function ConvertXOPErrorCode(xopError)
-	variable xopError
+threadsafe Function ConvertXOPErrorCode(variable err)
+	// error codes -1 to 9999 are Igor Pro error codes
+	// for first loaded XOP -> xop error codes returned are in the range 10000+ up to max. 10999
+	// for second+ loaded XOP -> xop error codes returned are offsetted by n x 0x10000 per XOP instead of 10000
 
-	if(xopError < FIRST_XOP_ERROR)
-		// stock Igor Pro error
-		return xopError
-	endif
+	// Therefore, returning the code through RTE and directly through V_flag (SetOperationReturnValue):
+	err = err < 0xFFFF ? err : (err & 0xFFFF) + 10000
 
-	return xopError == 0 ? 0 : (mod(xopError, FIRST_XOP_ERROR) + FIRST_XOP_ERROR)
+	// Note: Getting the error message through GetRTErrMessage,
+	// GetErrMessage(code) requires the original RTE code (does not work with directly return through  V_flag).
+	return err
 End
 
 /// @brief Extended version of `FindValue`

--- a/Packages/tests/Basic/UTF_Utils.ipf
+++ b/Packages/tests/Basic/UTF_Utils.ipf
@@ -7237,3 +7237,22 @@ static Function TestGetAllFilesRecursivelyFromPath()
 	KillPath $symbPath
 	CHECK_NO_RTE()
 End
+
+static Function TestErrorCodeConversion()
+
+	variable err, convErr
+	string errMsg
+
+	JSONXOP_Parse/Q ""
+	err = GetRTError(0)
+	CHECK_RTE(err)
+
+	errMsg = "Error when parsing string to JSON"
+	CHECK_EQUAL_STR(errMsg, GetErrMessage(err))
+
+	convErr = ConvertXOPErrorCode(err)
+	CHECK_EQUAL_VAR(convErr, 10009)
+
+	// is idempotent
+	CHECK_EQUAL_VAR(ConvertXOPErrorCode(convErr), 10009)
+End


### PR DESCRIPTION
We need to handle two different ways to feed in error codes. The first is directly the runtime error code we got from IP. These are unique and for XOPs shifted by 10000 per XOP. The second is V_flag as returned by the XOP with /Z being present. These are the exact same values as defined in the XOP.

The new code handles both cases correctly.

Close #1755