### PR TITLE
LOG_AddEntry: Readd timestamp

### DIFF
--- a/Packages/MIES/MIES_Logging.ipf
+++ b/Packages/MIES/MIES_Logging.ipf
@@ -143,6 +143,7 @@ threadsafe Function LOG_AddEntry(string package, string action, [variable stackt
 	caller = GetRTStackInfo(2)
 	JSONid = LOG_GenerateEntryTemplate(caller)
 	JSON_AddString(JSONid, "/action", action)
+	JSON_AddString(JSONid, "/ts", GetISO8601TimeStamp(numFracSecondsDigits = 3, localTimeZone = 1))
 
 	if(numAdditionalEntries > 0)
 		Make/FREE/N=(numAdditionalEntries) indexHelper = JSON_AddString(JSONid, "/" + keys[p], values[p])


### PR DESCRIPTION
The template function LOG_GenerateEntryTemplate had its ts object with the timestamp removed in 2fab915a (LOG_GenerateEntryTemplate: Remove ts object, 2023-05-24). The idea was the don't want to have the timestamp in the template for the log writters in the ITCXOP and the ZeroMQ XOP.

But we forgot that we also use that function via LOG_AddEntry and this needs have a timestamp.

So let's add it back here.
