### PR TITLE
AB: bugfix AB_LoadWave does not retrieve wave from the correct DF

### DIFF
--- a/Packages/MIES/MIES_AnalysisBrowser.ipf
+++ b/Packages/MIES/MIES_AnalysisBrowser.ipf
@@ -2472,8 +2472,7 @@ static Function AB_LoadWave(expFilePath, fullPath, overwrite)
 		return 1
 	endif
 
-	WAVE wv = $(GetIndexedObjNameDFR(newDFR, 1, 0))
-	SetDataFolder root:
+	WAVE/SDFR=newDFR wv = $(GetIndexedObjNameDFR(newDFR, 1, 0))
 	createDFWithAllParents(dataFolder)
 	MoveWave wv, $fullPath
 

--- a/Packages/tests/Basic/UTF_AnalysisBrowserTest.ipf
+++ b/Packages/tests/Basic/UTF_AnalysisBrowserTest.ipf
@@ -113,3 +113,28 @@ static Function TestAB_LoadDataWrapper()
 	numLoaded = MIES_AB#AB_LoadDataWrapper(tmpDFR, expFilePath, "root:", wName, typeFlags=COUNTOBJECTS_WAVES)
 	CHECK_GT_VAR(numLoaded, 0)
 End
+
+static Function TestABLoadWave()
+
+	variable err
+	string expFilePath
+	string expName = "TestAB_LoadWave.pxp"
+	string wName = "wAvE1"
+
+	WAVE/Z wv = root:$wName
+	KillOrMoveToTrash(wv=wv)
+
+	Make root:$wName/WAVE=wv
+	SaveExperiment/P=home as expName
+
+	KillOrMoveToTrash(wv=wv)
+
+	PathInfo home
+	expFilePath = S_path + expName
+	err = MIES_AB#AB_LoadWave(expFilePath, "root:" + wName, 1)
+	CHECK_EQUAL_VAR(err, 0)
+
+	WAVE/Z wv = root:$wName
+	CHECK_WAVE(wv, NUMERIC_WAVE)
+
+End


### PR DESCRIPTION
AB_LoadWave retrieves the wave from the current DF instead from the given DF after loading before moving the wave to the final destination.

Fix: Use specifically the given DF.

since 97b1252

close https://github.com/AllenInstitute/MIES/issues/2049