### PR TITLE
tools/sign-installer.sh: Add retry loop

### DIFF
--- a/tools/sign-installer.sh
+++ b/tools/sign-installer.sh
@@ -65,12 +65,27 @@ done
 # signtool does not accept a path for the certificate
 cp $top_level/tools/installer/public-key.cer public-key.cer
 
-MSYS_NO_PATHCONV=1 "$sign_tool_exe" sign \
-  /tr http://timestamp.sectigo.com \
-  /fd sha256 \
-  /td sha256 \
-  /csp "eToken Base Cryptographic Provider" \
-  /kc "$privKeyContainerName" \
-  /f public-key.cer \
-  tools/installer/MIES*.exe \
-  || exit $?
+i=0
+
+while [ $i -le 10 ]
+do
+  MSYS_NO_PATHCONV=1 "$sign_tool_exe" sign    \
+    /tr http://timestamp.sectigo.com          \
+    /fd sha256                                \
+    /td sha256                                \
+    /csp "eToken Base Cryptographic Provider" \
+    /kc "$privKeyContainerName"               \
+    /f public-key.cer                         \
+    tools/installer/MIES*.exe
+
+  if [ $? -eq 0 ]
+  then
+    exit 0
+  fi
+
+  ((i++))
+
+  sleep $i
+done
+
+exit 1


### PR DESCRIPTION
We currently have CI issues with signing the installer. The signing step fails very often with:

Run tools/sign-installer.sh -p "***"
Done Adding Additional Store

Number of errors: 1

SignTool Error: The file is being used by another process.
SignTool Error: An error occurred while attempting to sign: tools/installer/MIES-Release_2.7_20230809-85-g2be12df50-cis.exe

The causes are unknown.

As a band-aid let's retry the signing step on error.

Close #1904