### PR TITLE
Sutter HW support preparation PR: Change internal sweep data storage format

### DIFF
--- a/Packages/MIES/MIES_AnalysisBrowser.ipf
+++ b/Packages/MIES/MIES_AnalysisBrowser.ipf
@@ -2495,7 +2495,7 @@ static Function AB_SplitSweepIntoComponents(expFolder, device, sweep, sweepWave)
 	DFREF dfr = GetAnalysisLabNBFolder(expFolder, device)
 	WAVE/SDFR=dfr numericalValues
 
-	SplitAndUpgradeSweep(numericalValues, sweep, sweepWave, configSweep, TTL_RESCALE_ON, targetDFR=sweepFolder)
+	SplitAndUpgradeSweep(numericalValues, sweep, sweepWave, configSweep, TTL_RESCALE_ON, 1, targetDFR=sweepFolder)
 	KillOrMoveToTrash(wv=sweepWave)
 
 	return 0

--- a/Packages/MIES/MIES_AnalysisBrowser.ipf
+++ b/Packages/MIES/MIES_AnalysisBrowser.ipf
@@ -1785,7 +1785,7 @@ static Function AB_LoadSweepFromFile(discLocation, dataFolder, fileType, device,
 	variable sweep, overwrite
 
 	string sweepFolder, sweeps, msg
-	variable h5_fileID, h5_groupID
+	variable h5_fileID, h5_groupID, err
 
 	if(ParamIsDefault(overwrite))
 		overwrite = 0
@@ -1810,12 +1810,8 @@ static Function AB_LoadSweepFromFile(discLocation, dataFolder, fileType, device,
 
 	strswitch(fileType)
 		case ANALYSISBROWSER_FILE_TYPE_IGOR:
-			sweeps = AB_LoadSweepFromIgor(discLocation, dataFolder, sweepDFR, device, sweep)
-			if(!cmpstr(sweeps, ""))
-				return 1
-			endif
-			Wave sweepsWave = sweepDFR:$sweeps
-			if(AB_SplitSweepIntoComponents(dataFolder, device, sweep, sweepsWave))
+			err = AB_LoadSweepFromIgor(discLocation, dataFolder, sweepDFR, device, sweep)
+			if(err)
 				return 1
 			endif
 			break
@@ -2084,43 +2080,71 @@ End
 /// @brief Load specified device/sweep combination from Igor experiment file to sweepDFR
 ///
 /// @returns name of loaded sweep
-static Function/S AB_LoadSweepFromIgor(discLocation, expFolder, sweepDFR, device, sweep)
-	string discLocation, expFolder, device
-	DFREF sweepDFR
-	variable sweep
+static Function AB_LoadSweepFromIgor(string discLocation, string expFolder, DFREF sweepDFR, string device, variable sweep)
 
-	variable numWavesLoaded
+	variable i, numWavesLoaded, numComponentsLoaded, numChannels
 	string sweepWaveList = ""
-	string sweepWaveName, dataPath
+	string sweepWaveName, sweepWaveNameBak, dataPath, componentsDataPath, sweepComponent
+	string channelName, channelWaveList
 
 	// we load the backup wave also
 	// in case it exists, it holds the original unmodified data
 	sweepWaveName  = "sweep_" + num2str(sweep)
+	sweepWaveNameBak = sweepWaveName + WAVE_BACKUP_SUFFIX
 	sweepWaveList = AddListItem(sweepWaveList, sweepWaveName, ";", Inf)
-	sweepWaveList = AddListItem(sweepWaveList, sweepWaveName + WAVE_BACKUP_SUFFIX, ";", Inf)
+	sweepWaveList = AddListItem(sweepWaveList, sweepWaveNameBak, ";", Inf)
 
 	dataPath = GetDeviceDataPathAsString(device)
 	dataPath = AB_TranslatePath(dataPath, expFolder)
-	DFREF newDFR = UniqueDataFolder(GetAnalysisFolder(), "temp")
+	DFREF newDFR = NewFreeDataFolder()
 	numWavesLoaded = AB_LoadDataWrapper(newDFR, discLocation, dataPath, sweepWaveList)
 
 	if(numWavesLoaded <= 0)
 		printf "Could not load sweep %d of device %s and %s\r", sweep, device, discLocation
 		KillOrMoveToTrash(dfr=newDFR)
 		KillOrMoveToTrash(dfr=sweepDFR)
-		return ""
+		return 1
 	endif
 
 	Wave sweepWave = newDFR:$sweepWaveName
+	if(IsTextWave(sweepWave) && DimSize(sweepWave, ROWS) > 0)
+		WAVE/Z/T sweepT = newDFR:$sweepWaveNameBak
+		if(!WaveExists(sweepT))
+			printf "Could not find original sweep wave in pxp (only working copy). Sweep %d of device %s and %s\r", sweep, device, discLocation
+			return 1
+		endif
 
-	if(numWavesLoaded == 2)
-		ReplaceWaveWithBackup(sweepWave)
+		numChannels = DimSize(sweepT, ROWS)
+		for(i = 0; i < numChannels; i += 1)
+			[componentsDataPath, channelName] = SplitTextSweepElement(sweepT[i])
+			sweepT[i] = channelName
+		endfor
+		channelWaveList = TextWaveToList(sweepT, ";")
+		DFREF sweepComponentsDFR = NewFreeDataFolder()
+		numComponentsLoaded = AB_LoadDataWrapper(sweepComponentsDFR, discLocation, dataPath + ":" + componentsDataPath, channelWaveList)
+		if(numComponentsLoaded != DimSize(sweepT, ROWS))
+			printf "Error loading all sweep components. Sweep %d of device %s and %s\r", sweep, device, discLocation
+			return 1
+		endif
+
+		for(sweepComponent : sweepT)
+			WAVE wv = sweepComponentsDFR:$sweepComponent
+			MoveWave wv, sweepDFR
+		endfor
+		RestoreFromBackupWavesForAll(sweepDFR)
+	else
+		// old sweep format
+		if(numWavesLoaded == 2)
+			ReplaceWaveWithBackup(sweepWave)
+		endif
+
+		MoveWave sweepWave, sweepDFR
+		if(AB_SplitSweepIntoComponents(expFolder, device, sweep, sweepWave))
+			return 1
+		endif
 	endif
 
-	MoveWave sweepWave, sweepDFR
-	KillOrMoveToTrash(dfr=newDFR)
-
-	return sweepWaveName
+	return 0
 End
 
 /// @brief a failsave alternative for AB_LoadStimsets() to load RAW stimsets

--- a/Packages/MIES/MIES_AnalysisBrowser.ipf
+++ b/Packages/MIES/MIES_AnalysisBrowser.ipf
@@ -2471,7 +2471,7 @@ static Function AB_SplitSweepIntoComponents(expFolder, device, sweep, sweepWave)
 	DFREF dfr = GetAnalysisLabNBFolder(expFolder, device)
 	WAVE/SDFR=dfr numericalValues
 
-	SplitSweepIntoComponents(numericalValues, sweep, sweepWave, configSweep, TTL_RESCALE_ON, targetDFR=sweepFolder)
+	SplitAndUpgradeSweep(numericalValues, sweep, sweepWave, configSweep, TTL_RESCALE_ON, targetDFR=sweepFolder)
 	KillOrMoveToTrash(wv=sweepWave)
 
 	return 0

--- a/Packages/MIES/MIES_AnalysisFunctions_MultiPatchSeq.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_MultiPatchSeq.ipf
@@ -343,11 +343,7 @@ static Function/WAVE MSQ_SearchForSpikes(device, type, sweepWave, headstage, tot
 	variable minVal, maxVal
 	string msg
 
-	if(WaveRefsEqual(sweepWave, GetDAQDataWave(device, DATA_ACQUISITION_MODE)))
-		WAVE config = GetDAQConfigWave(device)
-	else
-		WAVE config = GetConfigWave(sweepWave)
-	endif
+	WAVE config = AFH_GetConfigWave(device, sweepWave)
 
 	if(ParamIsDefault(numberOfSpikes))
 		numberOfSpikes = 1

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -59,10 +59,10 @@ Constant SC_SPIKE_CONTROL_VERSION    = 1
 /// @}
 
 /// Especially interesting for PXP consumers like the analysis browser.
-Constant EXPERIMENT_VERSION = 2
+Constant EXPERIMENT_VERSION = 3
 
 /// All experiment versions up to the given value are supported
-Constant ANALYSIS_BROWSER_SUPP_VERSION = 2
+Constant ANALYSIS_BROWSER_SUPP_VERSION = 3
 
 Constant PA_SETTINGS_STRUCT_VERSION = 6
 /// @}

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -172,6 +172,7 @@ Constant MAXIMUM_WAVE_SIZE = 16384 // 2^14
 /// Convenience definition to nicify expressions like DimSize(wv, ROWS)
 /// easier to read than DimSize(wv, 0).
 /// @{
+Constant DATADIMENSION       = -1
 Constant ROWS                = 0
 Constant COLS                = 1
 Constant LAYERS              = 2

--- a/Packages/MIES/MIES_DataBrowser.ipf
+++ b/Packages/MIES/MIES_DataBrowser.ipf
@@ -651,56 +651,11 @@ End
 /// @returns 1 on error, 0 on success
 Function DB_SplitSweepsIfReq(string win, variable sweepNo)
 
-	string device, mainPanel
-	variable sweepModTime, numWaves, requireNewSplit, i
-	variable numBackupWaves
-
 	if(!BSP_HasBoundDevice(win))
 		return NaN
 	endif
 
-	device = BSP_GetDevice(win)
-
-	DFREF deviceDFR = GetDeviceDataPath(device)
-	DFREF singleSweepDFR = GetSingleSweepFolder(deviceDFR, sweepNo)
-
-	WAVE/Z sweepWave  = GetSweepWave(device, sweepNo)
-	if(!WaveExists(sweepWave))
-		return 1
-	endif
-
-	WAVE configWave = GetConfigWave(sweepWave)
-
-	sweepModTime = max(ModDate(sweepWave), ModDate(configWave))
-	numWaves = CountObjectsDFR(singleSweepDFR, COUNTOBJECTS_WAVES)
-	requireNewSplit = (numWaves == 0)
-
-	for(i = 0; i < numWaves; i += 1)
-		WAVE/SDFR=singleSweepDFR wv = $GetIndexedObjNameDFR(singleSweepDFR, COUNTOBJECTS_WAVES, i)
-		if(sweepModTime > ModDate(wv))
-			// original sweep was modified, regenerate single sweep waves
-			KillOrMoveToTrash(dfr=singleSweepDFR)
-			DFREF singleSweepDFR = GetSingleSweepFolder(deviceDFR, sweepNo)
-			requireNewSplit = 1
-			break
-		endif
-		if(GrepString(NameOfWave(wv), "\\Q" + WAVE_BACKUP_SUFFIX + "\\E$"))
-			numBackupWaves += 1
-		endif
-	endfor
-
-	if(!requireNewSplit && (numBackupWaves * 2 == numWaves))
-		return 0
-	endif
-
-	KillOrMoveToTrash(dfr = singleSweepDFR)
-	DFREF singleSweepDFR = GetSingleSweepFolder(deviceDFR, sweepNo)
-
-	WAVE numericalValues = DB_GetLBNWave(win, LBN_NUMERICAL_VALUES)
-
-	SplitAndUpgradeSweep(numericalValues, sweepNo, sweepWave, configWave, TTL_RESCALE_ON, targetDFR=singleSweepDFR)
-
-	return 0
+	return SplitAndUpgradeSweepGlobal(BSP_GetDevice(win), sweepNo)
 End
 
 /// @brief Find a Databrowser which is locked to the given DAEphys panel

--- a/Packages/MIES/MIES_DataBrowser.ipf
+++ b/Packages/MIES/MIES_DataBrowser.ipf
@@ -698,7 +698,7 @@ Function DB_SplitSweepsIfReq(string win, variable sweepNo)
 
 	WAVE numericalValues = DB_GetLBNWave(win, LBN_NUMERICAL_VALUES)
 
-	SplitSweepIntoComponents(numericalValues, sweepNo, sweepWave, configWave, TTL_RESCALE_ON, targetDFR=singleSweepDFR)
+	SplitAndUpgradeSweep(numericalValues, sweepNo, sweepWave, configWave, TTL_RESCALE_ON, targetDFR=singleSweepDFR)
 
 	return 0
 End

--- a/Packages/MIES/MIES_Epochs.ipf
+++ b/Packages/MIES/MIES_Epochs.ipf
@@ -742,25 +742,15 @@ End
 
 /// @brief Write the epoch info into the sweep settings wave
 ///
-/// @param device device
-/// @param sweepWave  sweep wave
-/// @param configWave config wave
-Function EP_WriteEpochInfoIntoSweepSettings(string device, WAVE sweepWave, WAVE configWave)
-	variable i, numDACEntries, channel, headstage, acquiredTime, plannedTime
+/// @param device       device
+/// @param sweepNo      sweep Number
+/// @param acquiredTime actual acquired time in seconds, if acquisition was stopped early lower than plannedTime
+/// @param plannedTime  planned acquisition time in seconds, if acquisition was not stopped early equals acquiredTime
+Function EP_WriteEpochInfoIntoSweepSettings(string device, variable sweepNo, variable acquiredTime, variable plannedTime)
+	variable i, numDACEntries, channel, headstage
 	string entry
 
-	plannedTime = IndexToScale(sweepWave, DimSize(sweepWave, ROWS) - 1, ROWS) * MILLI_TO_ONE
-
-	// all channels are acquired simultaneously we can just check if the last
-	// channel has NaN in the last element
-	if(IsNaN(sweepWave[inf][inf]))
-		FindValue/FNAN sweepWave
-		ASSERT(V_row >= 0, "Unexpected result")
-
-		acquiredTime = IndexToScale(sweepWave, max(V_row - 1, 0), ROWS) * MILLI_TO_ONE
-	else
-		acquiredTime = plannedTime
-	endif
+	[WAVE sweepWave, WAVE configWave] = GetSweepAndConfigWaveFromDevice(device, sweepNo)
 
 	EP_AdaptEpochInfo(device, configWave, acquiredTime, plannedTime)
 

--- a/Packages/MIES/MIES_ExperimentDocumentation.ipf
+++ b/Packages/MIES/MIES_ExperimentDocumentation.ipf
@@ -402,7 +402,7 @@ static Function ED_WriteChangedValuesToNoteText(device, sweepNo)
 	string device
 	variable sweepNo
 
-	string key, factor, text, frontLabel
+	string key, factor, text, frontLabel, ignoreKeyList
 	string str = ""
 	variable tolerance, i, j, numRows, numCols
 
@@ -413,11 +413,17 @@ static Function ED_WriteChangedValuesToNoteText(device, sweepNo)
 	WAVE/Z junk = GetLastSetting(textualValues, sweepNo, "TimeStamp", UNKNOWN_MODE)
 	WAVE/Z junk = GetLastSetting(textualValues, sweepNo - 1, "TimeStamp", UNKNOWN_MODE)
 
+	ignoreKeyList = AddListItem("MIES version", "")
+	ignoreKeyList = AddListItem("Igor Pro version", ignoreKeyList)
+	ignoreKeyList = AddListItem("Igor Pro build", ignoreKeyList)
+	ignoreKeyList = AddListItem(STIMSET_WAVE_NOTE_KEY, ignoreKeyList)
+	ignoreKeyList = AddListItem(EPOCHS_ENTRY_KEY, ignoreKeyList)
+
 	numCols = DimSize(textualKeys, COLS)
 	for (j = INITIAL_KEY_WAVE_COL_COUNT + 1; j < numCols; j += 1)
 		key = textualKeys[0][j]
 
-		if(!cmpstr(key, "MIES version") || !cmpstr(key, "Igor Pro version") || !cmpstr(key, "Igor Pro build") || !cmpstr(key, "Stim Wave Note"))
+		if(WhichListItem(key, ignoreKeyList) >= 0)
 			continue
 		endif
 

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -5521,7 +5521,9 @@ End
 ///
 /// The backup wave will be located in the same data folder and
 /// its name will be the original name with #WAVE_BACKUP_SUFFIX
-/// appended.
+/// appended. If the backup wave exists and the main type of the backup wave can be overridden by Duplicate/O
+/// then the wave reference of the backup wave is kept. Otherwise the main type is changed and the wave reference
+/// is not kept (e.g. backup wave is numerical, original wave is text)
 threadsafe Function/Wave CreateBackupWave(wv, [forceCreation])
 	Wave wv
 	variable forceCreation
@@ -5544,8 +5546,10 @@ threadsafe Function/Wave CreateBackupWave(wv, [forceCreation])
 	if(WaveExists(backup) && !forceCreation)
 		return backup
 	endif
-
-	Duplicate/O wv, dfr:$backupname/Wave=backup
+	if(WaveExists(backup) && WaveType(backup, 1) != WaveType(wv, 1) && (WaveType(backup, 1) == IGOR_TYPE_TEXT_WAVE || WaveType(wv, 1) == IGOR_TYPE_TEXT_WAVE))
+		KillOrMoveToTrash(wv = backup)
+	endif
+	Duplicate/O wv, dfr:$backupname/WAVE=backup
 
 	return backup
 End

--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -8590,3 +8590,15 @@ End
 Function/S GetWorkLoadName(string workload, string device)
 	return workload + "_" + device
 End
+
+Function GetFirstADCChannelIndex(WAVE config)
+
+	variable col
+
+	col = FindDimlabel(config, COLS, "ChannelType")
+	ASSERT(col >= 0, "Could not find ChannelType column in config wave")
+	FindValue/RMD=[][col]/V=(XOP_CHANNEL_TYPE_ADC) config
+	ASSERT(V_value >= 0, "Could not find any XOP_CHANNEL_TYPE_ADC channel")
+
+	return V_row
+End

--- a/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
+++ b/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
@@ -336,12 +336,17 @@ threadsafe Function/DF NWB_ASYNC_Worker(DFREF dfr)
 	KillDataFolder/Z root:
 
 	[s] = NWB_ASYNC_DeserializeStruct(dfr)
+	// @todo This is a workaround to keep the references for the unlocking of the channel waves after saving.
+	//       The references in s.DAQDataWave seem to be gone after saving. Needs further investigation why.
+	Duplicate/FREE s.DAQDataWave, dataWave
 
 	AddModificationTimeEntry(s.locationID, s.nwbVersion)
 	NWB_AddDevice(s)
 	NWB_WriteLabnoteBooksAndComments(s)
 	NWB_WriteResultsWaves(s)
 	NWB_AppendSweepLowLevel(s)
+
+	ChangeWaveLock(dataWave, 0)
 
 	NWB_Flush(s.locationID)
 
@@ -641,7 +646,7 @@ Function NWB_ExportAllData(nwbVersion, [overrideFilePath, writeStoredTestPulses,
 
 			// init: 3/3
 			s.sweep = sweep
-			WAVE s.DAQDataWave = sweepWave
+			WAVE s.DAQDataWave = TextSweepToWaveRef(sweepWave)
 			WAVE s.DAQConfigWave = configWave
 
 			NWB_AppendSweepLowLevel(s)
@@ -931,6 +936,9 @@ Function NWB_AppendSweepDuringDAQ(string device, WAVE DAQDataWave, WAVE DAQConfi
 		return NaN
 	endif
 
+	WAVE/WAVE sweepRef = TextSweepToWaveRef(DAQDataWave)
+	ChangeWaveLock(sweepRef, 1)
+
 	STRUCT NWBAsyncParameters s
 
 	s.device = device
@@ -944,7 +952,7 @@ Function NWB_AppendSweepDuringDAQ(string device, WAVE DAQDataWave, WAVE DAQConfi
 	s.locationID = locationID
 	s.nwbVersion = nwbVersion
 
-	WAVE s.DAQDataWave = DAQDataWave
+	WAVE s.DAQDataWave = sweepRef
 	WAVE s.DAQConfigWave = DAQConfigWave
 
 	WAVE s.numericalValues = GetLBNumericalValues(device)
@@ -972,7 +980,9 @@ threadsafe static Function NWB_AppendSweepLowLevel(STRUCT NWBAsyncParameters &s)
 	string group, path, list, name, stimset, key
 	string channelSuffix, listOfStimsets, contents
 
-	Make/FREE/N=(DimSize(s.DAQDataWave, COLS)) writtenDataColumns = 0
+	ASSERT_TS(IsWaveRefWave(s.DAQDataWave), "Unsupported sweep wave format")
+
+	Make/FREE/N=(DimSize(s.DAQDataWave, ROWS)) writtenDataColumns = 0
 
 	// comment denotes the introducing comment of the labnotebook entry
 	// a2220e9f (Add the clamp mode to the labnotebook for acquired data, 2015-04-26)

--- a/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
+++ b/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
@@ -1082,7 +1082,7 @@ threadsafe static Function NWB_AppendSweepLowLevel(STRUCT NWBAsyncParameters &s)
 	params.samplingRate = ConvertSamplingIntervalToRate(GetSamplingInterval(s.DAQConfigWave)) * KILO_TO_ONE
 
 	DFREF sweepDFR = NewFreeDataFolder()
-	SplitSweepIntoComponents(s.numericalValues, s.sweep, s.DAQDataWave, s.DAQConfigWave, TTL_RESCALE_OFF, targetDFR = sweepDFR, createBackup = 0)
+	SplitAndUpgradeSweep(s.numericalValues, s.sweep, s.DAQDataWave, s.DAQConfigWave, TTL_RESCALE_OFF, targetDFR = sweepDFR, createBackup = 0)
 
 	for(i = 0; i < NUM_HEADSTAGES; i += 1)
 

--- a/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
+++ b/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
@@ -1089,7 +1089,7 @@ threadsafe static Function NWB_AppendSweepLowLevel(STRUCT NWBAsyncParameters &s)
 	params.samplingRate = ConvertSamplingIntervalToRate(GetSamplingInterval(s.DAQConfigWave)) * KILO_TO_ONE
 
 	DFREF sweepDFR = NewFreeDataFolder()
-	SplitAndUpgradeSweep(s.numericalValues, s.sweep, s.DAQDataWave, s.DAQConfigWave, TTL_RESCALE_OFF, targetDFR = sweepDFR, createBackup = 0)
+	SplitAndUpgradeSweep(s.numericalValues, s.sweep, s.DAQDataWave, s.DAQConfigWave, TTL_RESCALE_OFF, 0, targetDFR = sweepDFR, createBackup = 0)
 
 	for(i = 0; i < NUM_HEADSTAGES; i += 1)
 

--- a/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
+++ b/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
@@ -336,9 +336,6 @@ threadsafe Function/DF NWB_ASYNC_Worker(DFREF dfr)
 	KillDataFolder/Z root:
 
 	[s] = NWB_ASYNC_DeserializeStruct(dfr)
-	// @todo This is a workaround to keep the references for the unlocking of the channel waves after saving.
-	//       The references in s.DAQDataWave seem to be gone after saving. Needs further investigation why.
-	Duplicate/FREE s.DAQDataWave, dataWave
 
 	AddModificationTimeEntry(s.locationID, s.nwbVersion)
 	NWB_AddDevice(s)
@@ -346,7 +343,7 @@ threadsafe Function/DF NWB_ASYNC_Worker(DFREF dfr)
 	NWB_WriteResultsWaves(s)
 	NWB_AppendSweepLowLevel(s)
 
-	ChangeWaveLock(dataWave, 0)
+	ChangeWaveLock(s.DAQDataWave, 0)
 
 	NWB_Flush(s.locationID)
 

--- a/Packages/MIES/MIES_Oscilloscope.ipf
+++ b/Packages/MIES/MIES_Oscilloscope.ipf
@@ -652,7 +652,7 @@ static Function SCOPE_NI_UpdateOscilloscope(device, dataAcqOrTP, deviceiD, fifoP
 	string device
 	variable dataAcqOrTP, deviceID, fifoPos
 
-	variable i, channel, decMethod, decFactor, gain, numCols, numFifoChannels
+	variable i, channel, decMethod, decFactor, numCols, numFifoChannels
 	string fifoName, msg, fifoInfo
 
 	WAVE/WAVE scaledDataWave = GetScaledDataWave(device)
@@ -685,17 +685,15 @@ static Function SCOPE_NI_UpdateOscilloscope(device, dataAcqOrTP, deviceiD, fifoP
 		// it is in this moment the previous fifo position, so the new data goes from here to fifoPos-1
 		NVAR fifoPosGlobal = $GetFifoPosition(device)
 
-		WAVE allGain = SWS_GetChannelGains(device, timing = GAIN_AFTER_DAQ)
 		numCols = DimSize(scaledDataWave, COLS)
 		for(i = 0; i < numFifoChannels; i += 1)
 			channel = NumberByKey("NAME" + num2istr(i), fifoInfo)
-			gain = allGain[channel]
 			WAVE NIChannel = NIDataWave[channel]
 			WAVE scaledChannel = scaledDataWave[channel]
 
 			AssertOnAndClearRTError()
 			try
-				Multithread scaledChannel[fifoPosGlobal, fifoPos - 1] = NIChannel[p] / gain; AbortOnRTE
+				Multithread scaledChannel[fifoPosGlobal, fifoPos - 1] = NIChannel[p]; AbortOnRTE
 			catch
 				sprintf msg, "Writing scaledDataWave failed, please save the experiment and file a bug report: fifoPosGlobal %g, fifoPos %g, scaledDataWave rows %g, stopCollectionPoint %g\r", fifoPosGlobal, fifoPos, DimSize(scaledDataWave, ROWS), ROVAR(GetStopCollectionPoint(device))
 				ASSERT(0, msg)

--- a/Packages/MIES/MIES_Oscilloscope.ipf
+++ b/Packages/MIES/MIES_Oscilloscope.ipf
@@ -190,7 +190,7 @@ static Function [variable showSteadyStateResistance, variable showPeakResistance
 
 	showPeakResistance        = DAG_GetNumericalValue(device, "check_settings_TP_show_peak")
 	showSteadyStateResistance = DAG_GetNumericalValue(device, "check_settings_TP_show_steady")
-	showPowerSpectrum         = dataAcqOrTP == TEST_PULSE_MODE && DAG_GetNumericalValue(device, "check_settings_show_power")
+	showPowerSpectrum         = DAG_GetNumericalValue(device, "check_settings_show_power")
 End
 
 Function SCOPE_CreateGraph(device, dataAcqOrTP)
@@ -204,7 +204,7 @@ Function SCOPE_CreateGraph(device, dataAcqOrTP)
 	string steadyStateTrace, peakTrace, adcStr
 	variable YaxisLow, YaxisHigh, YaxisSpacing, Yoffset, resPosPercY
 	variable testPulseLength, cutOff, sampInt, axisMinTop, axisMaxTop
-	variable headStage, activeHeadStage, showPowerSpectrum, baselineFrac, pulseLength
+	variable headStage, activeHeadStage, showPowerSpectrum, baselineFrac, pulseLength, pointsAcq
 	STRUCT RGBColor peakColor
 	STRUCT RGBColor steadyColor
 
@@ -382,9 +382,9 @@ Function SCOPE_CreateGraph(device, dataAcqOrTP)
 	endif
 	if(gotDAQChan)
 		Label/W=$graph bottomDAQ "Time DAQ (\\U)"
-		NVAR stopCollectionPoint = $GetStopCollectionPoint(device)
+		pointsAcq = HW_GetEffectiveADCWaveLength(device, dataAcqOrTP)
 		sampInt = DAP_GetSampInt(device, DATA_ACQUISITION_MODE, XOP_CHANNEL_TYPE_ADC) * MICRO_TO_MILLI
-		SetAxis/W=$graph bottomDAQ, 0, stopCollectionPoint * sampInt
+		SetAxis/W=$graph bottomDAQ, 0, pointsAcq * sampInt
 		ModifyGraph/W=$graph freePos(bottomDAQ)=-35
 	endif
 End
@@ -444,23 +444,20 @@ Function SCOPE_SetADAxisLabel(device, dataAcqOrTP, activeHeadStage)
 	endfor
 End
 
-static Function SCOPE_UpdatePowerSpectrum(device)
-	String device
-
-	variable startOfADColumns, numADCs
+static Function SCOPE_UpdatePowerSpectrum(string device, WAVE columns, [WAVE osci])
 
 	if(DAG_GetNumericalValue(device, "check_settings_show_power"))
-		WAVE OscilloscopeData = GetOscilloscopeWave(device)
+		if(ParamIsDefault(osci))
+			WAVE OscilloscopeData = GetOscilloscopeWave(device)
+		else
+			WAVE OscilloscopeData = osci
+		endif
 		WAVE TPOscilloscopeData = GetTPOscilloscopeWave(device)
-		startOfADColumns = ROVar(GetADChannelToMonitor(device))
-		numADCs = DimSize(OscilloscopeData, COLS) - startOfADColumns
 
 		// FFT knows how to transform units without prefix so transform them temporarly
 		SetScale/P x, DimOffset(OscilloscopeData, ROWS) * MILLI_TO_ONE, DimDelta(OscilloscopeData, ROWS) * MILLI_TO_ONE, "s", OscilloscopeData
 
-		Make/FREE/N=(numADCs) junk
-
-		MultiThread junk[] = DoPowerSpectrum(OscilloscopeData, TPOscilloscopeData, (startOfADColumns + p))
+		MultiThread columns[] = DoPowerSpectrum(OscilloscopeData, TPOscilloscopeData, columns[p])
 
 		SetScale/P x, DimOffset(OscilloscopeData, ROWS) * ONE_TO_MILLI, DimDelta(OscilloscopeData, ROWS) * ONE_TO_MILLI, "ms", OscilloscopeData
 	endif
@@ -481,11 +478,10 @@ Function SCOPE_UpdateOscilloscopeData(device, dataAcqOrTP, [chunk, fifoPos, devi
 	variable dataAcqOrTP, chunk, fifoPos, deviceID
 
 	STRUCT TPAnalysisInput tpInput
-	string osciUnits
 	variable i, j
 	variable tpChannels, numADCs, numDACs, tpLengthPoints, tpStart, tpEnd, tpStartPos
-	variable TPChanIndex, saveTP, sampleInt, clampAmp
-	variable headstage, fifoLatest
+	variable TPChanIndex, saveTP, clampAmp
+	variable headstage, fifoLatest, channelIndex
 	string hsList
 
 	variable hardwareType = GetHardwareType(device)
@@ -508,6 +504,8 @@ Function SCOPE_UpdateOscilloscopeData(device, dataAcqOrTP, [chunk, fifoPos, devi
 			ASSERT(!ParamIsDefault(deviceID), "optional parameter deviceID missing (required for NI devices in TP mode)")
 			SCOPE_NI_UpdateOscilloscope(device, dataAcqOrTP, deviceID, fifoPos)
 			break
+		default:
+			ASSERT(0, "Unsupported hardware type")
 	endswitch
 
 	WAVE config = GetDAQConfigWave(device)
@@ -522,7 +520,7 @@ Function SCOPE_UpdateOscilloscopeData(device, dataAcqOrTP, [chunk, fifoPos, devi
 		WAVE TPSettings     = GetTPSettings(device)
 		WAVE TPSettingsCalc = GetTPSettingsCalculated(device)
 
-		tpLengthPoints = (dataAcqOrTP == TEST_PULSE_MODE) ? TPSettingsCalc[%totalLengthPointsTP] : TPSettingsCalc[%totalLengthPointsDAQ]
+		tpLengthPoints = (dataAcqOrTP == TEST_PULSE_MODE) ? TPSettingsCalc[%totalLengthPointsTP_ADC] : TPSettingsCalc[%totalLengthPointsDAQ_ADC]
 
 		// use a 'virtual' end position for fifoLatest for TP Mode since the input data contains one TP only
 		fifoLatest = (dataAcqOrTP == TEST_PULSE_MODE) ? tpLengthPoints : fifoPos
@@ -531,19 +529,16 @@ Function SCOPE_UpdateOscilloscopeData(device, dataAcqOrTP, [chunk, fifoPos, devi
 		WAVE DACs = GetDACListFromConfig(config)
 		WAVE hsProp = GetHSProperties(device)
 
-		WAVE scaledDataWave = GetScaledDataWave(device)
-		sampleInt = DimDelta(scaledDataWave, ROWS)
-		osciUnits = WaveUnits(scaledDataWave, ROWS)
+		WAVE/WAVE scaledDataWave = GetScaledDataWave(device)
 		numDACs = DimSize(DACs, ROWS)
 		numADCs = DimSize(ADCs, ROWS)
 
 		// note: currently this works for multiplier = 1 only, see DC_PlaceDataInDAQDataWave
 		Make/FREE/N=(tpLengthPoints) channelData
 		WAVE tpInput.data = channelData
-		SetScale/P x, 0, sampleInt, osciUnits, channelData
 
 		tpInput.device = device
-		tpInput.duration = (dataAcqOrTP == TEST_PULSE_MODE) ? TPSettingsCalc[%pulseLengthPointsTP] : TPSettingsCalc[%pulseLengthPointsDAQ]
+		tpInput.duration = (dataAcqOrTP == TEST_PULSE_MODE) ? TPSettingsCalc[%pulseLengthPointsTP_ADC] : TPSettingsCalc[%pulseLengthPointsDAQ_ADC]
 		tpInput.baselineFrac = TPSettingsCalc[%baselineFrac]
 		tpInput.tpLengthPoints = tpLengthPoints
 		tpInput.readTimeStamp = ticks * TICKS_TO_SECONDS
@@ -565,8 +560,12 @@ Function SCOPE_UpdateOscilloscopeData(device, dataAcqOrTP, [chunk, fifoPos, devi
 			tpStartPos = i * tpLengthPoints
 
 			if(saveTP)
-				Duplicate/FREE/R=[tpStartPos, tpStartPos + tpLengthPoints - 1][numDACs, numDACs + tpChannels - 1] scaledDataWave, StoreTPWave
-				SetScale/P x, 0, sampleInt, osciUnits, StoreTPWave
+				Make/FREE/N=(tpLengthPoints, tpChannels) StoreTPWave
+				for(j = 0; j < tpChannels; j += 1)
+					WAVE scaledChannel = scaledDataWave[numDACs + j]
+					Multithread StoreTPWave[][j] = scaledChannel[tpStartPos + p]
+				endfor
+				CopyScales/P scaledChannel, StoreTPWave
 				TPChanIndex = 0
 				hsList = ""
 			endif
@@ -574,7 +573,9 @@ Function SCOPE_UpdateOscilloscopeData(device, dataAcqOrTP, [chunk, fifoPos, devi
 			for(j = 0; j < numADCs; j += 1)
 				if(ADCmode[j] == DAQ_CHANNEL_TYPE_TP)
 
-					MultiThread channelData[] = scaledDataWave[tpStartPos + p][numDACs + j]
+					WAVE scaledChannel = scaledDataWave[numDACs + j]
+					MultiThread channelData[] = scaledChannel[tpStartPos + p]
+					CopyScales/P scaledChannel, channelData
 
 					headstage = AFH_GetHeadstageFromADC(device, ADCs[j])
 					if(hsProp[headstage][%ClampMode] == I_CLAMP_MODE)
@@ -610,12 +611,35 @@ Function SCOPE_UpdateOscilloscopeData(device, dataAcqOrTP, [chunk, fifoPos, devi
 
 		endfor
 
-		if(dataAcqOrTP == DATA_ACQUISITION_MODE)
-			WAVE TPOscilloscopeData = GetTPOscilloscopeWave(device)
-			Duplicate/O/R=[tpStartPos, tpStartPos + tpLengthPoints - 1][] scaledDataWave TPOscilloscopeData
-			SetScale/P x, 0, sampleInt, osciUnits, TPOscilloscopeData
+		if(dataAcqOrTP == DATA_ACQUISITION_MODE && tpEnd > tpStart)
+			tpStartPos = (tpEnd - 1) * tpLengthPoints
+			if(DAG_GetNumericalValue(device, "check_settings_show_power"))
+				WAVE tpOsciForPowerSpectrum = GetScaledTPTempWave(device)
+				Make/FREE/D/N=(numADCs) tpColumns
+				j = 0
+				for(i = 0; i < numADCs; i += 1)
+					if(ADCmode[i] == DAQ_CHANNEL_TYPE_TP)
+						channelIndex = numDACs + i
+						WAVE scaledChannel = scaledDataWave[channelIndex]
+						MultiThread tpOsciForPowerSpectrum[][channelIndex] = scaledChannel[tpStartPos + p]
+						tpColumns[j] = channelIndex
+						j += 1
+					endif
+					CopyScales/P scaledChannel, tpOsciForPowerSpectrum
+				endfor
+				Redimension/N=(j) tpColumns
+				SCOPE_UpdatePowerSpectrum(device, tpColumns, osci=tpOsciForPowerSpectrum)
+			else
+				WAVE TPOscilloscopeData = GetTPOscilloscopeWave(device)
+				for(i = 0; i < numADCs; i += 1)
+					if(ADCmode[i] == DAQ_CHANNEL_TYPE_TP)
+						channelIndex = numDACs + i
+						WAVE scaledChannel = scaledDataWave[channelIndex]
+						MultiThread TPOscilloscopeData[][channelIndex] = scaledChannel[tpStartPos + p]
+					endif
+				endfor
+			endif
 		endif
-
 	endif
 
 	// Sync fifo position
@@ -628,39 +652,50 @@ static Function SCOPE_NI_UpdateOscilloscope(device, dataAcqOrTP, deviceiD, fifoP
 	string device
 	variable dataAcqOrTP, deviceID, fifoPos
 
-	variable i, channel, decMethod, decFactor, gain, numCols
-	string fifoName, msg
+	variable i, channel, decMethod, decFactor, gain, numCols, numFifoChannels
+	string fifoName, msg, fifoInfo
 
-	WAVE scaledDataWave    = GetScaledDataWave(device)
+	WAVE/WAVE scaledDataWave = GetScaledDataWave(device)
 	WAVE OscilloscopeData = GetOscilloscopeWave(device)
 	WAVE/WAVE NIDataWave = GetDAQDataWave(device, dataAcqOrTP)
 
 	fifoName = GetNIFIFOName(deviceID)
 	FIFOStatus/Q $fifoName
 	ASSERT(V_Flag != 0, "FIFO does not exist!")
+	numFifoChannels = V_FIFOnchans
+	fifoInfo = S_info
 	if(dataAcqOrTP == TEST_PULSE_MODE)
 		// update a full pulse
-		for(i = 0; i < V_FIFOnchans; i += 1)
-			channel = NumberByKey("NAME" + num2str(i), S_Info)
+		Make/FREE/N=(numFifoChannels) tpColumns
+		for(i = 0; i < numFifoChannels; i += 1)
+			channel = NumberByKey("NAME" + num2istr(i), fifoInfo)
 			WAVE NIChannel = NIDataWave[channel]
-			multithread OscilloscopeData[][channel] = NIChannel[p]
-			Multithread scaledDataWave[][] = OscilloscopeData
+			WAVE scaledChannel = scaledDataWave[channel]
+			Multithread OscilloscopeData[][channel] = NIChannel[p]
+			Multithread scaledChannel[] = NIChannel[p]
+			tpColumns[i] = channel
 		endfor
-		SCOPE_UpdatePowerSpectrum(device)
+		SCOPE_UpdatePowerSpectrum(device, tpColumns)
 	elseif(dataAcqOrTP == DATA_ACQUISITION_MODE)
+
+		if(fifoPos == 0)
+			return NaN
+		endif
+
 		// it is in this moment the previous fifo position, so the new data goes from here to fifoPos-1
 		NVAR fifoPosGlobal = $GetFifoPosition(device)
 
 		WAVE allGain = SWS_GetChannelGains(device, timing = GAIN_AFTER_DAQ)
 		numCols = DimSize(scaledDataWave, COLS)
-		for(i = 0; i < numCols; i += 1)
-			WAVE NIChannel = NIDataWave[i]
-
-			gain = allGain[i]
+		for(i = 0; i < numFifoChannels; i += 1)
+			channel = NumberByKey("NAME" + num2istr(i), fifoInfo)
+			gain = allGain[channel]
+			WAVE NIChannel = NIDataWave[channel]
+			WAVE scaledChannel = scaledDataWave[channel]
 
 			AssertOnAndClearRTError()
 			try
-				Multithread scaledDataWave[fifoPosGlobal, fifoPos - 1][i] = NIChannel[p] / gain; AbortOnRTE
+				Multithread scaledChannel[fifoPosGlobal, fifoPos - 1] = NIChannel[p] / gain; AbortOnRTE
 			catch
 				sprintf msg, "Writing scaledDataWave failed, please save the experiment and file a bug report: fifoPosGlobal %g, fifoPos %g, scaledDataWave rows %g, stopCollectionPoint %g\r", fifoPosGlobal, fifoPos, DimSize(scaledDataWave, ROWS), ROVAR(GetStopCollectionPoint(device))
 				ASSERT(0, msg)
@@ -670,8 +705,8 @@ static Function SCOPE_NI_UpdateOscilloscope(device, dataAcqOrTP, deviceiD, fifoP
 		decMethod = GetNumberFromWaveNote(OscilloscopeData, "DecimationMethod")
 		decFactor = GetNumberFromWaveNote(OscilloscopeData, "DecimationFactor")
 
-		for(i = 0; i < V_FIFOnchans; i += 1)
-			channel = NumberByKey("NAME" + num2str(i), S_Info)
+		for(i = 0; i < numFifoChannels; i += 1)
+			channel = NumberByKey("NAME" + num2str(i), fifoInfo)
 			WAVE NIChannel = NIDataWave[channel]
 
 			switch(decMethod)
@@ -692,21 +727,21 @@ static Function SCOPE_ITC_UpdateOscilloscope(device, dataAcqOrTP, chunk, fifoPos
 
 	WAVE OscilloscopeData = GetOscilloscopeWave(device)
 	variable length, first, last
-	variable startOfADColumns, numEntries, decMethod, decFactor
+	variable startOfADColumns, endOfADColumns, decMethod, decFactor, i
 	string msg
-	WAVE scaledDataWave    = GetScaledDataWave(device)
+	WAVE/WAVE scaledDataWave = GetScaledDataWave(device)
 	WAVE DAQDataWave       = GetDAQDataWave(device, dataAcqOrTP)
 	WAVE DAQConfigWave = GetDAQConfigWave(device)
 	WAVE ADCs = GetADCListFromConfig(DAQConfigWave)
 	WAVE DACs = GetDACListFromConfig(DAQConfigWave)
 	startOfADColumns = DimSize(DACs, ROWS)
-	numEntries = DimSize(ADCs, ROWS)
+	endOfADColumns = startOfADColumns + DimSize(ADCs, ROWS)
 
 	WAVE allGain = SWS_GETChannelGains(device, timing = GAIN_AFTER_DAQ)
 
 	if(dataAcqOrTP == TEST_PULSE_MODE)
 		WAVE TPSettingsCalc = GetTPSettingsCalculated(device)
-		length = TPSettingsCalc[%totalLengthPointsTP]
+		length = TPSettingsCalc[%totalLengthPointsTP_ADC]
 		first  = chunk * length
 		last   = first + length - 1
 		ASSERT(first >= 0 && last < DimSize(DAQDataWave, ROWS) && first < last, "Invalid wave subrange")
@@ -724,10 +759,15 @@ static Function SCOPE_ITC_UpdateOscilloscope(device, dataAcqOrTP, chunk, fifoPos
 		endif
 #endif
 
-		Multithread OscilloscopeData[][startOfADColumns, startOfADColumns + numEntries - 1] = DAQDataWave[first + p][q] / allGain[q]
-		Multithread scaledDataWave[][] = OscilloscopeData
+		Multithread OscilloscopeData[][startOfADColumns, endOfADColumns - 1] = DAQDataWave[first + p][q] / allGain[q]
+		for(i = startOfADColumns; i < endOfADColumns; i += 1)
+			WAVE scaledChannel = scaledDataWave[i]
+			Multithread scaledChannel[] = OscilloscopeData[p][i]
+		endfor
 
-		SCOPE_UpdatePowerSpectrum(device)
+		Make/FREE/N=(DimSize(ADCs, ROWS)) tpColumns
+		tpColumns[] = startOfADColumns + p
+		SCOPE_UpdatePowerSpectrum(device, tpColumns)
 
 	elseif(dataAcqOrTP == DATA_ACQUISITION_MODE)
 
@@ -743,9 +783,12 @@ static Function SCOPE_ITC_UpdateOscilloscope(device, dataAcqOrTP, chunk, fifoPos
 
 		AssertOnAndClearRTError()
 		try
-			Multithread scaledDataWave[fifoPosGlobal, fifoPos - 1][] = DAQDataWave[p][q] / allGain[q]; AbortOnRTE
+			for(i = startOfADColumns; i < endOfADColumns; i += 1)
+				WAVE scaledChannel = scaledDataWave[i]
+				Multithread scaledChannel[fifoPosGlobal, fifoPos - 1] = DAQDataWave[p][i] / allGain[i]; AbortOnRTE
+			endfor
 		catch
-			sprintf msg, "Writing scaledDataWave failed, please save the experiment and file a bug report: fifoPosGlobal %g, fifoPos %g, scaledDataWave rows %g, stopCollectionPoint %g\r", fifoPosGlobal, fifoPos, DimSize(scaledDataWave, ROWS), ROVAR(GetStopCollectionPoint(device))
+			sprintf msg, "Writing scaledDataWave failed, please save the experiment and file a bug report: fifoPosGlobal %g, fifoPos %g, Channel Index %d, scaledChannelWave rows %g, stopCollectionPoint %g\r", fifoPosGlobal, fifoPos, i, DimSize(scaledChannel, ROWS), ROVAR(GetStopCollectionPoint(device))
 			ASSERT(0, msg)
 		endtry
 
@@ -754,12 +797,12 @@ static Function SCOPE_ITC_UpdateOscilloscope(device, dataAcqOrTP, chunk, fifoPos
 
 		switch(decMethod)
 			case DECIMATION_NONE:
-				Multithread OscilloscopeData[fifoPosGlobal, fifoPos - 1][startOfADColumns, startOfADColumns + numEntries - 1] = DAQDataWave[p][q] / allGain[q]
+				Multithread OscilloscopeData[fifoPosGlobal, fifoPos - 1][startOfADColumns, endOfADColumns - 1] = DAQDataWave[p][q] / allGain[q]
 				break
 			default:
-				Duplicate/FREE/RMD=[startOfADColumns, startOfADColumns + numEntries - 1] allGain, gain
+				Duplicate/FREE/RMD=[startOfADColumns, endOfADColumns - 1] allGain, gain
 				gain[] = 1 / gain[p]
-				DecimateWithMethod(DAQDataWave, OscilloscopeData, decFactor, decMethod, firstRowInp = fifoPosGlobal, lastRowInp = fifoPos - 1, firstColInp = startOfADColumns, lastColInp = startOfADColumns + numEntries - 1, factor = gain)
+				DecimateWithMethod(DAQDataWave, OscilloscopeData, decFactor, decMethod, firstRowInp = fifoPosGlobal, lastRowInp = fifoPos - 1, firstColInp = startOfADColumns, lastColInp = endOfADColumns - 1, factor = gain)
 		endswitch
 	else
 		ASSERT(0, "Invalid dataAcqOrTP value")
@@ -778,8 +821,6 @@ static Function SCOPE_ITC_AdjustFIFOPos(device, fifopos)
 
 	variable stopCollectionPoint
 
-	WAVE scaledDataWave = GetScaledDataWave(device)
-
 	WAVE DAQConfigWave = GetDAQConfigWave(device)
 	fifopos += GetDataOffset(DAQConfigWave)
 
@@ -795,5 +836,8 @@ static Function SCOPE_ITC_AdjustFIFOPos(device, fifopos)
 		return 0
 	endif
 
-	return min(fifoPos, DimSize(scaledDataWave, ROWS))
+	WAVE/WAVE scaledDataWave = GetScaledDataWave(device)
+	WAVE channel = scaledDataWave[0]
+
+	return min(fifoPos, DimSize(channel, ROWS))
 End

--- a/Packages/MIES/MIES_Structures.ipf
+++ b/Packages/MIES/MIES_Structures.ipf
@@ -381,6 +381,8 @@ Structure NWBAsyncParameters
 	variable sweep, compressionMode, session_start_time
 	variable locationID, nwbVersion
 
+	// DAQDataWave is a waveRef wave referencing the sweep channels from the main thread
+	// See also @ref GetSweepWave "intermediate sweep format"
 	WAVE DAQDataWave, DAQConfigWave
 
 	WAVE numericalValues
@@ -434,6 +436,7 @@ threadsafe Function [STRUCT NWBAsyncParameters s] NWB_ASYNC_DeserializeStruct(DF
 	s.nwbVersion = ASYNC_FetchVariable(threadDFR, "nwbVersion")
 
 	WAVE s.DAQDataWave = ASYNC_FetchWave(threadDFR, "DAQDataWave")
+	ASSERT_TS(IsWaveRefWave(s.DAQDataWave), "Unsupported sweep wave format")
 	ChangeWaveLock(s.DAQDataWave, 1)
 
 	WAVE s.DAQConfigWave = ASYNC_FetchWave(threadDFR, "DAQConfigWave")

--- a/Packages/MIES/MIES_Structures.ipf
+++ b/Packages/MIES/MIES_Structures.ipf
@@ -235,29 +235,12 @@ Structure AnalysisFunction_V3
 	/// one of @ref EVENT_TYPE_ANALYSIS_FUNCTIONS
 	variable eventType
 
-	/// raw data wave for interacting with the DAC hardware (locked to prevent
-	/// changes using `SetWaveLock`). The exact wave format depends on the hardware.
-	/// @sa GetDAQDataWave()
-	WAVE rawDACWave
-
 	/// scaled and undecimated data from the DAC hardware, 2D floating-point wave
 	/// Rows has channel data, one column per channel, channels are in the order DA/AD/TTL
 	WAVE scaledDACWave
 
 	/// active headstage index, `[0, NUM_HEADSTAGES[`
 	variable headStage
-
-	/// last valid row index in `rawDACWave` which will be filled with data at the
-	/// end of DAQ. The total number of rows in `rawDACWave` might be higher
-	/// due to alignment requirements of the data acquisition hardware.
-	///
-	/// Always `NaN` for #PRE_DAQ_EVENT/#PRE_SET_EVENT events.
-	variable lastValidRowIndex
-
-	/// last written row index in `rawDACWave`/`scaledDACWave` with already acquired data
-	///
-	/// Always `NaN` for #PRE_DAQ_EVENT/#PRE_SET_EVENT/#PRE_SWEEP_CONFIG_EVENT.
-	variable lastKnownRowIndex
 
 	/// Potential *future* number of the sweep. Once the sweep is finished it will be
 	/// saved with this number. Use GetSweepWave() to query the sweep itself.
@@ -269,6 +252,38 @@ Structure AnalysisFunction_V3
 	/// Analysis function parameters set in the stimset's textual parameter
 	/// wave. Settable via AFH_AddAnalysisParameter().
 	string params
+
+	/// last valid row index for DA channels in `rawDAQWave` which will be filled with data at the
+	/// end of DAQ. If the acquisition was aborted, the remaining samples beyond lastValidRowIndexDA
+	/// are NaN.
+	/// The total number of rows in `rawDAQWave` might be higher
+	/// due to alignment requirements of the data acquisition hardware (e.g. ITC).
+	///
+	/// Always `NaN` for #PRE_DAQ_EVENT/#PRE_SET_EVENT events.
+	variable lastValidRowIndexDA
+
+	/// last valid row index for AD/TTL channels in `rawDAQWave` which will be filled with data at the
+	/// end of DAQ. The total number of rows in `rawDAQWave` might be higher
+	/// due to alignment requirements of the data acquisition hardware (e.g. ITC).
+	///
+	/// Always `NaN` for #PRE_DAQ_EVENT/#PRE_SET_EVENT events.
+	variable lastValidRowIndexAD
+
+	/// last written row index in `rawDAQWave`/`scaledDACWave`s DA channel(s) with already acquired data
+	///
+	/// Always `NaN` for #PRE_DAQ_EVENT/#PRE_SET_EVENT/#PRE_SWEEP_CONFIG_EVENT.
+	variable lastKnownRowIndexDA
+
+	/// last written row index in `rawDAQWave`/`scaledDACWave`s AD/TTL channel(s) with already acquired data
+	///
+	/// Always `NaN` for #PRE_DAQ_EVENT/#PRE_SET_EVENT/#PRE_SWEEP_CONFIG_EVENT.
+	variable lastKnownRowIndexAD
+
+	/// sample interval of DA channel(s) in ms
+	variable sampleIntervalDA
+
+	/// sample interval of AD channel(s) in ms
+	variable sampleIntervalAD
 EndStructure
 
 Function InitDeltaControlNames(s)

--- a/Packages/MIES/MIES_SweepFormula_PSX.ipf
+++ b/Packages/MIES/MIES_SweepFormula_PSX.ipf
@@ -3073,6 +3073,12 @@ static Function/S PSX_GetPSXGraph(string win)
 	ASSERT(0, "Could not find an psx graph as part of the window hierarchy")
 End
 
+/// @brief Return the name of the possibly non-existing stats subwindow
+static Function/S PSX_GetPSXStatsGraph(string win)
+
+	return GetMainWindow(win) + "#Graph1"
+End
+
 static Function/WAVE PSX_GetEventsInsideAxisRange(string win, string traceName, variable first, variable last, WAVE xCrds)
 	WAVE data = TraceNameToWaveRef(win, traceName)
 

--- a/Packages/MIES/MIES_SweepSaving.ipf
+++ b/Packages/MIES/MIES_SweepSaving.ipf
@@ -17,7 +17,7 @@ Function SWS_SaveAcquiredData(device, [forcedStop])
 	string device
 	variable forcedStop
 
-	variable sweepNo
+	variable sweepNo,  plannedTime, acquiredTime
 	string sweepName, configName
 
 	forcedStop = ParamIsDefault(forcedStop) ? 0 : !!forcedStop
@@ -44,13 +44,14 @@ Function SWS_SaveAcquiredData(device, [forcedStop])
 	WAVE/SDFR=dfr/Z sweepWave = $sweepName
 	ASSERT(!WaveExists(sweepWave), "The sweep wave must not exist, name=" + sweepName)
 
+	[plannedTime, acquiredTime] = SWS_ProcessDATTLChannelsOnEarlyAcqStop(device, scaledDataWave, hardwareConfigWave)
+
 	Duplicate hardwareConfigWave, dfr:$configName
 	MoveWave scaledDataWave, dfr:$sweepName
 
-	WAVE sweepWave = GetSweepWave(device, sweepNo)
-	WAVE configWave = GetConfigWave(sweepWave)
+	SplitAndUpgradeSweepGlobal(device, sweepNo)
 
-	EP_WriteEpochInfoIntoSweepSettings(device, sweepWave, configWave)
+	EP_WriteEpochInfoIntoSweepSettings(device, sweepNo, acquiredTime, plannedTime)
 
 	// Add labnotebook entries for the acquired sweep
 	ED_createWaveNoteTags(device, sweepNo)
@@ -58,6 +59,7 @@ Function SWS_SaveAcquiredData(device, [forcedStop])
 	EP_CopyLBNEpochsToEpochsWave(device, sweepNo)
 
 	if(DAG_GetNumericalValue(device, "Check_Settings_NwbExport"))
+		[WAVE sweepWave, WAVE configWave] = GetSweepAndConfigWaveFromDevice(device, sweepNo)
 		NWB_AppendSweepDuringDAQ(device, sweepWave, configWave, sweepNo, str2num(DAG_GetTextualValue(device, "Popup_Settings_NwbVersion")))
 	endif
 
@@ -71,8 +73,49 @@ Function SWS_SaveAcquiredData(device, [forcedStop])
 		AFM_CallAnalysisFunctions(device, POST_SET_EVENT)
 	endif
 
-	EP_WriteEpochInfoIntoSweepSettings(device, sweepWave, configWave)
+	EP_WriteEpochInfoIntoSweepSettings(device, sweepNo, acquiredTime, plannedTime)
 	SWS_SweepSettingsEpochInfoToLBN(device, sweepNo)
+End
+
+/// @brief Determine actual acquisition times and if acquisition was stopped early, change the remaining data points in DA/TTL with NaN.
+///        DA/TTL data was prefilled in @sa DC_InitScaledDataWave with no early acquisition stop as default
+static Function [variable plannedTime, variable acquiredTime] SWS_ProcessDATTLChannelsOnEarlyAcqStop(string device, WAVE/WAVE scaledDataWave, WAVE config)
+
+	variable i, numChannels, firstUnAcquiredIndex, adcSize
+
+	NVAR fifoPosGlobal = $GetFifoPosition(device)
+	ASSERT(!IsNaN(fifoPosGlobal), "Invalid fifoPosGlobal")
+
+	WAVE channelADC = scaledDataWave[GetFirstADCChannelIndex(config)]
+	adcSize = HW_GetEffectiveADCWaveLength(device, DATA_ACQUISITION_MODE)
+	plannedTime = IndexToScale(channelADC, adcSize - 1, ROWS) * MILLI_TO_ONE
+
+	FindValue/FNAN  channelADC
+	if(V_row < 0)
+		V_row = adcSize
+	endif
+	ASSERT(V_row == fifoPosGlobal, "Mismatch of NaN boundary in ADC channel to last fifo position")
+
+	if(fifoPosGlobal == adcSize)
+		return [plannedTime, plannedTime]
+	endif
+
+	acquiredTime = fifoPosGlobal ? IndexToScale(channelADC, max(fifoPosGlobal - 1, 0), ROWS) * MILLI_TO_ONE : 0
+
+	numChannels = DimSize(config, ROWS)
+	for(i = 0; i < numChannels; i += 1)
+		if(!(config[i][%ChannelType] == XOP_CHANNEL_TYPE_DAC || config[i][%ChannelType] == XOP_CHANNEL_TYPE_TTL))
+			continue
+		endif
+		WAVE channel = scaledDataWave[i]
+		if(acquiredTime)
+			firstUnAcquiredIndex = trunc((acquiredTime * ONE_TO_MILLI - DimOffset(channel, ROWS)) / DimDelta(channel, ROWS)) + 1
+			firstUnAcquiredIndex = min(firstUnAcquiredIndex, DimSize(channel, ROWS) - 1)
+		endif
+		MultiThread channel[firstUnAcquiredIndex, Inf] = NaN
+	endfor
+
+	return [plannedTime, acquiredTime]
 End
 
 static Function SWS_SweepSettingsEpochInfoToLBN(string device, variable sweepNo)

--- a/Packages/MIES/MIES_SweepSaving.ipf
+++ b/Packages/MIES/MIES_SweepSaving.ipf
@@ -174,6 +174,16 @@ End
 ///
 /// \endrst
 ///
+/// With GAIN_BEFORE_DAQ the function returns the gain factor for all channels.
+/// With GAIN_AFTER_DAC the gain factor for ADC channels is returned as 1.
+/// Gain handling for NI:
+/// In dataconfigurator setup DAC_values = data(before_DAQ) * gain_factor(DAC_channel) @sa DC_FillDAQDataWaveForDAQ
+/// at acquisition time done by hardware ADC_values = data(acquired_by_ADC) * gain_factor(ADC_channel) @sa HW_NI_PrepareAcq
+/// at acquisition time on readout:
+/// oscilloscopeValues = DAC_values
+/// scaledValues = DAC_values / gain_factor(DAC_channel)
+/// ADC_values are NOT changed, thus a gain factor of 1 is used when calculation indexes over all DAC, ADC, TTL channels. @sa SCOPE_NI_UpdateOscilloscope
+///
 /// @param device device
 /// @param timing     One of @ref GainTimeParameter
 ///

--- a/Packages/MIES/MIES_SweepSaving.ipf
+++ b/Packages/MIES/MIES_SweepSaving.ipf
@@ -49,12 +49,12 @@ Function SWS_SaveAcquiredData(device, [forcedStop])
 	Duplicate hardwareConfigWave, dfr:$configName
 	MoveWave scaledDataWave, dfr:$sweepName
 
-	SplitAndUpgradeSweepGlobal(device, sweepNo)
-
 	EP_WriteEpochInfoIntoSweepSettings(device, sweepNo, acquiredTime, plannedTime)
 
-	// Add labnotebook entries for the acquired sweep
+	// Add labnotebook entries for the acquired sweep and note to sweepWave
 	ED_createWaveNoteTags(device, sweepNo)
+
+	SplitAndUpgradeSweepGlobal(device, sweepNo)
 
 	EP_CopyLBNEpochsToEpochsWave(device, sweepNo)
 

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -1571,7 +1571,7 @@ End
 ///
 /// @param dfr 	    datafolder reference where the new datafolder should be created
 /// @param baseName first part of the wave name, might be shorted due to Igor Pro limitations
-Function/S UniqueWaveName(dfr, baseName)
+threadsafe Function/S UniqueWaveName(dfr, baseName)
 	dfref dfr
 	string baseName
 
@@ -1579,8 +1579,8 @@ Function/S UniqueWaveName(dfr, baseName)
 	string name
 	string path
 
-	ASSERT(!isEmpty(baseName), "baseName must not be empty" )
-	ASSERT(DataFolderExistsDFR(dfr), "dfr does not exist")
+	ASSERT_TS(!isEmpty(baseName), "baseName must not be empty" )
+	ASSERT_TS(DataFolderExistsDFR(dfr), "dfr does not exist")
 
 	// shorten basename so that we can attach some numbers
 	baseName = CleanupName(baseName[0, MAX_OBJECT_NAME_LENGTH_IN_BYTES - 5], 0)
@@ -1597,7 +1597,7 @@ Function/S UniqueWaveName(dfr, baseName)
 		index += 1
 	while(index < 10000)
 
-	DEBUGPRINT("Could not find a unique folder with 10000 trials")
+	DEBUGPRINT_TS("Could not find a unique folder with 10000 trials")
 
 	return ""
 End

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -7631,7 +7631,7 @@ End
 /// The entries in this wave are only valid during DAQ/TP and are updated via DC_UpdateGlobals().
 Function/WAVE GetTPSettingsCalculated(string device)
 
-	variable versionOfNewWave = 2
+	variable versionOfNewWave = 3
 
 	DFREF dfr = GetDeviceTestPulse(device)
 
@@ -7640,13 +7640,34 @@ Function/WAVE GetTPSettingsCalculated(string device)
 	if(ExistsWithCorrectLayoutVersion(wv, versionOfNewWave))
 		return wv
 	elseif(WaveExists(wv))
-		Redimension/N=(10) wv
+		if(!IsWaveVersioned(wv))
+			Redimension/N=(7) wv
+			SetDimensionLabels(wv, "baselineFrac;pulseLengthMS;pulseLengthPointsTP;pulseLengthPointsDAQ;totalLengthMS;totalLengthPointsTP;totalLengthPointsDAQ;", ROWS)
+			SetWaveVersion(wv, 1)
+		endif
+		if(WaveVersionIsAtLeast(wv, 1))
+			Redimension/N=(10) wv
+			SetDimensionLabels(wv, "baselineFrac;pulseLengthMS;pulseLengthPointsTP;pulseLengthPointsDAQ;totalLengthMS;totalLengthPointsTP;totalLengthPointsDAQ;pulseStartMS;pulseStartPointsTP;pulseStartPointsDAQ;", ROWS)
+			SetWaveVersion(wv, 2)
+		endif
+		if(WaveVersionIsAtLeast(wv, 2))
+			Redimension/N=(16) wv
+			SetDimensionLabels(wv, "baselineFrac;pulseLengthMS;pulseLengthPointsTP;pulseLengthPointsDAQ;totalLengthMS;totalLengthPointsTP;totalLengthPointsDAQ;pulseStartMS;pulseStartPointsTP;pulseStartPointsDAQ;pulseLengthPointsTP_ADC;pulseLengthPointsDAQ_ADC;totalLengthPointsTP_ADC;totalLengthPointsDAQ_ADC;pulseStartPointsTP_ADC;pulseStartPointsDAQ_ADC;", ROWS)
+			wv[%pulseLengthPointsTP_ADC] = wv[%pulseLengthPointsTP]
+			wv[%pulseLengthPointsDAQ_ADC] = wv[%pulseLengthPointsDAQ]
+			wv[%totalLengthPointsTP_ADC] = wv[%totalLengthPointsTP]
+			wv[%totalLengthPointsDAQ_ADC] = wv[%totalLengthPointsDAQ]
+			wv[%pulseStartPointsTP_ADC] = wv[%pulseStartPointsTP]
+			wv[%pulseStartPointsDAQ_ADC] = wv[%pulseStartPointsDAQ]
+		endif
 	else
-		Make/N=(10)/D dfr:settingsCalculated/WAVE=wv
+		Make/N=(16)/D dfr:settingsCalculated/WAVE=wv
 		wv = NaN
 	endif
 
-	SetDimensionLabels(wv, "baselineFrac;pulseLengthMS;pulseLengthPointsTP;pulseLengthPointsDAQ;totalLengthMS;totalLengthPointsTP;totalLengthPointsDAQ;pulseStartMS;pulseStartPointsTP;pulseStartPointsDAQ", ROWS)
+	SetDimensionLabels(wv, "baselineFrac;pulseLengthMS;pulseLengthPointsTP;pulseLengthPointsDAQ;totalLengthMS;totalLengthPointsTP;totalLengthPointsDAQ;pulseStartMS;pulseStartPointsTP;pulseStartPointsDAQ;pulseLengthPointsTP_ADC;pulseLengthPointsDAQ_ADC;totalLengthPointsTP_ADC;totalLengthPointsDAQ_ADC;pulseStartPointsTP_ADC;pulseStartPointsDAQ_ADC;", ROWS)
+
+	SetWaveVersion(wv, versionOfNewWave)
 
 	return wv
 End

--- a/Packages/MIES/analysis_function_parameters.itx
+++ b/Packages/MIES/analysis_function_parameters.itx
@@ -51,7 +51,7 @@ BEGIN
 	"PostDAQDAScaleForFailedHS"	"variable"	"required"	"FR"	"Failed headstages will be set to this DAScale value [pA] in the post set event"
 	"PostDAQDAScaleMinOffset"	"variable"	"required"	"FR"	"Mininum absolute offset value applied to the found DAScale [pA]"
 	"RelativeVoltageDiff"	"variable"	"required"	"VM"	"Maximum relative allowed difference of the baseline membrane potentials [%].\r Set to `inf` to disable this check."
-	"SamplingFrequency"	"variable"	"optional"	"AR, CR, DA, PB, RA, RB, SE, SP, VM"	"Required sampling frequency for the acquired data [kHz]. Defaults to 50.\rRequired sampling frequency for the acquired data [kHz]. Defaults to 200.\rRequired sampling frequency for the acquired data [kHz]. Defaults to 200.\rRequired sampling frequency for the acquired data [kHz]. Defaults to 200.\rRequired sampling frequency for the acquired data [kHz]. Defaults to 50."
+	"SamplingFrequency"	"variable"	"optional"	"AR, CR, DA, PB, RA, RB, SE, SP, VM"	"Required sampling frequency for the acquired data [kHz]. Defaults to ITC:50 NI:50.\rRequired sampling frequency for the acquired data [kHz]. Defaults to ITC:200 NI:250.\rRequired sampling frequency for the acquired data [kHz]. Defaults to ITC:200 NI:250.\rRequired sampling frequency for the acquired data [kHz]. Defaults to ITC:200 NI:250.\rRequired sampling frequency for the acquired data [kHz]. Defaults to ITC:50 NI:50."
 	"SamplingMultiplier"	"variable"	"required"	"AR, CR, DA, FR, PB, RA, RB, SE, SP, VM"	"Sampling multiplier, use 1 for no multiplier"
 	"SealThreshold"	"variable"	"required"	"SE"	"Minimum required seal threshold [GΩ]"
 	"ShowPlot"	"variable"	"optional"	"DA"	"Show the resistance (\"Sub\") or the f-I (\"Supra\") plot, defaults to true."

--- a/Packages/tests/Basic/UTF_AnalysisFunctionParameters.ipf
+++ b/Packages/tests/Basic/UTF_AnalysisFunctionParameters.ipf
@@ -928,7 +928,7 @@ static Function GenerateAnalysisFunctionTable()
 	// if this test fails and the CRC changes
 	// commit the file `Packages/MIES/analysis_function_parameters.itx`
 	// and check that the changes therein are intentional
-	CHECK_EQUAL_VAR(WaveCRC(0, output, 0), 1642314015)
+	CHECK_EQUAL_VAR(WaveCRC(0, output, 0), 303837295)
 	StoreWaveOnDisk(output, "analysis_function_parameters")
 End
 

--- a/Packages/tests/Basic/UTF_SweepFormula_PSX.ipf
+++ b/Packages/tests/Basic/UTF_SweepFormula_PSX.ipf
@@ -5,7 +5,10 @@
 
 Function [string browser, string device, string formulaGraph] CreateFakeDataBrowserWithSweepFormulaGraph()
 
-	[browser, device] = CreateFakeDataBrowserWindow()
+	[browser, device] = CreateEmptyUnlockedDataBrowserWindow()
+	GetDeviceDataPath(device)
+	browser = MIES_DB#DB_LockToDevice(browser, device)
+
 	formulaGraph = GetSweepFormulaGraph()
 
 	SetWindow $formulaGraph, userData($SFH_USER_DATA_BROWSER)=browser
@@ -1004,10 +1007,10 @@ static Function TestOperationPSXKernel()
 	string win, device, str, expected, actual
 	variable jsonID
 
-	[win, device] = CreateFakeDataBrowserWindow()
+	[win, device] = CreateEmptyUnlockedDataBrowserWindow()
 
-	CreateFakeSweepData(win, device, sweepNo = 0, sweepGen=FakeSweepDataGeneratorPSXKernel)
-	CreateFakeSweepData(win, device, sweepNo = 2, sweepGen=FakeSweepDataGeneratorPSXKernel)
+	win = CreateFakeSweepData(win, device, sweepNo = 0, sweepGen=FakeSweepDataGeneratorPSXKernel)
+	win = CreateFakeSweepData(win, device, sweepNo = 2, sweepGen=FakeSweepDataGeneratorPSXKernel)
 
 	str = "psxKernel([50, 150], select(channels(AD6), [0, 2], all), 1, 15, (-5))"
 	WAVE/WAVE dataWref = SF_ExecuteFormula(str, win, useVariables = 0)
@@ -1092,10 +1095,10 @@ static Function TestOperationPSX()
 	// all decay fits are successfull
 	overrideResults[][][%$"Fit Result"] = 1
 
-	[win, device] = CreateFakeDataBrowserWindow()
+	[win, device] = CreateEmptyUnlockedDataBrowserWindow()
 
-	CreateFakeSweepData(win, device, sweepNo = 0, sweepGen=FakeSweepDataGeneratorPSX)
-	CreateFakeSweepData(win, device, sweepNo = 2, sweepGen=FakeSweepDataGeneratorPSX)
+	win = CreateFakeSweepData(win, device, sweepNo = 0, sweepGen=FakeSweepDataGeneratorPSX)
+	win = CreateFakeSweepData(win, device, sweepNo = 2, sweepGen=FakeSweepDataGeneratorPSX)
 
 	str = "psx(myID, psxKernel([50, 150], select(channels(AD6), [0, 2], all), 1, 15, (-5)), 2.5, 100, 0)"
 	WAVE/WAVE dataWref = SF_ExecuteFormula(str, win, useVariables = 0)
@@ -1154,10 +1157,10 @@ static Function TestOperationPSXTooLargeDecayTau()
 	overrideResults[][][%$"Fit Result"] = 1
 	overrideResults[][][%Tau] = 1000
 
-	[win, device] = CreateFakeDataBrowserWindow()
+	[win, device] = CreateEmptyUnlockedDataBrowserWindow()
 
-	CreateFakeSweepData(win, device, sweepNo = 0, sweepGen=FakeSweepDataGeneratorPSX)
-	CreateFakeSweepData(win, device, sweepNo = 2, sweepGen=FakeSweepDataGeneratorPSX)
+	win = CreateFakeSweepData(win, device, sweepNo = 0, sweepGen=FakeSweepDataGeneratorPSX)
+	win = CreateFakeSweepData(win, device, sweepNo = 2, sweepGen=FakeSweepDataGeneratorPSX)
 
 	str = "psx(myID, psxKernel([50, 150], select(channels(AD6), [0], all), 1, 15, (-5)), 1.5, 100, 0)"
 	WAVE/WAVE dataWref = SF_ExecuteFormula(str, win, useVariables = 0)
@@ -1257,8 +1260,8 @@ static Function MouseSelectionPSX()
 	browser = DB_OpenDataBrowser()
 	device  = HW_ITC_BuildDeviceString(StringFromList(0, DEVICE_TYPES_ITC), StringFromList(0, DEVICE_NUMBERS))
 
-	CreateFakeSweepData(browser, device, sweepNo = 0, sweepGen=FakeSweepDataGeneratorPSX)
-	CreateFakeSweepData(browser, device, sweepNo = 2, sweepGen=FakeSweepDataGeneratorPSX)
+	browser = CreateFakeSweepData(browser, device, sweepNo = 0, sweepGen=FakeSweepDataGeneratorPSX)
+	browser = CreateFakeSweepData(browser, device, sweepNo = 2, sweepGen=FakeSweepDataGeneratorPSX)
 
 	browser = MIES_DB#DB_LockToDevice(browser, device)
 
@@ -1268,7 +1271,7 @@ static Function MouseSelectionPSX()
 
 	ExecuteSweepFormulaCode(browser, code)
 
-	psxPlot = "SweepFormula_plotDatabrowser_#Graph0"
+	psxPlot = "SweepFormula_plotDatabrowser_1_#Graph0"
 	REQUIRE(WindowExists(psxPlot))
 
 	[WAVE psxEvent_0, WAVE psxEvent_1] = GetPSXEventWavesHelper(psxPlot)
@@ -1368,19 +1371,20 @@ static Function/S SetupDatabrowserWithSomeData()
 
 	string browser, device
 
-	browser = DB_OpenDataBrowser()
-	device  = HW_ITC_BuildDeviceString(StringFromList(0, DEVICE_TYPES_ITC), StringFromList(0, DEVICE_NUMBERS))
+	[browser, device] = CreateEmptyUnlockedDataBrowserWindow()
 
-	CreateFakeSweepData(browser, device, sweepNo = 0, sweepGen=FakeSweepDataGeneratorPSX)
-	CreateFakeSweepData(browser, device, sweepNo = 2, sweepGen=FakeSweepDataGeneratorPSX)
+	browser = CreateFakeSweepData(browser, device, sweepNo = 0, sweepGen=FakeSweepDataGeneratorPSX)
+	browser = CreateFakeSweepData(browser, device, sweepNo = 2, sweepGen=FakeSweepDataGeneratorPSX)
 
 	// adjust x-position of sweep 2
 	// so sweep 0 has two events and sweep 2 only one but with a different x position
 	WAVE/Z sweepWave = GetSweepWave(device, 2)
-	CHECK_WAVE(sweepWave, NUMERIC_WAVE, minorType = DOUBLE_WAVE)
-	SetScale/P x, 25, DimDelta(sweepWave, ROWS), sweepWave
+	CHECK_WAVE(sweepWave, TEXT_WAVE)
 
-	browser = MIES_DB#DB_LockToDevice(browser, device)
+	Make/WAVE/N=(DimSize(sweepWave, ROWS)) input = ResolveSweepChannel(sweepWave, p)
+	for(WAVE wv : input)
+		SetScale/P x, 25, DimDelta(wv, ROWS), wv
+	endfor
 
 	return browser
 End
@@ -1401,7 +1405,7 @@ End
 /// UTF_TD_GENERATOR s0:SupportedPostProcForEventSelection
 static Function MouseSelectionPSXStats([STRUCT IUTF_mData &m])
 
-	string browser, code, psxStatsGraph, postProc
+	string win, browser, code, psxGraph, psxStatsGraph, postProc
 	variable numEvents, logMode
 
 	postProc = m.s0
@@ -1415,8 +1419,9 @@ static Function MouseSelectionPSXStats([STRUCT IUTF_mData &m])
 
 	ExecuteSweepFormulaCode(browser, code)
 
-	psxStatsGraph = "SweepFormula_plotDatabrowser_#Graph1"
-	REQUIRE(WindowExists(psxStatsGraph))
+	win = SFH_GetFormulaGraphForBrowser(browser)
+	psxGraph = MIES_PSX#PSX_GetPSXGraph(win)
+	psxStatsGraph = MIES_PSX#PSX_GetPSXStatsGraph(psxGraph)
 
 	ModifyGraph/W=$psxStatsGraph log(left)=logMode
 
@@ -1505,7 +1510,7 @@ static Function MouseSelectionStatsPostProcNonFinite()
 	win = SFH_GetFormulaGraphForBrowser(browser)
 	mainWindow = GetMainWindow(win)
 	psxGraph = MIES_PSX#PSX_GetPSXGraph(win)
-	psxStatsGraph = "SweepFormula_plotDatabrowser_#Graph1"
+	psxStatsGraph = MIES_PSX#PSX_GetPSXStatsGraph(psxGraph)
 
 	REQUIRE(WindowExists(psxStatsGraph))
 
@@ -1914,8 +1919,8 @@ static Function JumpToSelectedEvents([STRUCT IUTF_mData &m])
 
 	win = SFH_GetFormulaGraphForBrowser(browser)
 	mainWindow = GetMainWindow(win)
-	psxStatsGraph = "SweepFormula_plotDatabrowser_#Graph1"
 	psxGraph = MIES_PSX#PSX_GetPSXGraph(win)
+	psxStatsGraph = MIES_PSX#PSX_GetPSXStatsGraph(psxGraph)
 
 	REQUIRE(WindowExists(psxGraph))
 
@@ -2008,7 +2013,7 @@ static Function CursorMovementStats()
 	win = SFH_GetFormulaGraphForBrowser(browser)
 	mainWindow = GetMainWindow(win)
 	psxGraph = MIES_PSX#PSX_GetPSXGraph(win)
-	psxStatsGraph = "SweepFormula_plotDatabrowser_#Graph1"
+	psxStatsGraph = MIES_PSX#PSX_GetPSXStatsGraph(psxGraph)
 
 	REQUIRE(WindowExists(psxStatsGraph))
 
@@ -2068,7 +2073,7 @@ static Function KeyboardInteractions()
 	win = SFH_GetFormulaGraphForBrowser(browser)
 	mainWindow = GetMainWindow(win)
 	psxGraph = MIES_PSX#PSX_GetPSXGraph(win)
-	psxStatsGraph = "SweepFormula_plotDatabrowser_#Graph1"
+	psxStatsGraph = MIES_PSX#PSX_GetPSXStatsGraph(psxGraph)
 
 	REQUIRE(WindowExists(psxStatsGraph))
 
@@ -2282,7 +2287,7 @@ static Function KeyboardInteractionsStats()
 	win = SFH_GetFormulaGraphForBrowser(browser)
 	mainWindow = GetMainWindow(win)
 	psxGraph = MIES_PSX#PSX_GetPSXGraph(win)
-	psxStatsGraph = "SweepFormula_plotDatabrowser_#Graph1"
+	psxStatsGraph = MIES_PSX#PSX_GetPSXStatsGraph(psxGraph)
 
 	REQUIRE(WindowExists(psxStatsGraph))
 
@@ -2509,6 +2514,7 @@ static Function KeyboardInteractionsStatsSpecial()
 	win = SFH_GetFormulaGraphForBrowser(browser)
 	mainWindow = GetMainWindow(win)
 	psxGraph = MIES_PSX#PSX_GetPSXGraph(win)
+	psxStatsGraph = MIES_PSX#PSX_GetPSXStatsGraph(psxGraph)
 
 	SetActiveSubwindow $psxGraph
 
@@ -2519,7 +2525,7 @@ static Function KeyboardInteractionsStatsSpecial()
 	// replot so that stats now has data
 	ExecuteSweepFormulaCode(browser, code)
 
-	psxStatsGraph = "SweepFormula_plotDatabrowser_#Graph1"
+	psxStatsGraph = MIES_PSX#PSX_GetPSXStatsGraph(psxGraph)
 
 	REQUIRE(WindowExists(psxStatsGraph))
 
@@ -2580,7 +2586,7 @@ static Function KeyboardInteractionsStatsPostProcNonFinite()
 	win = SFH_GetFormulaGraphForBrowser(browser)
 	mainWindow = GetMainWindow(win)
 	psxGraph = MIES_PSX#PSX_GetPSXGraph(win)
-	psxStatsGraph = "SweepFormula_plotDatabrowser_#Graph1"
+	psxStatsGraph = MIES_PSX#PSX_GetPSXStatsGraph(psxGraph)
 
 	REQUIRE(WindowExists(psxStatsGraph))
 
@@ -2845,10 +2851,10 @@ End
 
 static Function TestOperationRiseTime()
 
-	string win, device, str
+	string win, str
 	variable lowerThreshold, upperThreshold
 
-	[win, device] = CreateFakeDataBrowserWindow()
+	win = SetupDatabrowserWithSomeData()
 
 	str = "psxRiseTime()"
 	WAVE/WAVE dataWref = SF_ExecuteFormula(str, win, useVariables = 0)
@@ -2890,9 +2896,9 @@ static Function TestOperationPrep()
 
 	string win, device, code, psxCode
 
-	[win, device] = CreateFakeDataBrowserWindow()
+	[win, device] = CreateEmptyUnlockedDataBrowserWindow()
 
-	CreateFakeSweepData(win, device, sweepNo = 0, sweepGen=FakeSweepDataGeneratorPSX)
+	win = CreateFakeSweepData(win, device, sweepNo = 0, sweepGen=FakeSweepDataGeneratorPSX)
 
 	psxCode = "psx(myID, psxKernel([50, 150], select(channels(AD6), [0, 2], all), 1, 15, (-5)), 2.5, 100, 0)"
 	sprintf code, "psxPrep(%s)", psxCode
@@ -3061,10 +3067,10 @@ End
 
 static Function TestOperationDeconvFilter()
 
-	string win, device, str
+	string win, str
 	variable filterLow, filterHigh, filterOrder
 
-	[win, device] = CreateFakeDataBrowserWindow()
+	win = SetupDatabrowserWithSomeData()
 
 	str = "psxDeconvFilter()"
 	WAVE/WAVE dataWref = SF_ExecuteFormula(str, win, useVariables = 0)

--- a/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqChirp.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqChirp.ipf
@@ -27,6 +27,9 @@ static Function GlobalPreInit(string device)
 
 	AdjustAnalysisParamsForPSQ(device, "PatchSeqChirp_DA_0")
 	PrepareForPublishTest()
+
+	// Ensure that PRE_SET_EVENT already sees the override wave
+	ResetOverrideResults()
 End
 
 static Function/WAVE GetLBNEntriesWave_IGNORE()

--- a/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqDAScale_Sub.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqDAScale_Sub.ipf
@@ -29,8 +29,7 @@ static Function GlobalPreInit(string device)
 	PrepareForPublishTest()
 
 	// Ensure that PSQ_DS_GetDAScaleOffset already sees the test override as enabled
-	Make/O/N=(0) root:overrideResults/Wave=overrideResults
-	Note/K overrideResults
+	ResetOverrideResults()
 End
 
 static Function/WAVE GetLBNEntries_IGNORE(device, sweepNo, name, [chunk])

--- a/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqDAScale_Supra.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqDAScale_Supra.ipf
@@ -27,8 +27,7 @@ static Function GlobalPreInit(string device)
 	PrepareForPublishTest()
 
 	// Ensure that PSQ_DS_GetDAScaleOffset already sees the test override as enabled
-	Make/O/N=(0) root:overrideResults/Wave=overrideResults
-	Note/K overrideResults
+	ResetOverrideResults()
 End
 
 static Function/WAVE GetLBNEntries_IGNORE(device, sweepNo, name, [chunk])

--- a/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqRamp.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqRamp.ipf
@@ -271,10 +271,13 @@ static Function PS_RA1_REENTRY([str])
 	onsetDelay = GetTotalOnsetDelay(numericalValues, sweepNo)
 
 	WAVE/Z stimSetLengths = GetStimsetLengths_IGNORE(sweepNo, str)
-	Make/FREE/N=(numEntries) sweepLengths   = DimSize(GetSweepWave(str, sweeps[p]), ROWS)
 
-	sweepLengths[] -= onsetDelay / DimDelta(GetSweepWave(str, sweeps[p]), ROWS)
-
+	Make/FREE/N=(numEntries) sweepLengths
+	for(i = 0; i < numEntries; i += 1)
+		WAVE sweepT = GetSweepWave(str, sweeps[i])
+		WAVE channel = ResolveSweepChannel(sweepT, 0)
+		sweepLengths[i] = DimSize(channel, ROWS) - onsetDelay / DimDelta(channel, ROWS)
+	endfor
 	CHECK_EQUAL_WAVES(stimSetLengths, sweepLengths, mode = WAVE_DATA)
 
 	WAVE/Z durations = GetPulseDurations_IGNORE(sweepNo, str)
@@ -834,7 +837,7 @@ End
 
 static Function PS_RA7_REENTRY([str])
 	string str
-	variable sweepNo, numEntries, onsetDelay, DAScale
+	variable i, sweepNo, numEntries, onsetDelay, DAScale
 
 	sweepNo = 0
 
@@ -880,10 +883,12 @@ static Function PS_RA7_REENTRY([str])
 	onsetDelay = GetTotalOnsetDelay(numericalValues, sweepNo)
 
 	WAVE/Z stimSetLengths = GetStimsetLengths_IGNORE(sweepNo, str)
-	Make/FREE/N=(numEntries) sweepLengths   = DimSize(GetSweepWave(str, sweeps[p]), ROWS)
-
-	sweepLengths[] -= onsetDelay / DimDelta(GetSweepWave(str, sweeps[p]), ROWS)
-
+	Make/FREE/N=(numEntries) sweepLengths
+	for(i = 0; i < numEntries; i += 1)
+		WAVE sweepT = GetSweepWave(str, sweeps[i])
+		WAVE channel = ResolveSweepChannel(sweepT, 0)
+		sweepLengths[i] = DimSize(channel, ROWS) - onsetDelay / DimDelta(channel, ROWS)
+	endfor
 	CHECK_EQUAL_WAVES(stimSetLengths, sweepLengths, mode = WAVE_DATA)
 
 	WAVE/Z durations = GetPulseDurations_IGNORE(sweepNo, str)

--- a/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqRheobase.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqRheobase.ipf
@@ -28,13 +28,13 @@ static Function GlobalPreInit(string device)
 
 	AdjustAnalysisParamsForPSQ(device, "Rheobase_DA_0")
 	PrepareForPublishTest()
+	ResetOverrideResults()
 End
 
 static Function SetFinalDAScale(variable var)
 
-	Make/O/N=(0) root:overrideResults/Wave=overrideResults
-	Note/K overrideResults
-
+	WAVE/Z overrideResults = GetOverrideResults()
+	CHECK_WAVE(overrideResults, NORMAL_WAVE)
 	SetNumberInWaveNote(overrideResults, PSQ_RB_FINALSCALE_FAKE_KEY, var)
 End
 

--- a/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqRheobase.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqRheobase.ipf
@@ -200,10 +200,13 @@ static Function PS_RB1_REENTRY([str])
 	onsetDelay = GetTotalOnsetDelay(numericalValues, sweepNo)
 
 	WAVE/Z stimSetLengths = GetStimsetLengths_IGNORE(sweepNo, str)
-	Make/FREE/N=(numEntries) sweepLengths   = DimSize(GetSweepWave(str, sweeps[p]), ROWS)
 
-	sweepLengths[] -= onsetDelay / DimDelta(GetSweepWave(str, sweeps[p]), ROWS)
-
+	Make/FREE/N=(numEntries) sweepLengths
+	for(i = 0; i < numEntries; i += 1)
+		WAVE sweepT = GetSweepWave(str, sweeps[i])
+		WAVE channel = ResolveSweepChannel(sweepT, 0)
+		sweepLengths[i] = DimSize(channel, ROWS) - onsetDelay / DimDelta(channel, ROWS)
+	endfor
 	CHECK_EQUAL_WAVES(stimSetLengths, sweepLengths, mode = WAVE_DATA)
 
 	WAVE/Z durations = GetPulseDurations_IGNORE(sweepNo, str)
@@ -1072,10 +1075,13 @@ static Function PS_RB11_REENTRY([str])
 	onsetDelay = GetTotalOnsetDelay(numericalValues, sweepNo)
 
 	WAVE/Z stimSetLengths = GetStimsetLengths_IGNORE(sweepNo, str)
-	Make/FREE/N=(numEntries) sweepLengths   = DimSize(GetSweepWave(str, sweeps[p]), ROWS)
 
-	sweepLengths[] -= onsetDelay / DimDelta(GetSweepWave(str, sweeps[p]), ROWS)
-
+	Make/FREE/N=(numEntries) sweepLengths
+	for(i = 0; i < numEntries; i += 1)
+		WAVE sweepT = GetSweepWave(str, sweeps[i])
+		WAVE channel = ResolveSweepChannel(sweepT, 0)
+		sweepLengths[i] = DimSize(channel, ROWS) - onsetDelay / DimDelta(channel, ROWS)
+	endfor
 	CHECK_EQUAL_WAVES(stimSetLengths, sweepLengths, mode = WAVE_DATA)
 
 	WAVE/Z durations = GetPulseDurations_IGNORE(sweepNo, str)

--- a/Packages/tests/HardwareBasic/UTF_Epochs.ipf
+++ b/Packages/tests/HardwareBasic/UTF_Epochs.ipf
@@ -310,7 +310,7 @@ End
 static Function TestEpochsGeneric(string device)
 
 	variable numEntries, endTimeDAC, endTimeEpochs, samplingInterval, hwType
-	variable i, lastPoint, channelType, channelNumber, index, hwChannelNumber, first, last, ttlBit
+	variable i, lastPointDA, channelType, channelNumber, index, hwChannelNumber, first, last, ttlBit
 	string setName, sweepChannelName
 
 	string sweeps, configs
@@ -325,19 +325,22 @@ static Function TestEpochsGeneric(string device)
 	CHECK_EQUAL_VAR(ItemsInList(sweeps), 1)
 	CHECK_EQUAL_VAR(ItemsInList(configs), 1)
 	WAVE/Z sweep  = $StringFromList(0, sweeps)
-	CHECK_WAVE(sweep, NUMERIC_WAVE, minorType = FLOAT_WAVE)
+	CHECK_WAVE(sweep, TEXT_WAVE)
+	CHECK_GT_VAR(DimSize(sweep, ROWS), 1)
+	WAVE channelDA = ResolveSweepChannel(sweep, 0)
+	CHECK_WAVE(channelDA, NUMERIC_WAVE, minorType = FLOAT_WAVE)
 	sweepNo = ExtractSweepNumber(NameOfWave(sweep))
 	CHECK_GE_VAR(sweepNo, 0)
 
 	WAVE/Z config = $StringFromList(0, configs)
 	CHECK_WAVE(config, NUMERIC_WAVE)
-	CHECK_EQUAL_VAR(DimSize(config, ROWS), DimSize(sweep, COLS))
+	CHECK_EQUAL_VAR(DimSize(config, ROWS), DimSize(sweep, ROWS))
 
 	WAVE/T textualValues   = GetLBTextualValues(device)
 	WAVE   numericalValues = GetLBNumericalValues(device)
 
 	DFREF dfr = UniqueDataFolder(GetDataFolderDFR(), "epochTestSweepChannels")
-	SplitSweepIntoComponents(numericalValues, sweepNo, sweep, config, TTL_RESCALE_ON, targetDFR = dfr)
+	SplitAndUpgradeSweep(numericalValues, sweepNo, sweep, config, TTL_RESCALE_ON, targetDFR = dfr)
 
 	// basic check of internal epoch wave
 	WAVE/T epochs = GetEpochsWave(device)
@@ -350,8 +353,8 @@ static Function TestEpochsGeneric(string device)
 	CHECK_WAVE(samplInt, NUMERIC_WAVE)
 	samplingInterval = samplInt[INDEP_HEADSTAGE] * MICRO_TO_MILLI
 
-	lastPoint = DimSize(sweep, ROWS)
-	endTimeDAC = samplingInterval * lastPoint
+	lastPointDA = DimSize(channelDA, ROWS)
+	endTimeDAC = samplingInterval * lastPointDA
 
 	WAVE/T epochLBEntries = GetLastSetting(textualValues, sweepNo, EPOCHS_ENTRY_KEY, DATA_ACQUISITION_MODE)
 	WAVE/T setNameLBEntries = GetLastSetting(textualValues, sweepNo, STIM_WAVE_NAME_KEY, DATA_ACQUISITION_MODE)
@@ -421,11 +424,11 @@ static Function TestEpochsGeneric(string device)
 
 			TestEpochsMonotony(epochChannel, sweepChannel)
 
-			TestUnacquiredEpoch(sweep, epochChannel)
+			TestUnacquiredEpoch(sweepChannel, epochChannel)
 
 			TestNaming(epochChannel)
 
-			TestTrigonometricEpochs(sweep, epochChannel, sweepChannel)
+			TestTrigonometricEpochs(epochChannel, sweepChannel)
 
 			chanMarker[channelNumber][channelType] = 1
 		endfor
@@ -485,7 +488,7 @@ static Function TestNaming(WAVE/T epochChannel)
 	CHECK_EQUAL_WAVES(shortnames, uniqueShortNames)
 End
 
-static Function TestTrigonometricEpochs(WAVE sweep, WAVE/T epochChannel, WAVE DAchannel)
+static Function TestTrigonometricEpochs(WAVE/T epochChannel, WAVE DAchannel)
 	variable numRows, i, num, epochBegin, epochEnd
 	string shortname, epochType, levelTwoType, levelTwoNumber, levelThreeType, levelThreeNumber, refEpochType
 

--- a/Packages/tests/HardwareBasic/UTF_Epochs.ipf
+++ b/Packages/tests/HardwareBasic/UTF_Epochs.ipf
@@ -340,7 +340,7 @@ static Function TestEpochsGeneric(string device)
 	WAVE   numericalValues = GetLBNumericalValues(device)
 
 	DFREF dfr = UniqueDataFolder(GetDataFolderDFR(), "epochTestSweepChannels")
-	SplitAndUpgradeSweep(numericalValues, sweepNo, sweep, config, TTL_RESCALE_ON, targetDFR = dfr)
+	SplitAndUpgradeSweep(numericalValues, sweepNo, sweep, config, TTL_RESCALE_ON, 1, targetDFR = dfr)
 
 	// basic check of internal epoch wave
 	WAVE/T epochs = GetEpochsWave(device)

--- a/Packages/tests/HardwareBasic/UTF_TestPulseAndTPDuringDAQ.ipf
+++ b/Packages/tests/HardwareBasic/UTF_TestPulseAndTPDuringDAQ.ipf
@@ -583,15 +583,16 @@ static Function TPDuringDAQOnlyTP_REENTRY([str])
 	CHECK_EQUAL_VAR(sweepNo, 0)
 
 	WAVE/Z sweepWave = GetSweepWave(str, 0)
-	CHECK_WAVE(sweepWave, NORMAL_WAVE)
-
-	CHECK_EQUAL_VAR(GetMinSamplingInterval(unit = "ms"), DimDelta(sweepWave, ROWS))
-	CHECK_EQUAL_VAR(DimSize(sweepWave, ROWS) * DimDelta(sweepWave, ROWS) / 1000, TIME_TP_ONLY_ON_DAQ)
+	CHECK_WAVE(sweepWave, TEXT_WAVE)
 
 	WAVE/Z configWave = GetConfigWave(sweepWave)
-	CHECK_WAVE(configWave, NORMAL_WAVE)
+	CHECK_WAVE(configWave, NUMERIC_WAVE)
 	CHECK_EQUAL_VAR(DimSize(configWave, ROWS), 2)
 	CHECK_EQUAL_VAR(DimSize(configWave, COLS), 8)
+
+	WAVE channelAD = ResolveSweepChannel(sweepWave, GetFirstADCChannelIndex(configWave))
+	CHECK_EQUAL_VAR(GetMinSamplingInterval(unit = "ms"), DimDelta(channelAD, ROWS))
+	CHECK_EQUAL_VAR(DimSize(channelAD, ROWS) * DimDelta(channelAD, ROWS) / 1000, TIME_TP_ONLY_ON_DAQ)
 
 	col = FindDimLabel(configWave, COLS, "DAQChannelType")
 	Duplicate/FREE/R=[][col] configWave, channelTypes
@@ -666,16 +667,17 @@ static Function TPDuringDAQTPAndUnAssoc_REENTRY([str])
 	CHECK_EQUAL_VAR(sweepNo, 0)
 
 	WAVE/Z sweepWave = GetSweepWave(str, 0)
-	CHECK_WAVE(sweepWave, NORMAL_WAVE)
-
-	CHECK_EQUAL_VAR(2 * GetMinSamplingInterval(unit = "ms"), DimDelta(sweepWave, ROWS))
-	stimSetLengthRef = 0.958336 // length of StimulusSetA_DA_0
-	CHECK_CLOSE_VAR(DimSize(sweepWave, ROWS) * DimDelta(sweepWave, ROWS) / 1000, stimSetLengthRef, tol = 1E-3)
+	CHECK_WAVE(sweepWave, TEXT_WAVE)
 
 	WAVE/Z configWave = GetConfigWave(sweepWave)
-	CHECK_WAVE(configWave, NORMAL_WAVE)
+	CHECK_WAVE(configWave, NUMERIC_WAVE)
 	CHECK_EQUAL_VAR(DimSize(configWave, ROWS), 4)
 	CHECK_EQUAL_VAR(DimSize(configWave, COLS), 8)
+
+	WAVE channelAD = ResolveSweepChannel(sweepWave, GetFirstADCChannelIndex(configWave))
+	CHECK_EQUAL_VAR(2 * GetMinSamplingInterval(unit = "ms"), DimDelta(channelAD, ROWS))
+	stimSetLengthRef = 0.958336 // length of StimulusSetA_DA_0
+	CHECK_CLOSE_VAR(DimSize(channelAD, ROWS) * DimDelta(channelAD, ROWS) / 1000, stimSetLengthRef, tol = 1E-3)
 
 	col = FindDimLabel(configWave, COLS, "DAQChannelType")
 	Duplicate/FREE/R=[][col] configWave, channelTypes
@@ -749,14 +751,15 @@ static Function TPDuringDAQ_REENTRY([str])
 	CHECK_EQUAL_VAR(sweepNo, 0)
 
 	WAVE/Z sweepWave = GetSweepWave(str, 0)
-	CHECK_WAVE(sweepWave, NORMAL_WAVE)
-
-	CHECK_EQUAL_VAR(2 * GetMinSamplingInterval(unit = "ms"), DimDelta(sweepWave, ROWS))
+	CHECK_WAVE(sweepWave, TEXT_WAVE)
 
 	WAVE/Z configWave = GetConfigWave(sweepWave)
-	CHECK_WAVE(configWave, NORMAL_WAVE)
+	CHECK_WAVE(configWave, NUMERIC_WAVE)
 	CHECK_EQUAL_VAR(DimSize(configWave, ROWS), 4)
 	CHECK_EQUAL_VAR(DimSize(configWave, COLS), 8)
+
+	WAVE channelAD = ResolveSweepChannel(sweepWave, GetFirstADCChannelIndex(configWave))
+	CHECK_EQUAL_VAR(2 * GetMinSamplingInterval(unit = "ms"), DimDelta(channelAD, ROWS))
 
 	col = FindDimLabel(configWave, COLS, "DAQChannelType")
 	Duplicate/FREE/R=[][col] configWave, channelTypes

--- a/Packages/tests/HistoricData/UTF_HistoricData.ipf
+++ b/Packages/tests/HistoricData/UTF_HistoricData.ipf
@@ -21,6 +21,7 @@ static StrConstant HTTP_FOLDER_URL = "https://www.byte-physics.de/Downloads/alle
 // keep sorted
 #include "UTF_HistoricDashboard"
 #include "UTF_HistoricEpochClipping"
+#include "UTF_HistoricSweepUpgrade"
 
 // Entry point for UTF
 Function run()
@@ -84,6 +85,7 @@ Function RunWithOpts([string testcase, string testsuite, variable allowdebug, va
 	// sorted list
 	list = AddListItem("UTF_HistoricDashboard.ipf", list, ";", inf)
 	list = AddListItem("UTF_HistoricEpochClipping.ipf", list, ";", inf)
+	list = AddListItem("UTF_HistoricSweepUpgrade.ipf", list, ";", inf)
 
 	if(ParamIsDefault(testsuite))
 		testsuite = list
@@ -172,17 +174,10 @@ Function DecompressFile(string file)
 	ASSERT(!V_flag, "Decompression error: " + S_Value)
 End
 
-Function/WAVE GetHistoricDataFiles()
+static Function DownloadFilesIfRequired(WAVE/T files)
 
-	string path, fullFilePath, compFile, file
-	variable i, numFiles, size, refSize
-
-	Make/FREE/T files = {"C57BL6J-629713.05.01.02.pxp",                       \
-	                     "Chat-IRES-Cre-neo;Ai14-582723.15.10.01.pxp",        \
-	                     "Pvalb-IRES-Cre;Ai14-646904.13.03.02.pxp",           \
-	                     "Sst-IRES-Cre;Ai14-554002.08.06.02.pxp",             \
-	                     "Sst-IRES-Cre;Th-P2A-FlpO;Ai65-561491.09.09.02.pxp", \
-	                     "epoch_clipping_2022_03_08_140256.pxp"}
+	string path, fullFilePath, file
+	variable i, numFiles
 
 	/// @TODO use hashes to verify files once IP supports strings > 2GB
 
@@ -199,11 +194,37 @@ Function/WAVE GetHistoricDataFiles()
 
 		DownloadFile(file)
 	endfor
+End
+
+static Function SetLabelsForDGWave(WAVE/T files)
 
 	Duplicate/FREE/T files, labels
 	labels[] = CleanUpName(labels[p], 0)
 
 	SetDimensionLabels(files, TextWaveToList(labels, ";"), ROWS)
+End
+
+Function/WAVE GetHistoricDataFiles()
+
+	Make/FREE/T files = {"C57BL6J-629713.05.01.02.pxp",                       \
+								"Chat-IRES-Cre-neo;Ai14-582723.15.10.01.pxp",        \
+								"Pvalb-IRES-Cre;Ai14-646904.13.03.02.pxp",           \
+								"Sst-IRES-Cre;Ai14-554002.08.06.02.pxp",             \
+								"Sst-IRES-Cre;Th-P2A-FlpO;Ai65-561491.09.09.02.pxp", \
+								"epoch_clipping_2022_03_08_140256.pxp"}
+
+	DownloadFilesIfRequired(files)
+	SetLabelsForDGWave(files)
+
+	return files
+End
+
+Function/WAVE GetHistoricDataFilesSweepUpgrade()
+
+	Make/FREE/T files = {"single_numeric_sweep.pxp"}
+
+	DownloadFilesIfRequired(files)
+	SetLabelsForDGWave(files)
 
 	return files
 End

--- a/Packages/tests/HistoricData/UTF_HistoricSweepUpgrade.ipf
+++ b/Packages/tests/HistoricData/UTF_HistoricSweepUpgrade.ipf
@@ -1,0 +1,55 @@
+#pragma TextEncoding = "UTF-8"
+#pragma rtGlobals=3 // Use modern global access method and strict wave access.
+#pragma rtFunctionErrors=1
+#pragma ModuleName=HistoricSweepUpgrade
+
+/// UTF_TD_GENERATOR GetHistoricDataFilesSweepUpgrade
+static Function TestSweepUpgrade([string str])
+
+	string abWin, sweepBrowsers, file, bsPanel, sbWin, dataFolder, device, preUpgradeName
+	variable sweepNo = 0
+	variable channelSize = 507778
+
+	file = "input:" + str
+
+	[abWin, sweepBrowsers] = OpenAnalysisBrowser({file}, loadSweeps = 1)
+	sbWin = StringFromList(0, sweepBrowsers)
+	CHECK_PROPER_STR(sbWin)
+	bsPanel = BSP_GetPanel(sbWin)
+
+	DFREF sweepBrowserDFR = SB_GetSweepBrowserFolder(sbWin)
+	WAVE/T sweepMap = GetSweepBrowserMap(sweepBrowserDFR)
+	dataFolder = sweepMap[0][%DataFolder]
+	device     = sweepMap[0][%Device]
+	DFREF sweepDFR  = GetAnalysisSweepPath(dataFolder, device)
+
+	WAVE/Z/SDFR=sweepDFR sweep = $GetSweepWaveName(sweepNo)
+	Make/FREE/T sweepRef = {"X_0:DA_0", "X_0:AD_0"}
+	CHECK_EQUAL_WAVES(sweepRef, sweep, mode=WAVE_DATA)
+
+	Make/FREE/T sweepBakRef = {"X_0:DA_0" + WAVE_BACKUP_SUFFIX, "X_0:AD_0" + WAVE_BACKUP_SUFFIX}
+	WAVE/Z/T sweepBak = MIES_MIESUTILS#GetBackupWave_TS(sweep)
+	CHECK_EQUAL_WAVES(sweepBakRef, sweepBak, mode=WAVE_DATA)
+
+	WAVE/Z channel0 = ResolveSweepChannel(sweep, 0, allowFail=1)
+	CHECK_WAVE(channel0, NUMERIC_WAVE)
+	CHECK_EQUAL_VAR(channelSize, DimSize(channel0, ROWS))
+	WAVE/Z channel1 = ResolveSweepChannel(sweep, 1, allowFail=1)
+	CHECK_WAVE(channel1, NUMERIC_WAVE)
+	CHECK_EQUAL_VAR(channelSize, DimSize(channel1, ROWS))
+
+	WAVE/Z channelB0 = ResolveSweepChannel(sweepBak, 0, allowFail=1)
+	WAVE/Z channelB1 = ResolveSweepChannel(sweepBak, 1, allowFail=1)
+	CHECK_EQUAL_WAVES(channel0, channelB0)
+	CHECK_EQUAL_WAVES(channel1, channelB1)
+
+	preUpgradeName = GetSweepWaveName(sweepNo) + "_preUpgrade"
+	WAVE/Z/SDFR=sweepDFR sweepPre = $preUpgradeName
+	CHECK_WAVE(sweepPre, NUMERIC_WAVE)
+	CHECK_EQUAL_VAR(channelSize, DimSize(sweepPre, ROWS))
+	CHECK_EQUAL_VAR(2, DimSize(sweepPre, COLS))
+
+	DFREF dfr0 = sweepDFR:X_0
+	SVAR/Z/SDFR=dfr0 noteStr = note
+	CHECK_EQUAL_VAR(SVAR_Exists(noteStr), 1)
+End

--- a/Packages/tests/UTF_HardwareHelperFunctions.ipf
+++ b/Packages/tests/UTF_HardwareHelperFunctions.ipf
@@ -885,7 +885,7 @@ static Function TestSweepReconstruction_IGNORE(string device)
 
 		DFREF singleSweepDFR = GetSingleSweepFolder(deviceDataBorkedUp, sweepNo)
 
-		SplitAndUpgradeSweep(numericalValues, sweepNo, sweepWave, configWave, TTL_RESCALE_OFF, targetDFR=singleSweepDFR)
+		SplitAndUpgradeSweep(numericalValues, sweepNo, sweepWave, configWave, TTL_RESCALE_OFF, 1, targetDFR=singleSweepDFR)
 	endfor
 
 	// delete sweep and config waves

--- a/Packages/tests/UTF_HardwareHelperFunctions.ipf
+++ b/Packages/tests/UTF_HardwareHelperFunctions.ipf
@@ -1644,10 +1644,17 @@ End
 
 Function StartFakeThreadMonitor_IGNORE(string device, variable fixedFifoPos)
 
-	variable deviceID
+	variable deviceID, i, numChannels, fifoPosLatest
 
 	deviceID = ROVar(GetDAQDeviceID(device))
+	NVAR tgID = $GetThreadGroupIDFifo(device)
+	fifoPosLatest = TS_GetNewestFromThreadQueue(tgID, "fifoPos")
 	TFH_StopFifoDaemon(HARDWARE_ITC_DAC, deviceID)
+
+	if(IsFinite(fifoPosLatest) && fixedFifoPos > 0)
+		fixedFifoPos = fifoPosLatest
+	endif
+
 	NVAR tgID = $GetThreadGroupIDFifo(device)
 	tgID = ThreadGroupCreate(1)
 
@@ -1705,7 +1712,7 @@ Function UseFakeFIFOThreadBeingStuck_IGNORE(s)
 	fifoPos = ROVar(GetFifoPosition(device))
 
 	if(IsFinite(dataAcqRunMode) && dataAcqRunMode != DAQ_NOT_RUNNING && fifoPos > 10000)
-		StartFakeThreadMonitor_IGNORE(device, 12345)
+		StartFakeThreadMonitor_IGNORE(device, fifoPos)
 
 		return 1
 	endif

--- a/Packages/tests/UTF_HardwareHelperFunctions.ipf
+++ b/Packages/tests/UTF_HardwareHelperFunctions.ipf
@@ -885,7 +885,7 @@ static Function TestSweepReconstruction_IGNORE(string device)
 
 		DFREF singleSweepDFR = GetSingleSweepFolder(deviceDataBorkedUp, sweepNo)
 
-		SplitSweepIntoComponents(numericalValues, sweepNo, sweepWave, configWave, TTL_RESCALE_OFF, targetDFR=singleSweepDFR)
+		SplitAndUpgradeSweep(numericalValues, sweepNo, sweepWave, configWave, TTL_RESCALE_OFF, targetDFR=singleSweepDFR)
 	endfor
 
 	// delete 2D sweep and config waves

--- a/Packages/tests/UTF_HelperFunctions.ipf
+++ b/Packages/tests/UTF_HelperFunctions.ipf
@@ -537,7 +537,7 @@ Function/WAVE FakeSweepDataGeneratorDefault(WAVE sweep, variable numChannels)
 	return sweep
 End
 
-Function CreateFakeSweepData(string win, string device, [variable sweepNo, FUNCREF FakeSweepDataGeneratorProto sweepGen])
+Function/S CreateFakeSweepData(string win, string device, [variable sweepNo, FUNCREF FakeSweepDataGeneratorProto sweepGen])
 
 	string list, key, keyTxt
 	variable numChannels, hwType
@@ -606,7 +606,7 @@ Function CreateFakeSweepData(string win, string device, [variable sweepNo, FUNCR
 		default:
 			INFO("Unsupported sweep number in test setup")
 			FAIL()
-			return NaN
+			return ""
 	endswitch
 
 	DFREF dfr = GetDeviceDataPath(device)
@@ -615,12 +615,14 @@ Function CreateFakeSweepData(string win, string device, [variable sweepNo, FUNCR
 
 	PGC_SetAndActivateControl(BSP_GetPanel(win), "popup_DB_lockedDevices", str = device)
 	win = GetCurrentWindow()
-	MIES_DB#DB_SplitSweepsIfReq(win, sweepNo)
+	REQUIRE_EQUAL_VAR(MIES_DB#DB_SplitSweepsIfReq(win, sweepNo), 0)
 
 	list = GetAllDevicesWithContent()
 	list = RemoveEnding(list, ";")
 	CHECK_EQUAL_VAR(ItemsInList(list), 1)
 	CHECK_EQUAL_STR(list, device)
+
+	return win
 End
 
 Function/S GetDataBrowserWithData()

--- a/Packages/tests/UTF_HelperFunctions.ipf
+++ b/Packages/tests/UTF_HelperFunctions.ipf
@@ -993,3 +993,9 @@ Function GetWaveTrackingMode()
 
 	return UTF_WAVE_TRACKING_NONE
 End
+
+Function ResetOverrideResults()
+
+	KillOrMoveToTrash(wv=root:overrideResults)
+	Make/N=0 root:overrideResults
+End

--- a/Packages/tests/UTF_HelperFunctions.ipf
+++ b/Packages/tests/UTF_HelperFunctions.ipf
@@ -551,6 +551,7 @@ Function CreateFakeSweepData(string win, string device, [variable sweepNo, FUNCR
 
 	[key, keyTxt] = PrepareLBN_IGNORE(device)
 
+	// Use old 2D data format as sweep template and rely on sweep splitting for upconversion
 	WAVE sweepTemplate = GetDAQDataWave(device, DATA_ACQUISITION_MODE)
 	WAVE config = GetDAQConfigWave(device)
 	hwType = GetHardwareType(device)
@@ -611,6 +612,9 @@ Function CreateFakeSweepData(string win, string device, [variable sweepNo, FUNCR
 	DFREF dfr = GetDeviceDataPath(device)
 	MoveWave sweep, dfr:$GetSweepWaveName(sweepNo)
 	MoveWave config, dfr:$GetConfigWaveName(sweepNo)
+
+	PGC_SetAndActivateControl(BSP_GetPanel(win), "popup_DB_lockedDevices", str = device)
+	win = GetCurrentWindow()
 	MIES_DB#DB_SplitSweepsIfReq(win, sweepNo)
 
 	list = GetAllDevicesWithContent()
@@ -626,7 +630,6 @@ Function/S GetDataBrowserWithData()
 
 	win = DB_OpenDataBrowser()
 	CreateFakeSweepData(win, device)
-	PGC_SetAndActivateControl(BSP_GetPanel(win), "popup_DB_lockedDevices", str = device)
 	win = GetCurrentWindow()
 
 	result = BSP_GetDevice(win)

--- a/Packages/tests/UTF_TestNWBExportV1.ipf
+++ b/Packages/tests/UTF_TestNWBExportV1.ipf
@@ -526,7 +526,7 @@ static Function/DF TestSweepData(entry, device, sweep)
 	CHECK_WAVE(sweepWave, NORMAL_WAVE)
 
 	DFREF pxpSweepsDFR = UniqueDataFolder(GetDataFolderDFR(), "pxpSweeps")
-	SplitAndUpgradeSweep(numericalValues, sweep, sweepWave, configWave, TTL_RESCALE_OFF, targetDFR=pxpSweepsDFR)
+	SplitAndUpgradeSweep(numericalValues, sweep, sweepWave, configWave, TTL_RESCALE_OFF, 1, targetDFR=pxpSweepsDFR)
 
 	nwbSweeps = SortList(GetListOfObjects(nwbSweepsDFR, ".*"))
 	pxpSweeps = SortList(GetListOfObjects(pxpSweepsDFR, ".*"))

--- a/Packages/tests/UTF_TestNWBExportV1.ipf
+++ b/Packages/tests/UTF_TestNWBExportV1.ipf
@@ -526,7 +526,7 @@ static Function/DF TestSweepData(entry, device, sweep)
 	CHECK_WAVE(sweepWave, NORMAL_WAVE)
 
 	DFREF pxpSweepsDFR = UniqueDataFolder(GetDataFolderDFR(), "pxpSweeps")
-	SplitSweepIntoComponents(numericalValues, sweep, sweepWave, configWave, TTL_RESCALE_OFF, targetDFR=pxpSweepsDFR)
+	SplitAndUpgradeSweep(numericalValues, sweep, sweepWave, configWave, TTL_RESCALE_OFF, targetDFR=pxpSweepsDFR)
 
 	nwbSweeps = SortList(GetListOfObjects(nwbSweepsDFR, ".*"))
 	pxpSweeps = SortList(GetListOfObjects(pxpSweepsDFR, ".*"))

--- a/Packages/tests/UTF_TestNWBExportV2.ipf
+++ b/Packages/tests/UTF_TestNWBExportV2.ipf
@@ -577,7 +577,7 @@ static Function/DF TestSweepData(entry, device, sweep)
 	CHECK_WAVE(sweepWave, NORMAL_WAVE)
 
 	DFREF pxpSweepsDFR = UniqueDataFolder(GetDataFolderDFR(), "pxpSweeps")
-	SplitSweepIntoComponents(numericalValues, sweep, sweepWave, configWave, TTL_RESCALE_OFF, targetDFR=pxpSweepsDFR)
+	SplitAndUpgradeSweep(numericalValues, sweep, sweepWave, configWave, TTL_RESCALE_OFF, targetDFR=pxpSweepsDFR)
 
 	nwbSweeps = SortList(GetListOfObjects(nwbSweepsDFR, ".*"))
 	pxpSweeps = SortList(GetListOfObjects(pxpSweepsDFR, ".*"))

--- a/Packages/tests/UTF_TestNWBExportV2.ipf
+++ b/Packages/tests/UTF_TestNWBExportV2.ipf
@@ -577,7 +577,7 @@ static Function/DF TestSweepData(entry, device, sweep)
 	CHECK_WAVE(sweepWave, NORMAL_WAVE)
 
 	DFREF pxpSweepsDFR = UniqueDataFolder(GetDataFolderDFR(), "pxpSweeps")
-	SplitAndUpgradeSweep(numericalValues, sweep, sweepWave, configWave, TTL_RESCALE_OFF, targetDFR=pxpSweepsDFR)
+	SplitAndUpgradeSweep(numericalValues, sweep, sweepWave, configWave, TTL_RESCALE_OFF, 1, targetDFR=pxpSweepsDFR)
 
 	nwbSweeps = SortList(GetListOfObjects(nwbSweepsDFR, ".*"))
 	pxpSweeps = SortList(GetListOfObjects(pxpSweepsDFR, ".*"))


### PR DESCRIPTION
The is a part of #1667 that includes hardware independent changes required for proper sutter hardware support.

Main changes:
- support for different sample rates per channel
- a related change is that the storage format for sweep data in MIES is changed
- implications on measurement setup, helper wave during measurement, analysisfunctions etc.
- adapted tests

close https://github.com/AllenInstitute/MIES/issues/1954