### PR TITLE
Tests/CheckLogFiles: Fix the test

### DIFF
--- a/Packages/tests/UTF_HelperFunctions.ipf
+++ b/Packages/tests/UTF_HelperFunctions.ipf
@@ -179,6 +179,8 @@ End
 
 Function PrepareForPublishTest()
 
+	UpdateXOPLoggingTemplate()
+
 	variable numTrials = StartZeroMQSockets(forceRestart = 1)
 	REQUIRE_EQUAL_VAR(numTrials, 0)
 


### PR DESCRIPTION
We should only ignore the lines with {}. And only if we only have these lines can we skip the file.

Added also two more info calls for better debugging.

Bug introduced in ed8a41dc (LOG_AddEntry: Readd timestamp, 2023-12-11).

Close #1970 
