### PR TITLE
AB: bugfix LoadDataWrapper excluded loaded waves if the casing was di…

### DIFF
--- a/Packages/MIES/MIES_AnalysisBrowser.ipf
+++ b/Packages/MIES/MIES_AnalysisBrowser.ipf
@@ -627,7 +627,7 @@ static Function AB_LoadDataWrapper(tmpDFR, expFilePath, datafolderPath, listOfNa
 
 	RemoveAllEmptyDataFolders(tmpDFR)
 
-	regexp = ConvertListToRegexpWithAlternations(listOfNames)
+	regexp = "(?i)" + ConvertListToRegexpWithAlternations(listOfNames)
 	list = GetListOfObjects(tmpDFR, regexp, recursive=1, typeFlag=typeFlags)
 
 	return ItemsInList(list)

--- a/Packages/tests/Basic/UTF_AnalysisBrowserTest.ipf
+++ b/Packages/tests/Basic/UTF_AnalysisBrowserTest.ipf
@@ -91,3 +91,25 @@ static Function TryLoadingDifferentFiles()
 	KillWindow $abWin
 	KillWindow $sBrowser1
 End
+
+static Function TestAB_LoadDataWrapper()
+
+	variable numLoaded
+	string expFilePath
+	string expName = "TestAB_LoadDataWrapper.pxp"
+	string wName = "wAvE1"
+
+	WAVE/Z wv =root:WAVE1
+	KillOrMoveToTrash(wv=wv)
+	wName = UpperStr(wName)
+	Make root:$wName
+	SaveExperiment/P=home as expName
+
+	PathInfo home
+	expFilePath = S_path + expName
+
+	DFREF tmpDFR = NewFreeDataFolder()
+	wName = LowerStr(wName) + ";"
+	numLoaded = MIES_AB#AB_LoadDataWrapper(tmpDFR, expFilePath, "root:", wName, typeFlags=COUNTOBJECTS_WAVES)
+	CHECK_GT_VAR(numLoaded, 0)
+End


### PR DESCRIPTION
…fferent

LoadDataWrapper does a check if it can find the loaded waves after the load. This check was case-sensitive. Thus, it failed if the input wave name was e.g. lower case and the actual loaded wave was upper case named.

Fix: Make the check case-insensitive to be in line with general object name handling in Igor Pro

close https://github.com/AllenInstitute/MIES/issues/2042