### PR TITLE
.github/workflows: Update actions

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -278,12 +278,7 @@ jobs:
           find "${{ steps.download.outputs.download-path }}" -mindepth 1 -maxdepth 1 -type d |\
             xargs -I {} tools/ftp-upload/flatten-files.sh "{}"
       - name: Compress NWB artifacts
-        run: |
-          for dir in test-itc18-assets test-itc1600-assets test-ni-assets
-          do
-            tar --remove-files --use-compress-program=zstd -cvf $dir/NWB.tar.zst $dir/*nwb
-          done
-        working-directory: ${{ steps.download.outputs.download-path }}
+        run: tools/ftp-upload/compress-nwb-files.sh "${{ steps.download.outputs.download-path }}"
       - name: Upload artifacts using FTP
         run: |
           tools/ftp-upload/upload-files.sh \

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: [ self-hosted, Windows, Certificate ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0 # load all commits
@@ -59,7 +59,7 @@ jobs:
       - name: Sign installer
         run: tools/sign-installer.sh -p "${{ secrets.GHA_MIES_CERTIFICATE_PIN }}"
       - name: upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: BuildInstaller-${{ matrix.kind }}-assets
@@ -72,13 +72,13 @@ jobs:
     runs-on: [ self-hosted, Linux, Docker ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Code Checks
         run: tools/check-code.sh
         # straight from the documentation, see https://pre-commit.com/#github-actions-example
       - name: set PY
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
@@ -115,7 +115,7 @@ jobs:
     runs-on: [ self-hosted, Linux, Docker ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0 # load all commits
@@ -124,7 +124,7 @@ jobs:
       - name: Build documentation
         run: tools/documentation/run.sh
       - name: upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: Documentation-assets
@@ -230,21 +230,21 @@ jobs:
       - TestNI
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Initial repo config
         run: tools/initial-repo-config.sh
       - name: Download ITC18-USB artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: test-itc18-assets
       - name: Download ITC1600 artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: test-itc1600-assets
       - name: Download NI artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: test-ni-assets
       - name: Validate and read NWBv2 files
@@ -265,12 +265,12 @@ jobs:
       - TestITC1600
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Initial repo config
         run: tools/initial-repo-config.sh
       - name: Download all artifacts
         id: download
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
       - name: Flatten artifact structure

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -151,7 +151,7 @@ jobs:
       job_name: 🧪 Test ${{ matrix.name }}
       overwrite_job_name: ${{ inputs.is_called_workflow || false }}
       experiment: ${{ matrix.experiment }}
-      artifact_name: test-without-hw-assets
+      artifact_name: TestWithoutHardware-${{ matrix.name }}-assets
       expensive_checks: "1"
       instrument_tests: ${{ fromJson('["0", "1"]')[inputs.do_instrumentation] }}
 
@@ -173,7 +173,7 @@ jobs:
       overwrite_job_name: ${{ inputs.is_called_workflow || false }}
       experiment: ${{ matrix.experiment }}
       target: "[ 'self-hosted', 'Windows', 'IgorPro', 'NI' ]"
-      artifact_name: test-ni-assets
+      artifact_name: TestNI-${{ matrix.name }}-assets
       expensive_checks: "1"
       instrument_tests: ${{ fromJson('["0", "1"]')[inputs.do_instrumentation] }}
 
@@ -195,7 +195,7 @@ jobs:
       overwrite_job_name: ${{ inputs.is_called_workflow || false }}
       experiment: ${{ matrix.experiment }}
       target: "[ 'self-hosted', 'Windows', 'IgorPro', 'ITC' ]"
-      artifact_name: test-itc18-assets
+      artifact_name: TestITC18-${{ matrix.name }}-assets
       expensive_checks: "1"
       instrument_tests: ${{ fromJson('["0", "1"]')[inputs.do_instrumentation] }}
 
@@ -217,7 +217,7 @@ jobs:
       overwrite_job_name: ${{ inputs.is_called_workflow || false }}
       experiment: ${{ matrix.experiment }}
       target: "[ 'self-hosted', 'Windows', 'IgorPro', 'ITC1600' ]"
-      artifact_name: test-itc1600-assets
+      artifact_name: TestITC1600-${{ matrix.name }}-assets
       expensive_checks: "1"
       instrument_tests: ${{ fromJson('["0", "1"]')[inputs.do_instrumentation] }}
 
@@ -238,15 +238,15 @@ jobs:
       - name: Download ITC18-USB artifacts
         uses: actions/download-artifact@v4
         with:
-          name: test-itc18-assets
+          pattern: TestITC18-*
       - name: Download ITC1600 artifacts
         uses: actions/download-artifact@v4
         with:
-          name: test-itc1600-assets
+          pattern: TestITC1600-*
       - name: Download NI artifacts
         uses: actions/download-artifact@v4
         with:
-          name: test-ni-assets
+          pattern: TestNI-*
       - name: Validate and read NWBv2 files
         run: tools/nwb-read-tests/run.sh
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -143,12 +143,7 @@ jobs:
           find "${{ steps.download.outputs.download-path }}" -mindepth 1 -maxdepth 1 -type d |\
             xargs -I {} tools/ftp-upload/flatten-files.sh "{}"
       - name: Compress NWB artifacts
-        run: |
-          for dir in test-itc18-assets test-itc1600-assets test-ni-assets
-          do
-            tar --remove-files --use-compress-program=zstd -cvf $dir/NWB.tar.zst $dir/*nwb
-          done
-        working-directory: ${{ steps.download.outputs.download-path }}
+        run: tools/ftp-upload/compress-nwb-files.sh "${{ steps.download.outputs.download-path }}"
       - name: Upload artifacts using FTP
         run: |
           tools/ftp-upload/upload-files.sh \

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -27,14 +27,14 @@ jobs:
       - CallPR
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0 # load all commits
       - name: Initial repo config
         run: tools/initial-repo-config.sh
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Documentation-assets
       - name: Deploy documentation to github pages
@@ -48,14 +48,14 @@ jobs:
       - CallPR
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0 # load all commits
       - name: Initial repo config
         run: tools/initial-repo-config.sh
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: BuildInstaller-user-assets
       - name: Deploy release assets to github
@@ -69,12 +69,12 @@ jobs:
       - CallPR
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Initial repo config
         run: tools/initial-repo-config.sh
       - name: Download all artifacts
         id: download
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
       - name: 📥 Download report cache from FTP
@@ -112,7 +112,7 @@ jobs:
             -d "${{ steps.gen.outputs.history }}" \
             -t "cache/coverage-history"
       - name: upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: report-artifacts
@@ -130,12 +130,12 @@ jobs:
       - GenerateReport
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Initial repo config
         run: tools/initial-repo-config.sh
       - name: Download all artifacts
         id: download
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
       - name: Flatten artifact structure

--- a/.github/workflows/test-igor-workflow.yml
+++ b/.github/workflows/test-igor-workflow.yml
@@ -64,14 +64,14 @@ jobs:
       CI_INSTRUMENT_TESTS: ${{ inputs.instrument_tests }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Initial repo config
         run: tools/initial-repo-config.sh
       - name: Download artifacts
         if: inputs.installer_artifact_name != ''
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         continue-on-error: false
         with:
           name: ${{ inputs.installer_artifact_name }}
@@ -83,7 +83,7 @@ jobs:
         if: always()
         run: tools/gather-logfiles-and-crashdumps.sh
       - name: upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: ${{ inputs.artifact_name }}

--- a/tools/ftp-upload/compress-nwb-files.sh
+++ b/tools/ftp-upload/compress-nwb-files.sh
@@ -2,9 +2,12 @@
 
 cd $1
 
-for dir in test-itc18-assets test-itc1600-assets test-ni-assets
+for dir in TestNI-* TestITC18-* TestITC1600-*
 do
-  if [ -n "$(find "$dir" -maxdepth 0 -type d -empty)" ]
+  if [ ! -d $dir ]
+  then
+    continue
+  elif [ -n "$(find "$dir" -maxdepth 0 -type d -empty)" ]
   then
     continue
   fi

--- a/tools/ftp-upload/compress-nwb-files.sh
+++ b/tools/ftp-upload/compress-nwb-files.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+cd $1
+
+for dir in test-itc18-assets test-itc1600-assets test-ni-assets
+do
+  if [ -n "$(find "$dir" -maxdepth 0 -type d -empty)" ]
+  then
+    continue
+  fi
+
+  tar --remove-files --use-compress-program=zstd -cvf $dir/NWB.tar.zst $dir/*nwb
+done


### PR DESCRIPTION
The v4 versions don't use the deprecated Node.js version 16 [1].

[1]: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Will merge once CI passes.