### PR TITLE
WB: fix WB_SplitStimsetName must be case insensitive

### DIFF
--- a/Packages/MIES/MIES_WaveBuilder.ipf
+++ b/Packages/MIES/MIES_WaveBuilder.ipf
@@ -2755,7 +2755,7 @@ Function WB_SplitStimsetName(string setName, string &setPrefix, variable &stimul
 	setPrefix    = ""
 	stimulusType = CHANNEL_TYPE_UNKNOWN
 
-	SplitString/E="(.*)_(DA|TTL)_([[:digit:]]+)" setName, setPrefixString, stimulusTypeString, setNumberString
+	SplitString/E="(?i)(.*)_(DA|TTL)_([[:digit:]]+)" setName, setPrefixString, stimulusTypeString, setNumberString
 
 	if(V_flag != 3)
 		return NaN

--- a/Packages/tests/Basic/UTF_Utils.ipf
+++ b/Packages/tests/Basic/UTF_Utils.ipf
@@ -7692,3 +7692,20 @@ static Function TestAreIntervalsIntersecting()
 	Make/FREE data = {{-inf, 3}, {2, inf}}
 	CHECK(!AreIntervalsIntersecting(data))
 End
+
+static Function TestCaseInsensitivityWB_SplitStimsetName()
+
+	string setPrefix
+	variable stimulusType
+	variable setNumber
+
+	WB_SplitStimsetName("formula_DA_0", setPrefix, stimulusType, setNumber)
+	CHECK_EQUAL_STR(setPrefix, "formula")
+	CHECK_EQUAL_VAR(stimulusType, CHANNEL_TYPE_DAC)
+	CHECK_EQUAL_VAR(setNumber, 0)
+
+	WB_SplitStimsetName("formula_da_0", setPrefix, stimulusType, setNumber)
+	CHECK_EQUAL_STR(setPrefix, "formula")
+	CHECK_EQUAL_VAR(stimulusType, CHANNEL_TYPE_DAC)
+	CHECK_EQUAL_VAR(setNumber, 0)
+End


### PR DESCRIPTION
WB_SplitStimsetName was case-sensitive that led to failing on parsing formula stimset names that are by definition lower case.

The effect was that checks on the existence of formula stimsets failed.

since 714a9aa

close #2045