### PR TITLE
PSQ_CreateOverrideResults: Pass in the operation mode for PSQ_DAScale

### DIFF
--- a/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
@@ -1163,14 +1163,12 @@ Function/WAVE PSQ_CreateOverrideResults(device, headstage, type, [opMode])
 		case PSQ_RAMP:
 		case PSQ_RHEOBASE:
 			numChunks = 4
-			numLayers = 3
 			numRows = PSQ_GetNumberOfChunks(device, 0, headstage, type)
 			numCols = IDX_NumberOfSweepsInSet(stimset)
 			layerDimLabels = "BaselineQC;SpikePositionAndQC;AsyncQC"
 			break
 		case PSQ_DA_SCALE:
 			numChunks = 4
-			numLayers = 4
 			numRows = PSQ_GetNumberOfChunks(device, 0, headstage, type)
 			numCols = IDX_NumberOfSweepsInSet(stimset)
 			layerDimLabels = "BaselineQC;SpikePosition;NumberOfSpikes;AsyncQC"
@@ -1178,40 +1176,34 @@ Function/WAVE PSQ_CreateOverrideResults(device, headstage, type, [opMode])
 		case PSQ_SQUARE_PULSE:
 			numRows = 1
 			numCols = IDX_NumberOfSweepsInSet(stimset)
-			numLayers = 2
 			layerDimLabels = "SpikePositionAndQC;AsyncQC"
 			break
 		case PSQ_CHIRP:
 			numChunks = 4
-			numLayers = 5
 			numRows = PSQ_GetNumberOfChunks(device, 0, headstage, type)
 			numCols = IDX_NumberOfSweepsInSet(stimset)
 			layerDimLabels = "BaselineQC;MaxInChirp;MinInChirp;SpikeQC;AsyncQC"
 			break
 		case PSQ_PIPETTE_BATH:
 			numChunks = 4
-			numLayers = 3
 			numRows = PSQ_GetNumberOfChunks(device, 0, headstage, type)
 			numCols = IDX_NumberOfSweepsInSet(stimset)
 			layerDimLabels = "BaselineQC;SteadyStateResistance;AsyncQC"
 			break
 		case PSQ_SEAL_EVALUATION:
 			numChunks = 4
-			numLayers = 4
 			numRows = 2 // upper limit
 			numCols = IDX_NumberOfSweepsInSet(stimset)
 			layerDimLabels = "BaselineQC;ResistanceA;ResistanceB;AsyncQC"
 			break
 		case PSQ_TRUE_REST_VM:
 			numChunks = 4
-			numLayers = 4
 			numRows = 2
 			numCols = IDX_NumberOfSweepsInSet(stimset)
 			layerDimLabels = "BaselineQC;NumberOfSpikes;AverageVoltage;AsyncQC"
 			break
 		case PSQ_ACC_RES_SMOKE:
 			numChunks = 4
-			numLayers = 4
 			numRows = 1
 			numCols = IDX_NumberOfSweepsInSet(stimset)
 			layerDimLabels = "BaselineQC;AccessResistance;SteadyStateResistance;AsyncQC"
@@ -1221,6 +1213,7 @@ Function/WAVE PSQ_CreateOverrideResults(device, headstage, type, [opMode])
 	endswitch
 
 	WAVE/D/Z wv = GetOverrideResults()
+	numLayers = ItemsInList(layerDimLabels, ";")
 
 	if(WaveExists(wv))
 		Redimension/D/N=(numRows, numCols, numLayers, numChunks) wv

--- a/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
@@ -1141,9 +1141,10 @@ End
 /// - 1: RMS long baseline QC
 /// - 2: target voltage baseline QC
 /// - 3: leak current baseline QC
-Function/WAVE PSQ_CreateOverrideResults(device, headstage, type)
+Function/WAVE PSQ_CreateOverrideResults(device, headstage, type, [opMode])
 	string device
 	variable headstage, type
+	string opMode
 
 	variable DAC, numCols, numRows, numLayers, numChunks
 	string stimset
@@ -1153,6 +1154,10 @@ Function/WAVE PSQ_CreateOverrideResults(device, headstage, type)
 	stimset = AFH_GetStimSetName(device, DAC, CHANNEL_TYPE_DAC)
 	WAVE/Z stimsetWave = WB_CreateAndGetStimSet(stimset)
 	ASSERT(WaveExists(stimsetWave), "Stimset does not exist")
+
+	if(type == PSQ_DA_SCALE)
+		ASSERT(!ParamIsDefault(opMode) && PSQ_DS_IsValidMode(opMode), "Expected valid opMode")
+	endif
 
 	switch(type)
 		case PSQ_RAMP:

--- a/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqDAScale_Sub.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqDAScale_Sub.ipf
@@ -116,7 +116,7 @@ static Function PS_DS_Sub1([str])
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
 	AcquireData_NG(s, str)
 
-	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE)
+	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE, opMode = PSQ_DS_SUB)
 	// all tests fail
 	wv = 0
 End
@@ -265,7 +265,7 @@ static Function PS_DS_Sub2([str])
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
 	AcquireData_NG(s, str)
 
-	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE)
+	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE, opMode = PSQ_DS_SUB)
 	// only pre pulse chunk pass, async QC passes, others fail
 	wv[]      = 0
 	wv[0][]   = 1
