### PR TITLE
MIES_TestPulse_Single.ipf: Zero DAC after stopping acquisition

### DIFF
--- a/Packages/MIES/MIES_TestPulse_Single.ipf
+++ b/Packages/MIES/MIES_TestPulse_Single.ipf
@@ -56,7 +56,7 @@ Function TPS_TestPulseFunc(s)
 		// nothing
 	while (HW_ITC_MoreData(deviceID, flags=(HARDWARE_ABORT_ON_ERROR)))
 
-	HW_StopAcq(HARDWARE_ITC_DAC, deviceID, prepareForDAQ = 1)
+	HW_StopAcq(HARDWARE_ITC_DAC, deviceID, prepareForDAQ = 1, zeroDAC = 1, flags = HARDWARE_ABORT_ON_ERROR)
 
 	SCOPE_UpdateOscilloscopeData(device, TEST_PULSE_MODE)
 
@@ -160,7 +160,7 @@ Function TPS_StartTestPulseForeground(device, [elapsedTime])
 			// nothing
 		while (HW_ITC_MoreData(deviceID, flags=(HARDWARE_ABORT_ON_ERROR)))
 
-		HW_StopAcq(HARDWARE_ITC_DAC, deviceID, prepareForDAQ = 1)
+		HW_StopAcq(HARDWARE_ITC_DAC, deviceID, prepareForDAQ = 1, zeroDAC = 1, flags = HARDWARE_ABORT_ON_ERROR)
 		SCOPE_UpdateOscilloscopeData(device, TEST_PULSE_MODE)
 
 		SCOPE_UpdateGraph(device, TEST_PULSE_MODE)

--- a/ctags.cnf
+++ b/ctags.cnf
@@ -5,3 +5,4 @@
 --exclude=tools/installer/*
 --exclude=Packages/igortest/internal_dev/*
 --exclude=Packages/igortest/docu/*
+--exclude=Packages/igortest/tests/*


### PR DESCRIPTION
We always pass zeroDAC = 1 for TP MD so there is no reason to deviate for
single device from that approach.

We also pass the abort on error flag as done in a lot of other call sites
of HW_StopAcq.

Close #1996
Close #1965
