### PR TITLE
LBV: fix uncaught RTE if result waves were not loaded in LBV_PopupExtGetResultsKeys

### DIFF
--- a/Packages/MIES/MIES_LogbookViewer.ipf
+++ b/Packages/MIES/MIES_LogbookViewer.ipf
@@ -84,8 +84,8 @@ Function/WAVE LBV_PopupExtGetResultsKeys(string win)
 	WAVE/Z textualValues   = BSP_GetLogbookWave(win, LBT_RESULTS, LBN_TEXTUAL_VALUES, selectedExpDevice = 1)
 	WAVE/Z numericalValues = BSP_GetLogbookWave(win, LBT_RESULTS, LBN_NUMERICAL_VALUES, selectedExpDevice = 1)
 
-	WAVE/T textualNames = LBV_GetFilledLabnotebookEntries(textualValues)
-	WAVE/T numericalNames = LBV_GetFilledLabnotebookEntries(numericalValues)
+	WAVE/Z/T textualNames = LBV_GetFilledLabnotebookEntries(textualValues)
+	WAVE/Z/T numericalNames = LBV_GetFilledLabnotebookEntries(numericalValues)
 
 	WAVE/Z entries = LBV_GetAllLogbookParamNames(textualNames, numericalNames)
 


### PR DESCRIPTION
The function tried to retrieve valid LBN entries from non-existent result waves

Note on test:
For that case the RTE is only generated by IP when NVAR_SVAR_WAVE_Checking is enabled in the debugger, that implies that the Debugger is enabled. Thus, a test that would catch this wave assignment error would need to enable the debugger and then stop on the critical location.

For CI execution this is no option and thus a test case for that was discarded. It could look like this:

```igorpro
/// @brief This test checks if LBV_PopupExtGetResultsKeys works properly if no result waves are loaded.
///        To check that some sweeps are loaded through the AB.
static Function TestLBVPopupExtGetResultsKeys()

	string abWin, sweepBrowsers, win
	variable s_enable, s_debugOnError, s_debugOnAbort, s_NVAR_SVAR_WAVE_Checking

	[abWin, sweepBrowsers] = OpenAnalysisBrowser({PXP_FILENAME}, loadSweeps = 1)

	CHECK_EQUAL_VAR(ItemsInList(sweepBrowsers), 1)
	win = StringFromList(0, sweepBrowsers)
	DebuggerOptions
	s_enable = V_enable
	s_debugOnAbort = V_debugOnAbort
	s_debugOnError = V_debugOnError
	s_NVAR_SVAR_WAVE_Checking = V_NVAR_SVAR_WAVE_Checking
	DebuggerOptions enable=1, debugOnAbort=0, debugOnError=0, NVAR_SVAR_WAVE_Checking=1
	LBV_PopupExtGetResultsKeys(win)
	DebuggerOptions enable=s_enable, debugOnAbort=s_debugOnAbort, debugOnError=s_debugOnError, NVAR_SVAR_WAVE_Checking=s_NVAR_SVAR_WAVE_Checking
	CHECK_NO_RTE()

	KillWindow $abWin
	KilLWindow $win
End
```

close #2043