### PR TITLE
MIES_AnalysisFunctions_PatchSeq.ipf: Remove fallthrough to PRE_SET_EVENT

### DIFF
--- a/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
@@ -2165,8 +2165,7 @@ Function PSQ_DAScale(device, s)
 			endif
 
 			DisableControls(device, "Button_DataAcq_SkipBackwards;Button_DataAcq_SkipForward")
-
-			// fallthrough-by-design
+			break
 		case PRE_SET_EVENT:
 			SetAnalysisFunctionVersion(device, PSQ_DA_SCALE, s.headstage, s.sweepNo)
 
@@ -2425,7 +2424,7 @@ Function PSQ_DAScale(device, s)
 			break
 	endswitch
 
-	if(s.eventType == PRE_DAQ_EVENT || s.eventType == PRE_SET_EVENT || s.eventType == POST_SWEEP_EVENT)
+	if(s.eventType == PRE_SET_EVENT || s.eventType == POST_SWEEP_EVENT)
 		WAVE statusHS = DAG_GetChannelState(device, CHANNEL_TYPE_HEADSTAGE)
 
 		for(i = 0; i < NUM_HEADSTAGES; i += 1)
@@ -2585,8 +2584,7 @@ Function PSQ_SquarePulse(device, s)
 			endif
 
 			DisableControls(device, "Button_DataAcq_SkipBackwards;Button_DataAcq_SkipForward")
-
-			// fallthrough-by-design
+			break
 		case PRE_SET_EVENT:
 			SetAnalysisFunctionVersion(device, PSQ_SQUARE_PULSE, s.headstage, s.sweepNo)
 
@@ -2868,8 +2866,7 @@ Function PSQ_Rheobase(device, s)
 			endif
 
 			DisableControls(device, "Button_DataAcq_SkipBackwards;Button_DataAcq_SkipForward")
-
-			// fallthrough-by-design
+			break
 		case PRE_SET_EVENT:
 			SetAnalysisFunctionVersion(device, PSQ_RHEOBASE, s.headstage, s.sweepNo)
 
@@ -3324,8 +3321,7 @@ Function PSQ_Ramp(device, s)
 			endif
 
 			DisableControls(device, "Button_DataAcq_SkipBackwards;Button_DataAcq_SkipForward")
-
-			// fallthrough-by-design
+			break
 		case PRE_SET_EVENT:
 			SetAnalysisFunctionVersion(device, PSQ_RAMP, s.headstage, s.sweepNo)
 
@@ -4253,8 +4249,8 @@ Function PSQ_Chirp(device, s)
 			endif
 
 			DisableControls(device, "Button_DataAcq_SkipBackwards;Button_DataAcq_SkipForward")
-
-		case PRE_SET_EVENT: // fallthrough-by-design
+			break
+		case PRE_SET_EVENT:
 			SetAnalysisFunctionVersion(device, PSQ_CHIRP, s.headstage, s.sweepNo)
 
 			PSQ_SetAutobiasTargetVIfPresent(device, s.headstage, s.params, "AutobiasTargetV")


### PR DESCRIPTION
In 76b7cd2f (Patch Seq: Make it work with indexing, 2018-06-11) we introduced support for using indexing with the patch seq analysis functions. We did that by executing the code we can in PRE_SET_EVENT and everything else in PRE_DAQ_EVENT. The added fallthrough means that we execute the code in PRE_SET_EVENT also in PRE_DAQ_EVENT.

It is not clear why we did it back then like that, so let's remove the fallthrough.

Close #1192

The reason I'm doing that now is that I want to perform some more expensive tasks for DAScale adaptive supratreshold in PRE_SET_EVENT but then it matters if we execute that code in PRE_DAQ_EVENT or not.
