### PR TITLE
[Backport] LOG_AddEntry: Readd timestamp

### DIFF
--- a/Packages/MIES/MIES_Logging.ipf
+++ b/Packages/MIES/MIES_Logging.ipf
@@ -143,6 +143,7 @@ threadsafe Function LOG_AddEntry(string package, string action, [variable stackt
 	caller = GetRTStackInfo(2)
 	JSONid = LOG_GenerateEntryTemplate(caller)
 	JSON_AddString(JSONid, "/action", action)
+	JSON_AddString(JSONid, "/ts", GetISO8601TimeStamp(numFracSecondsDigits = 3, localTimeZone = 1))
 
 	if(numAdditionalEntries > 0)
 		Make/FREE/N=(numAdditionalEntries) indexHelper = JSON_AddString(JSONid, "/" + keys[p], values[p])

--- a/Packages/tests/Basic/UTF_Utils.ipf
+++ b/Packages/tests/Basic/UTF_Utils.ipf
@@ -7327,3 +7327,41 @@ static Function TestFindRightMostHighBit()
 	CHECK_EQUAL_VAR(FindRightMostHighBit(3), 0)
 	CHECK_EQUAL_VAR(FindRightMostHighBit(18), 1)
 End
+
+static Function CheckLogFiles()
+
+	// ensure that the ZeroMQ logfile exists as well
+	PrepareForPublishTest()
+
+	string file
+	variable foundFiles, jsonID
+
+	WAVE/T filesAndOther = GetLogFileNames()
+	Duplicate/RMD=[][0]/FREE/T filesAndOther, files
+
+	for(file : files)
+		if(!FileExists(file))
+			continue
+		endif
+
+		WAVE/T contents = LoadTextFileToWave(file, "\n")
+		CHECK_WAVE(contents, TEXT_WAVE)
+		CHECK_GT_VAR(DimSize(contents, ROWS), 0)
+
+		if(!cmpstr(contents[0], "{}"))
+			continue
+		endif
+
+		jsonID = JSON_Parse(contents[0])
+		CHECK(JSON_IsValid(jsonID))
+
+		CHECK(MIES_LOG#LOG_HasRequiredKeys(jsonID))
+		WAVE/T keys = JSON_GetKeys(jsonID, "")
+		FindValue/TEXT="ts" keys
+		CHECK_GE_VAR(V_Value, 0)
+
+		foundFiles += 1
+	endfor
+
+	CHECK_GT_VAR(foundFiles, 0)
+End


### PR DESCRIPTION
The template function LOG_GenerateEntryTemplate had its ts object with the timestamp removed in 2fab915a (LOG_GenerateEntryTemplate: Remove ts object, 2023-05-24). The idea was the don't want to have the timestamp in the template for the log writters in the ITCXOP and the ZeroMQ XOP.

But we forgot that we also use that function via LOG_AddEntry and this needs have a timestamp.

So let's add it back here.
