### PR TITLE
SI: Introduce channel type dependent sampling interval (SUTTER preparation 2)

### DIFF
--- a/Packages/MIES/MIES_DataConfigurator.ipf
+++ b/Packages/MIES/MIES_DataConfigurator.ipf
@@ -672,10 +672,6 @@ static Function DC_PlaceDataInDAQConfigWave(device, dataAcqOrTP)
 
 	AddEntryIntoWaveNoteAsList(DAQConfigWave, CHANNEL_UNIT_KEY, str = unitList, replaceEntry = 1)
 
-	DAQConfigWave[][%SamplingInterval] = DAP_GetSampInt(device, dataAcqOrTP)
-	DAQConfigWave[][%DecimationMode]   = 0
-	DAQConfigWave[][%Offset]           = 0
-
 	if(dataAcqOrTP == DATA_ACQUISITION_MODE)
 		variable hardwareType = GetHardwareType(device)
 		switch(hardwareType)
@@ -714,6 +710,10 @@ static Function DC_PlaceDataInDAQConfigWave(device, dataAcqOrTP)
 				break
 		endswitch
 	endif
+
+	DAQConfigWave[][%SamplingInterval] = DAP_GetSampInt(device, dataAcqOrTP, DAQConfigWave[p][%ChannelType])
+	DAQConfigWave[][%DecimationMode]   = 0
+	DAQConfigWave[][%Offset]           = 0
 End
 
 /// @brief Get the decimation factor for the current channel configuration
@@ -727,7 +727,7 @@ static Function DC_GetDecimationFactor(device, dataAcqOrTP)
 	string device
 	variable dataAcqOrTP
 
-	return DAP_GetSampInt(device, dataAcqOrTP) / (WAVEBUILDER_MIN_SAMPINT * MILLI_TO_MICRO)
+	return DAP_GetSampInt(device, dataAcqOrTP, XOP_CHANNEL_TYPE_DAC) / (WAVEBUILDER_MIN_SAMPINT * MILLI_TO_MICRO)
 End
 
 /// @brief Returns the longest sweep in a stimulus set across the given channel type
@@ -1318,7 +1318,7 @@ static Function [STRUCT DataConfigurationResult s] DC_GetConfiguration(string de
 	// MH: note with NI the decimationFactor can now be < 1, like 0.4 if a single NI ADC channel runs with 500 kHz
 	// whereas the source data generated waves for ITC min sample rate are at 200 kHz
 	s.decimationFactor = DC_GetDecimationFactor(device, dataAcqOrTP)
-	s.samplingInterval = DAP_GetSampInt(device, dataAcqOrTP)
+	s.samplingInterval = DAP_GetSampInt(device, dataAcqOrTP, XOP_CHANNEL_TYPE_DAC)
 	WAVE/T allSetNames = DAG_GetChannelTextual(device, CHANNEL_TYPE_DAC, CHANNEL_CONTROL_WAVE)
 	s.hardwareType     = GetHardwareType(device)
 

--- a/Packages/MIES/MIES_Oscilloscope.ipf
+++ b/Packages/MIES/MIES_Oscilloscope.ipf
@@ -383,7 +383,7 @@ Function SCOPE_CreateGraph(device, dataAcqOrTP)
 	if(gotDAQChan)
 		Label/W=$graph bottomDAQ "Time DAQ (\\U)"
 		NVAR stopCollectionPoint = $GetStopCollectionPoint(device)
-		sampInt = DAP_GetSampInt(device, DATA_ACQUISITION_MODE) * MICRO_TO_MILLI
+		sampInt = DAP_GetSampInt(device, DATA_ACQUISITION_MODE, XOP_CHANNEL_TYPE_ADC) * MICRO_TO_MILLI
 		SetAxis/W=$graph bottomDAQ, 0, stopCollectionPoint * sampInt
 		ModifyGraph/W=$graph freePos(bottomDAQ)=-35
 	endif

--- a/Packages/MIES/MIES_SamplingInterval.ipf
+++ b/Packages/MIES/MIES_SamplingInterval.ipf
@@ -503,11 +503,10 @@ End
 ///
 /// @param device  device
 /// @param dataAcqOrTP one of @ref DataAcqModes, ignores TTL channels for #TEST_PULSE_MODE
+/// @param channelType channel type @sa XopChannelConstants
 ///
 /// @returns sampling interval in microseconds (1e-6)
-Function SI_CalculateMinSampInterval(device, dataAcqOrTP)
-	string device
-	variable dataAcqOrTP
+Function SI_CalculateMinSampInterval(string device, variable dataAcqOrTP, variable channelType)
 
 	variable hardwareType = GetHardwareType(device)
 	switch(hardwareType)

--- a/Packages/MIES/MIES_TestPulse.ipf
+++ b/Packages/MIES/MIES_TestPulse.ipf
@@ -1538,8 +1538,8 @@ Function TP_UpdateTPSettingsCalculated(string device)
 	calculated[%baselineFrac]         = TPSettings[%baselinePerc][INDEP_HEADSTAGE] * PERCENT_TO_ONE
 
 	calculated[%pulseLengthMS]        = TPSettings[%durationMS][INDEP_HEADSTAGE] // here for completeness
-	calculated[%pulseLengthPointsTP]  = trunc(TPSettings[%durationMS][INDEP_HEADSTAGE] / (DAP_GetSampInt(device, TEST_PULSE_MODE) * MICRO_TO_MILLI))
-	calculated[%pulseLengthPointsDAQ] = trunc(TPSettings[%durationMS][INDEP_HEADSTAGE] / (DAP_GetSampInt(device, DATA_ACQUISITION_MODE) * MICRO_TO_MILLI))
+	calculated[%pulseLengthPointsTP]  = trunc(TPSettings[%durationMS][INDEP_HEADSTAGE] / (DAP_GetSampInt(device, TEST_PULSE_MODE, XOP_CHANNEL_TYPE_DAC) * MICRO_TO_MILLI))
+	calculated[%pulseLengthPointsDAQ] = trunc(TPSettings[%durationMS][INDEP_HEADSTAGE] / (DAP_GetSampInt(device, DATA_ACQUISITION_MODE, XOP_CHANNEL_TYPE_DAC) * MICRO_TO_MILLI))
 
 	calculated[%totalLengthMS]        = TP_CalculateTestPulseLength(calculated[%pulseLengthMS], calculated[%baselineFrac])
 	calculated[%totalLengthPointsTP]  = trunc(TP_CalculateTestPulseLength(calculated[%pulseLengthPointsTP], calculated[%baselineFrac]))


### PR DESCRIPTION
- there exists hardware that can have different sampling rates for DAC and ADC Thus, the function for determining the sampling interval must depend on the channel type.
- the main utility function changes is DAP_GetSampInt that got a channel type argument added

The scope of this change is only to introduce support in the sample interval getter functions, it does not introduce acquisition support for channel dependent sample rates.
