### PR TITLE
.github/workflows/FTPUpload: Handle missing nwb files gracefully

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -288,6 +288,11 @@ jobs:
         run: |
           for dir in test-itc18-assets test-itc1600-assets test-ni-assets
           do
+            if [ -n "$(find "$dir" -maxdepth 0 -type d -empty)" ]
+            then
+              continue
+            fi
+
             tar --remove-files --use-compress-program=zstd -cvf $dir/NWB.tar.zst $dir/*nwb
           done
         working-directory: ${{ steps.download.outputs.download-path }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -146,6 +146,11 @@ jobs:
         run: |
           for dir in test-itc18-assets test-itc1600-assets test-ni-assets
           do
+            if [ -n "$(find "$dir" -maxdepth 0 -type d -empty)" ]
+            then
+              continue
+            fi
+
             tar --remove-files --use-compress-program=zstd -cvf $dir/NWB.tar.zst $dir/*nwb
           done
         working-directory: ${{ steps.download.outputs.download-path }}


### PR DESCRIPTION
Failed pipelines might not have NWB files so we need to handle this case gracefully.

Code taken from [1] and checked locally.

[1]: https://superuser.com/a/352387

Close #1951
