### PR TITLE
.github/workflows/build-release.yaml: Fix deadlock on workflow skipping

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -8,9 +8,6 @@ on:
 defaults:
   run:
     shell: bash
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 jobs:
 
   CallPR:


### PR DESCRIPTION
The recent fix in ba69a129 (.github/workflows: Cancel redundant workflow runs, 2023-09-08) did not work for the main branch as the error message on cancelling was [1]:

> Cancelling since a deadlock for concurrency group 'Build Release-refs/heads/main'
> was detected between 'top level workflow' and 'CallPR'

So we now only cancel the CallPR workflow.
