### PR TITLE
MIES_StimsetAPI.ipf: Fix the path to the example file

### DIFF
--- a/Packages/MIES/MIES_StimsetAPI.ipf
+++ b/Packages/MIES/MIES_StimsetAPI.ipf
@@ -14,7 +14,7 @@
 ///
 /// Code example:
 /// \rst
-/// .. literalinclude:: ../ipf/example-stimulus-set-api.ipf
+/// .. literalinclude:: /ipf/example-stimulus-set-api.ipf
 ///    :language: igor
 ///    :dedent:
 ///    :tab-width: 4


### PR DESCRIPTION
Bug introduced in ea03d072 (MIES_StimsetAPI.ipf: Add functions for manipulating stimsets, 2021-05-28).
