### PR TITLE
bugfix: FIFO2WAVE does not work with single point ranges

### DIFF
--- a/Packages/tests/HardwareBasic/UTF_BasicHardwareTests.ipf
+++ b/Packages/tests/HardwareBasic/UTF_BasicHardwareTests.ipf
@@ -2362,3 +2362,22 @@ End
 static Function CheckIfNoTTLonTP_REENTRY([string str])
 	PASS()
 End
+
+#ifdef TESTS_WITH_NI_HARDWARE
+// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+static Function TestNIAcquisitionReliability([str])
+	string str
+
+	STRUCT DAQSettings s
+	InitDAQSettingsFromString(s, "MD1_RA1_I0_L0_BKG1_FFR:10:_RES1000"       + \
+										"__HS0_DA0_AD0_CM:VC:_ST:EpochTest6_DA_0:")
+
+	AcquireData_NG(s, str)
+End
+
+static Function TestNIAcquisitionReliability_REENTRY([str])
+	string str
+
+	CHECK_EQUAL_VAR(GetSetVariable(str, "SetVar_Sweep"), 1000)
+End
+#endif


### PR DESCRIPTION
- there exists a bug in Igor Pro 9 where FIFO2WAVE does not work with ranges of a single point

- These ranges can appear in DAQ however: - If the  background task is called very fast. However due to the 1/60 s minimul rate this is very unlikely and happens in reality basically never
	- If the last fifo position is one point before the planned end, i.e. size of the AD channel wave. Then on next readout only one point is read, even if V_FIFOChunks would allow more. This was an approach to minimize copying unnecessary data.

Workaround:
The workaround includes two changes:
1. Readout only if there are at least two new samples in the FIFO.
2. Readout all new samples in the FIFO and then copy only the needed part, specifically at the end of acquisition.

Change 1 guarantees that there are always 2 points or more read from the FIFO. Change 2 moves the possible single point transfer to our copy part.

Logical differences

Before:
* Enter readout for 1 to N new samples in FIFO.
* Readout X samples, where X is min(N, neededNumberOfSamples), neededNumberOfSamples is the size of the AD channel wave minus the last FIFO position. If that difference is one, a readout of a single point can be attempted here.
* Copy X samples from the readOut wave to the AD channel

Now:
* Enter readout for 2 to N new samples in FIFO.
* Readout N samples
* Copy X samples, where X is min(N, neededNumberOfSamples) from the readOut wave to the AD channel

After the change the algorithm is slightly less efficient because FIFO2WAVE copies always all new samples to the readout wave, even if for AD channel are less needed at the end of acquisiton.

close https://github.com/AllenInstitute/MIES/issues/2033
