### PR TITLE
.github/workflows: Move to v4 for upload-artifacts

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -151,7 +151,7 @@ jobs:
       job_name: 🧪 Test ${{ matrix.name }}
       overwrite_job_name: ${{ inputs.is_called_workflow || false }}
       experiment: ${{ matrix.experiment }}
-      artifact_name: test-without-hw-assets
+      artifact_name: TestWithoutHardware-${{ matrix.name }}-assets
       expensive_checks: "1"
       instrument_tests: ${{ fromJson('["0", "1"]')[inputs.do_instrumentation] }}
       timeout_minutes: 60
@@ -175,7 +175,7 @@ jobs:
       overwrite_job_name: ${{ inputs.is_called_workflow || false }}
       experiment: ${{ matrix.experiment }}
       target: "[ 'self-hosted', 'Windows', 'IgorPro', 'NI' ]"
-      artifact_name: test-ni-assets
+      artifact_name: TestNI-${{ matrix.name }}-assets
       expensive_checks: "1"
       instrument_tests: ${{ fromJson('["0", "1"]')[inputs.do_instrumentation] }}
       timeout_minutes: 180
@@ -199,7 +199,7 @@ jobs:
       overwrite_job_name: ${{ inputs.is_called_workflow || false }}
       experiment: ${{ matrix.experiment }}
       target: "[ 'self-hosted', 'Windows', 'IgorPro', 'ITC' ]"
-      artifact_name: test-itc18-assets
+      artifact_name: TestITC18-${{ matrix.name }}-assets
       expensive_checks: "1"
       instrument_tests: ${{ fromJson('["0", "1"]')[inputs.do_instrumentation] }}
       timeout_minutes: 180
@@ -223,7 +223,7 @@ jobs:
       overwrite_job_name: ${{ inputs.is_called_workflow || false }}
       experiment: ${{ matrix.experiment }}
       target: "[ 'self-hosted', 'Windows', 'IgorPro', 'ITC1600' ]"
-      artifact_name: test-itc1600-assets
+      artifact_name: TestITC1600-${{ matrix.name }}-assets
       expensive_checks: "1"
       instrument_tests: ${{ fromJson('["0", "1"]')[inputs.do_instrumentation] }}
       timeout_minutes: 180
@@ -245,15 +245,15 @@ jobs:
       - name: Download ITC18-USB artifacts
         uses: actions/download-artifact@v4
         with:
-          name: test-itc18-assets
+          pattern: TestITC18-*
       - name: Download ITC1600 artifacts
         uses: actions/download-artifact@v4
         with:
-          name: test-itc1600-assets
+          pattern: TestITC1600-*
       - name: Download NI artifacts
         uses: actions/download-artifact@v4
         with:
-          name: test-ni-assets
+          pattern: TestNI-*
       - name: Validate and read NWBv2 files
         run: tools/nwb-read-tests/run.sh
 

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -285,17 +285,7 @@ jobs:
           find "${{ steps.download.outputs.download-path }}" -mindepth 1 -maxdepth 1 -type d |\
             xargs -I {} tools/ftp-upload/flatten-files.sh "{}"
       - name: Compress NWB artifacts
