### PR TITLE
Bugfix: Fix pending RTE from ShowTraceInfoTags

### DIFF
--- a/Packages/MIES/MIES_GuiUtilities.ipf
+++ b/Packages/MIES/MIES_GuiUtilities.ipf
@@ -2137,6 +2137,16 @@ Function ShowTraceInfoTags()
 	// Window must not be hidden
 	// Returns in S_value the state before toggling
 	DoIgorMenu/OVRD "Graph", "Show Trace Info Tags"
+	if(IsNull(S_value))
+		BUG("DoIgorMenu returned S_value as null string for \"Show Trace Info Tags\"")
+		KillWindow/Z $S_name
+		return NaN
+	endif
+	if(IsEmpty(S_value))
+		BUG("DoIgorMenu returned S_value as empty string for \"Show Trace Info Tags\"")
+		KillWindow/Z $S_name
+		return NaN
+	endif
 	if(CmpStr(S_value,"Show Trace Info Tags"))
 		// toggled to "Show Trace Info Tags", need to toggle back
 		DoIgorMenu/OVRD "Graph", "Show Trace Info Tags"


### PR DESCRIPTION
Under special circumstance DoIgorMenu/OVRD returned a null string for S_value. This was reported to WM and should be fixed in Igor Pro 9 Build 56469 or later.

This commit adds two checks that give a BUG message if S_value is either returned null or empty as both should never happen.

since at least eceba1dd (bugfix for showing the traceinfotags, 2023-08-07)

close https://github.com/AllenInstitute/MIES/issues/1886