### PR TITLE
Tests: Call zeromq_stop after the complete test run

### DIFF
--- a/Packages/tests/Basic/UTF_Basic.ipf
+++ b/Packages/tests/Basic/UTF_Basic.ipf
@@ -141,6 +141,10 @@ Function TEST_BEGIN_OVERRIDE(string name)
 	TestBeginCommon()
 End
 
+Function TEST_END_OVERRIDE(string name)
+	TestEndCommon()
+End
+
 Function TEST_CASE_BEGIN_OVERRIDE(name)
 	string name
 

--- a/Packages/tests/HistoricData/UTF_HistoricData.ipf
+++ b/Packages/tests/HistoricData/UTF_HistoricData.ipf
@@ -104,6 +104,10 @@ Function TEST_BEGIN_OVERRIDE(string name)
 	TestBeginCommon()
 End
 
+Function TEST_END_OVERRIDE(string name)
+	TestEndCommon()
+End
+
 Function TEST_CASE_BEGIN_OVERRIDE(name)
 	string name
 

--- a/Packages/tests/PAPlot/UTF_PA_Tests.ipf
+++ b/Packages/tests/PAPlot/UTF_PA_Tests.ipf
@@ -423,6 +423,10 @@ static Function TEST_BEGIN_OVERRIDE(string name)
 	TestBeginCommon()
 End
 
+static Function TEST_END_OVERRIDE(string name)
+	TestEndCommon()
+End
+
 static Function TEST_CASE_END_OVERRIDE(string testcase)
 	CheckForBugMessages()
 

--- a/Packages/tests/UTF_HardwareHelperFunctions.ipf
+++ b/Packages/tests/UTF_HardwareHelperFunctions.ipf
@@ -48,6 +48,10 @@ Function TEST_BEGIN_OVERRIDE(name)
 	TestBeginCommon()
 End
 
+Function TEST_END_OVERRIDE(string name)
+	TestEndCommon()
+End
+
 Function TEST_CASE_BEGIN_OVERRIDE(name)
 	string name
 

--- a/Packages/tests/UTF_HelperFunctions.ipf
+++ b/Packages/tests/UTF_HelperFunctions.ipf
@@ -740,6 +740,11 @@ Function TestBeginCommon()
 	MEN_ClearPackageSettings()
 End
 
+Function TestEndCommon()
+
+	zeromq_stop()
+End
+
 Function SetAsyncChannelProperties(string device, WAVE asyncChannels, variable minValue, variable maxValue)
 	variable chan
 	string ctrl, title, unit


### PR DESCRIPTION
This allows to run tests for local debugging purposes in different igor instances.

Close #1975