### PR TITLE
.github/workflows/build-release.yml: Fix typo in assets name

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -144,7 +144,7 @@ jobs:
             xargs -I {} tools/ftp-upload/flatten-files.sh "{}"
       - name: Compress NWB artifacts
         run: |
-          for dir in test-itc18-assets tests-itc1600-assets test-ni-assets
+          for dir in test-itc18-assets test-itc1600-assets test-ni-assets
           do
             tar --remove-files --use-compress-program=zstd -cvf $dir/NWB.tar.zst $dir/*nwb
           done


### PR DESCRIPTION
Bug introduced in 30a590ea (CI: Add testing with ITC1600, 2023-09-25).