@@ -464,7 +464,7 @@ static Function PS_DS_Sub3([str])
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
 	AcquireData_NG(s, str)
 
-	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE)
+	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE, opMode = PSQ_DS_SUB)
 	// pre pulse chunk pass
 	// first post pulse chunk pass
 	// async QC passes
@@ -639,7 +639,7 @@ static Function PS_DS_Sub4([str])
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
 	AcquireData_NG(s, str)
 
-	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE)
+	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE, opMode = PSQ_DS_SUB)
 	// pre pulse chunk pass
 	// last post pulse chunk pass
 	// async QC passes
@@ -859,7 +859,7 @@ static Function PS_DS_Sub5([str])
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
 	AcquireData_NG(s, str)
 
-	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE)
+	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE, opMode = PSQ_DS_SUB)
 	// pre pulse chunk fails
 	// all post pulse chunk pass
 	// async QC passes
@@ -1012,7 +1012,7 @@ static Function PS_DS_Sub5a([str])
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
 	AcquireData_NG(s, str)
 
-	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE)
+	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE, opMode = PSQ_DS_SUB)
 	// pre pulse chunk fails due to targetV
 	// all post pulse chunk pass
 	// async QC passes
@@ -1165,7 +1165,7 @@ static Function PS_DS_Sub6([str])
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
 	AcquireData_NG(s, str)
 
-	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE)
+	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE, opMode = PSQ_DS_SUB)
 	// pre pulse chunk pass
 	// second post pulse chunk pass
 	// async QC passes
@@ -1386,7 +1386,7 @@ static Function PS_DS_Sub7([str])
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
 	AcquireData_NG(s, str)
 
-	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE)
+	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE, opMode = PSQ_DS_SUB)
 	// pre pulse chunk pass
 	// first post pulse chunk pass
 	// of sweeps 2-6
@@ -1569,7 +1569,7 @@ static Function PS_DS_Sub8([str])
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
 	AcquireData_NG(s, str)
 
-	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE)
+	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE, opMode = PSQ_DS_SUB)
 	// pre pulse chunk pass
 	// first post pulse chunk pass
 	// of sweep 0, 3, 6, 7 , 8
@@ -1768,7 +1768,7 @@ static Function PS_DS_Sub9([str])
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
 	AcquireData_NG(s, str)
 
-	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE)
+	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE, opMode = PSQ_DS_SUB)
 	// all tests fail
 	wv = 0
 End
@@ -1921,7 +1921,7 @@ static Function PS_DS_Sub10([str])
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
 	AcquireData_NG(s, str)
 
-	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE)
+	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE, opMode = PSQ_DS_SUB)
 	// pre pulse chunk pass
 	// first post pulse chunk pass
 	// async QC passes

--- a/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqDAScale_Supra.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqDAScale_Supra.ipf
@@ -109,7 +109,7 @@ static Function PS_DS_Supra1([str])
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str, "PSQ_DaScale_Supr_DA_0")
 	AcquireData_NG(s, str)
 
-	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE)
+	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE, opMode = PSQ_DS_SUPRA)
 	// pre pulse chunk pass
 	// second post pulse chunk pass
 	wv = 0
@@ -202,7 +202,7 @@ static Function PS_DS_Supra2([str])
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str, "PSQ_DaScale_Supr_DA_0")
 	AcquireData_NG(s, str)
 
-	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE)
+	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE, opMode = PSQ_DS_SUPRA)
 	// pre pulse chunk pass
 	// second post pulse chunk pass
 	wv = 0
@@ -297,7 +297,7 @@ static Function PS_DS_Supra3([str])
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str, "PSQ_DS_SupraLong_DA_0")
 	AcquireData_NG(s, str)
 
-	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE)
+	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE, opMode = PSQ_DS_SUPRA)
 	// pre pulse chunk pass
 	// second post pulse chunk pass
 	wv = 0
@@ -392,7 +392,7 @@ static Function PS_DS_Supra4([str])
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str, "PSQ_DS_SupraLong_DA_0")
 	AcquireData_NG(s, str)
 
-	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE)
+	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE, opMode = PSQ_DS_SUPRA)
 	// pre pulse chunk pass
 	// second post pulse chunk pass
 	wv = 0
@@ -491,7 +491,7 @@ static Function PS_DS_Supra5([str])
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str, "PSQ_DS_SupraLong_DA_0")
 	AcquireData_NG(s, str)
 
-	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE)
+	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE, opMode = PSQ_DS_SUPRA)
 	// pre pulse chunk pass
 	// second post pulse chunk pass
 	wv = 0
@@ -601,7 +601,7 @@ static Function PS_DS_Supra6([str])
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str, "PSQ_DS_SupraLong_DA_0")
 	AcquireData_NG(s, str)
 
-	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE)
+	WAVE wv = PSQ_CreateOverrideResults(str, PSQ_TEST_HEADSTAGE, PSQ_DA_SCALE, opMode = PSQ_DS_SUPRA)
 	// pre pulse chunk pass
 	// second post pulse chunk pass
 	wv = 0


### PR DESCRIPTION
We want to distinguish the setup of the overrideResults wave per operation mode for PSQ_DAScale in a future commit.

Will merge once CI passes.