### PR TITLE
WB: fix recreation of dependent Stimsets from Stimset parameter waves

### DIFF
--- a/Packages/MIES/MIES_WaveBuilder.ipf
+++ b/Packages/MIES/MIES_WaveBuilder.ipf
@@ -65,29 +65,18 @@ Function/Wave WB_CreateAndGetStimSet(setName)
 
 	DFREF dfr = GetSetFolder(type)
 	WAVE/Z/SDFR=dfr stimSet = $setName
-
-	if(WB_StimsetIsFromThirdParty(setName))
-		if(WaveExists(stimSet))
-			return stimSet
-		else
-			return $""
-		endif
+	if(WB_StimsetIsFromThirdParty(setName) || !WB_StimsetNeedsUpdate(setName))
+		return stimSet
 	endif
 
-	needToCreateStimSet = (!WaveExists(stimSet) || WB_StimsetNeedsUpdate(setName))
+	WAVE/Z/SDFR=dfr oldStimSet = $setName
+	if(WaveExists(oldStimSet))
+		KillOrMoveToTrash(wv=oldStimSet)
+	endif
 
-	if(needToCreateStimSet)
-		// create current stimset
-		WAVE/Z stimSet = WB_GetStimSet(setName=setName)
-		if(!WaveExists(stimSet))
-			return $""
-		endif
-
-		WAVE/Z/SDFR=dfr oldStimSet = $setName
-		if(WaveExists(oldStimSet))
-			KillOrMoveToTrash(wv=oldStimSet)
-		endif
-
+	// create current stimset
+	WAVE/Z stimSet = WB_GetStimSet(setName=setName)
+	if(WaveExists(stimSet))
 		MoveWave stimSet, dfr:$setName
 		WAVE/SDFR=dfr stimSet = $setName
 	endif
@@ -212,8 +201,8 @@ static Function WB_StimsetNeedsUpdate(setName)
 	string stimsets
 	variable lastModStimSet, numWaves, numStimsets, i
 
-	// stimset wave note is too old
-	if(!WB_StimsetHasLatestNoteVersion(setName))
+	// stimset does not exist or wave note is too old
+	if(!WB_StimsetExists(setName) || !WB_StimsetHasLatestNoteVersion(setName))
 		return 1
 	endif
 


### PR DESCRIPTION
The WB has an issue, where non-existing stimsets are not treated as needing an update. Thus, combine type stimsets that depend on another stimset being created first can not be created because the other stimset is not being created from the parameter waves.

since 792d0d2

close https://github.com/AllenInstitute/MIES/issues/2060

- [x] add test