-        run: |
-          for dir in test-itc18-assets test-itc1600-assets test-ni-assets
-          do
-            if [ -n "$(find "$dir" -maxdepth 0 -type d -empty)" ]
-            then
-              continue
-            fi
-
-            tar --remove-files --use-compress-program=zstd -cvf $dir/NWB.tar.zst $dir/*nwb
-          done
-        working-directory: ${{ steps.download.outputs.download-path }}
+        run: tools/ftp-upload/compress-nwb-files.sh "${{ steps.download.outputs.download-path }}"
       - name: Upload artifacts using FTP
         run: |
           tools/ftp-upload/upload-files.sh \

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Sign installer
         run: tools/sign-installer.sh -p "${{ secrets.GHA_MIES_CERTIFICATE_PIN }}"
       - name: upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: BuildInstaller-${{ matrix.kind }}-assets
@@ -123,7 +123,7 @@ jobs:
       - name: Build documentation
         run: tools/documentation/run.sh
       - name: upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: Documentation-assets
@@ -243,15 +243,15 @@ jobs:
       - name: Initial repo config
         run: tools/initial-repo-config.sh
       - name: Download ITC18-USB artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: test-itc18-assets
       - name: Download ITC1600 artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: test-itc1600-assets
       - name: Download NI artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: test-ni-assets
       - name: Validate and read NWBv2 files
@@ -277,7 +277,7 @@ jobs:
         run: tools/initial-repo-config.sh
       - name: Download all artifacts
         id: download
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
       - name: Flatten artifact structure

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Initial repo config
         run: tools/initial-repo-config.sh
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Documentation-assets
       - name: Deploy documentation to github pages
@@ -55,7 +55,7 @@ jobs:
       - name: Initial repo config
         run: tools/initial-repo-config.sh
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: BuildInstaller-user-assets
       - name: Deploy release assets to github
@@ -74,7 +74,7 @@ jobs:
         run: tools/initial-repo-config.sh
       - name: Download all artifacts
         id: download
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
       - name: 📥 Download report cache from FTP
@@ -112,7 +112,7 @@ jobs:
             -d "${{ steps.gen.outputs.history }}" \
             -t "cache/coverage-history"
       - name: upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: report-artifacts
@@ -135,7 +135,7 @@ jobs:
         run: tools/initial-repo-config.sh
       - name: Download all artifacts
         id: download
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
       - name: Flatten artifact structure

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -143,17 +143,7 @@ jobs:
           find "${{ steps.download.outputs.download-path }}" -mindepth 1 -maxdepth 1 -type d |\
             xargs -I {} tools/ftp-upload/flatten-files.sh "{}"
       - name: Compress NWB artifacts
-        run: |
-          for dir in test-itc18-assets test-itc1600-assets test-ni-assets
-          do
-            if [ -n "$(find "$dir" -maxdepth 0 -type d -empty)" ]
-            then
-              continue
-            fi
-
-            tar --remove-files --use-compress-program=zstd -cvf $dir/NWB.tar.zst $dir/*nwb
-          done
-        working-directory: ${{ steps.download.outputs.download-path }}
+        run: tools/ftp-upload/compress-nwb-files.sh "${{ steps.download.outputs.download-path }}"
       - name: Upload artifacts using FTP
         run: |
           tools/ftp-upload/upload-files.sh \

--- a/.github/workflows/test-igor-workflow.yml
+++ b/.github/workflows/test-igor-workflow.yml
@@ -77,7 +77,7 @@ jobs:
         run: tools/initial-repo-config.sh
       - name: Download artifacts
         if: inputs.installer_artifact_name != ''
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         continue-on-error: false
         with:
           name: ${{ inputs.installer_artifact_name }}
@@ -89,7 +89,7 @@ jobs:
         if: always()
         run: tools/gather-logfiles-and-crashdumps.sh
       - name: upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: ${{ inputs.artifact_name }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,9 +9,9 @@ exclude: |
            ^tools/installer/AccessControl|
            # patch and svg files always have trailing whitespace
            .*patch$|
-           .*svg$
+           .*svg$|
            # don't touch MacOSX XOPs
-           ^XOPs-MacOSX-IP9-64bit|
+           ^XOPs-MacOSX-IP9-64bit
          ) # end alternations
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/tools/ftp-upload/compress-nwb-files.sh
+++ b/tools/ftp-upload/compress-nwb-files.sh
@@ -2,9 +2,12 @@
 
 cd $1
 
-for dir in test-itc18-assets test-itc1600-assets test-ni-assets
+for dir in TestNI-* TestITC18-* TestITC1600-*
 do
-  if [ -n "$(find "$dir" -maxdepth 0 -type d -empty)" ]
+  if [ ! -d $dir ]
+  then
+    continue
+  elif [ -n "$(find "$dir" -maxdepth 0 -type d -empty)" ]
   then
     continue
   fi

--- a/tools/ftp-upload/compress-nwb-files.sh
+++ b/tools/ftp-upload/compress-nwb-files.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+cd $1
+
+for dir in test-itc18-assets test-itc1600-assets test-ni-assets
+do
+  if [ -n "$(find "$dir" -maxdepth 0 -type d -empty)" ]
+  then
+    continue
+  fi
+
+  tar --remove-files --use-compress-program=zstd -cvf $dir/NWB.tar.zst $dir/*nwb
+done


### PR DESCRIPTION
- [x] Check FTP upload location that all NWB binaries are uploaded and compressed

This finally supports download artifacts before the workflow finishes [1].

[1]: https://github.com/actions/toolkit/tree/main/packages/artifact#v2---whats-new