### PR TITLE
TestOperationPSXTooLargeDecayTau: Fix broken conflict resolution

### DIFF
--- a/Packages/tests/Basic/UTF_SweepFormula_PSX.ipf
+++ b/Packages/tests/Basic/UTF_SweepFormula_PSX.ipf
@@ -1172,7 +1172,7 @@ static Function TestOperationPSXTooLargeDecayTau()
 	win = CreateFakeSweepData(win, device, sweepNo = 0, sweepGen=FakeSweepDataGeneratorPSX)
 	win = CreateFakeSweepData(win, device, sweepNo = 2, sweepGen=FakeSweepDataGeneratorPSX)
 
-	str = "psx(myID, psxKernel([50, 150], select(channels(AD6), [0], all), 1, 15, -5), 1.5, 100, 0)"
+	str = "psx(myID, psxKernel([50, 150], select(channels(AD6), [0], all), 1, 15, -5), 10, 100, 0)"
 	WAVE/WAVE dataWref = SF_ExecuteFormula(str, win, useVariables = 0)
 	CHECK_WAVE(dataWref, WAVE_WAVE)
 


### PR DESCRIPTION
Introduced in d1cf16be (PSX_CreateHistogramOfDeconvSweepData: Rework it completely, 2024-01-17).
