### PR TITLE
Tests/AdditionalExperimentCleanup: Preserve the DebugPanel waves

### DIFF
--- a/Packages/tests/UTF_HelperFunctions.ipf
+++ b/Packages/tests/UTF_HelperFunctions.ipf
@@ -117,6 +117,11 @@ Function AdditionalExperimentCleanup()
 
 		if(!cmpstr(win, "DebugPanel"))
 			reopenDebugPanel = 1
+
+			WAVE debugPanelList = GetDebugPanelListWave()
+			Duplicate/FREE debugPanelList, debugPanelListCopy
+			WAVE debugPanelSel = GetDebugPanelListSelWave()
+			Duplicate/FREE debugPanelSel, debugPanelSelCopy
 		endif
 
 		KillWindow $win
@@ -142,6 +147,11 @@ Function AdditionalExperimentCleanup()
 
 	if(reopenDebugPanel)
 		DP_OpenDebugPanel()
+
+		WAVE debugPanelList = GetDebugPanelListWave()
+		Duplicate/O debugPanelListCopy, debugPanelList
+		WAVE debugPanelSel = GetDebugPanelListSelWave()
+		Duplicate/O debugPanelSelCopy, debugPanelSel
 	endif
 
 	// currently superfluous as we remove root:MIES above


### PR DESCRIPTION
Although 82a4bc59 (AdditionalExperimentCleanup: Handle reopening the debug panel correctly, 2021-12-22) claimed to fix the debug panel closing and reopening properly, it failed to preserve the listbox wave including the selections.

We now do that.

Close #1974
