### PR TITLE
.github/workflows: Cancel redundant workflow runs

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -31,6 +31,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
 
   BuildInstaller:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -229,7 +229,7 @@ jobs:
   FTPUpload:
     name: 📦 FTP Upload Artifacts
     runs-on: [ self-hosted, Linux, Docker ]
-    if: always() && !inputs.is_called_workflow
+    if: ${{ !cancelled() && !inputs.is_called_workflow}}
     needs:
       # All jobs that create new artifacts
       - BuildInstaller

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -126,7 +126,7 @@ jobs:
   FTPUpload:
     name: 📦 FTP Upload Artifacts
     runs-on: [ self-hosted, Linux, Docker ]
-    if: always()
+    if: ${{ !cancelled() }}
     needs:
       # All jobs that create new artifacts
       - CallPR

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -8,6 +8,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
 
   CallPR:


### PR DESCRIPTION
Evern since the move to github actions in 70daa61b (CI: add GH actions for main and release builds, 2023-04-20) we just executed the workflows for every branch push.

This can quickly result in the workflow queue being clogged. There is also no point in executing older versions of the same branch when a newer version is available.

The version here supports multiple workflows [1]. And also cancels, on purpose, redundant workflows on main and the release branches. See [2] for a future way to don't do that on special branches.

[1]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
[2]: https://stackoverflow.com/questions/68418857/how-to-cancel-existing-runs-when-a-new-push-happens-on-github-actions-but-only
