### PR TITLE
Fix: Testpulse calculation failed if TP data is NaN

### DIFF
--- a/Packages/MIES/MIES_TestPulse.ipf
+++ b/Packages/MIES/MIES_TestPulse.ipf
@@ -962,7 +962,12 @@ threadsafe Function/DF TP_TSAnalysis(dfrInp)
 	// as data is always too small for threaded execution, the values of V_minRowLoc/V_maxRowLoc are reproducible
 	WaveStats/P/Q/M=1/R=[refPoint, refPoint + 0.25 / sampleInt] data
 	instPoint = (clampAmp < 0) ? V_minRowLoc : V_maxRowLoc
-	instVal = data[instPoint]
+	if(instPoint == -1)
+		// all wave data is NaN
+		instVal = NaN
+	else
+		instVal = data[instPoint]
+	endif
 
 #if defined(TP_ANALYSIS_DEBUGGING)
 	DEBUGPRINT_TS("instantaneous refPoint: ", var = instPoint)


### PR DESCRIPTION
In the case the test pulse data is completely NaN WaveStats can not determine V_minRowLoc and V_maxRowLoc and returns a -1 in both. This index was used unchecked and resulted in a RTE for invalid wave index access.

This is now checked properly and NaN is returned for "instantaneous".

since
c5ed1686 (TP_TSAnalysis: Change the way we calculate the instantaneous resistance, 2022-09-02)
