### PR TITLE
.github/workflows/build-pr.yml: Rework job execution order

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -90,7 +90,6 @@ jobs:
       👩🏾‍🔬 Compilation: ${{ matrix.source }} ${{ fromJSON('["","with XOP"]')[matrix.hardware] }}
     needs:
       - BuildInstaller
-      - Linting
     strategy:
       matrix:
         source: [ git, installer ]
@@ -136,6 +135,7 @@ jobs:
     name: 🧪 Test ${{ matrix.name }}
     needs:
       - BuildInstaller
+      - Linting
       - CompilationTest
     strategy:
       matrix:
@@ -161,6 +161,7 @@ jobs:
     needs:
       - BuildInstaller
       - CompilationTest
+      - TestWithoutHardware
     strategy:
       matrix:
         include:
@@ -184,6 +185,7 @@ jobs:
     needs:
       - BuildInstaller
       - CompilationTest
+      - TestWithoutHardware
     strategy:
       matrix:
         include:
@@ -207,6 +209,7 @@ jobs:
     needs:
       - BuildInstaller
       - CompilationTest
+      - TestWithoutHardware
     strategy:
       matrix:
         include:


### PR DESCRIPTION
The compilaton job does not need to depend on the installer job and the tests without hardware job is now executed before the hardware jobs. The reason is that the latter jobs are quite expensive to run.