### PR TITLE
AD_FillWaves: Fix calculation of failed sweeps for Rheobase

### DIFF
--- a/Packages/MIES/MIES_AnalysisFunctions_Dashboard.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_Dashboard.ipf
@@ -349,7 +349,7 @@ static Function AD_FillWaves(win, list, info)
 						lastValid  = DimSize(spikeDetection, ROWS) - 1
 						ASSERT(Sum(spikeDetection, firstValid, lastValid) == 1, "Unexpected spike/non-spike duo")
 						Duplicate/FREE/R=[firstValid, lastValid] sweeps, passingSweeps
-						Duplicate/FREE/R=[0, firstValid - 1] sweeps, failingSweeps
+						WAVE/Z failingSweeps = GetSetDifference(sweeps, passingSweeps)
 					else
 						Duplicate/FREE sweeps, failingSweeps
 						WAVE/Z passingSweeps

--- a/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqRheobase.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqRheobase.ipf
@@ -422,7 +422,7 @@ static Function PS_RB4_REENTRY([str])
 
 	variable sweepNo, setPassed, i, numEntries, onsetDelay
 	variable initialDAScale, stepsize
-	string key
+	string key, browser
 
 	WAVE numericalValues = GetLBNumericalValues(str)
 
@@ -473,6 +473,19 @@ static Function PS_RB4_REENTRY([str])
 
 	CommonAnalysisFunctionChecks(str, sweepNo, {setPassed})
 	CheckPSQChunkTimes(str, {20, 520, 1023, 1523})
+
+	// check passing/failing sweeps
+	browser = DB_FindDataBrowser(str)
+	CHECK_PROPER_STR(browser)
+
+	DFREF dfr = BSP_GetFolder(browser, MIES_BSP_PANEL_FOLDER)
+
+	WAVE/T listWave = GetAnaFuncDashboardListWave(dfr)
+	CHECK_EQUAL_VAR(GetNumberFromWaveNote(listWave, NOTE_INDEX), 1)
+
+	WAVE/T infoWave = GetAnaFuncDashboardInfoWave(dfr)
+	CHECK_EQUAL_STR(infoWave[0][%$"Passing Sweeps"], "0;1;")
+	CHECK_EQUAL_STR(infoWave[0][%$"Failing Sweeps"], "")
 End
 
 static Function PS_RB5_preAcq(string device)


### PR DESCRIPTION
PSQ_Rheobase does not have a per Sweep QC labnotebok setting. Therefore we decided in 23f0714f (Analysis functions dashboard, 2018-05-06) to use, for passing set QC, the last spiking/non-spiking sweeps as passed and everything else as failed.

Unfortunately it was not anticipated that only two sweeps are present and in that case we have one sweep both failing and passing as Duplicate/RMD clips its passed indices.

By using the set difference we avoid this issue.

Close #2017
