### PR TITLE
EP: fix epoch sorting to be numerically correct

### DIFF
--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -27,7 +27,7 @@ Constant ANALYSISBROWSER_PANEL_VERSION    =  3
 Constant STIMSET_NOTE_VERSION = 9
 
 /// Version of the epoch information for DA+TTL data
-Constant SWEEP_EPOCH_VERSION = 8
+Constant SWEEP_EPOCH_VERSION = 9
 
 /// Version of the labnotebooks and results (numerical and textual) waves
 ///

--- a/Packages/MIES/MIES_Epochs.ipf
+++ b/Packages/MIES/MIES_Epochs.ipf
@@ -619,11 +619,13 @@ static Function EP_SortEpochs(string device)
 			endif
 
 			Duplicate/FREE/T/RMD=[, epochCnt - 1][][channel][channelType] epochWave, epochChannel
-			Redimension/N=(-1, -1, 0, 0) epochChannel
+			Redimension/N=(-1, -1) epochChannel
 
-			epochChannel[][%EndTime] = num2strHighPrec(-1 * str2num(epochChannel[p][%EndTime]), precision = EPOCHTIME_PRECISION)
-			SortColumns/DIML/KNDX={EPOCH_COL_STARTTIME, EPOCH_COL_ENDTIME, EPOCH_COL_TREELEVEL} sortWaves={epochChannel}
-			epochChannel[][%EndTime] = num2strHighPrec(-1 * str2num(epochChannel[p][%EndTime]), precision = EPOCHTIME_PRECISION)
+			Make/FREE/D/N=(DimSize(epochChannel, ROWS), DimSize(epochChannel, COLS)) epochSortColStartTime, epochSortColEndTime, epochSortColTreeLevel
+			epochSortColStartTime[] = str2numSafe(epochChannel[p][EPOCH_COL_STARTTIME])
+			epochSortColEndTime[] = -1 * str2numSafe(epochChannel[p][EPOCH_COL_ENDTIME])
+			epochSortColTreeLevel[] = str2numSafe(epochChannel[p][EPOCH_COL_TREELEVEL])
+			SortColumns/DIML keyWaves={epochSortColStartTime, epochSortColEndTime, epochSortColTreeLevel} sortWaves={epochChannel}
 
 			// remove epochs marked for removal
 			// first column needs to be StartTime
@@ -636,7 +638,9 @@ static Function EP_SortEpochs(string device)
 				epochWave[, epochCnt - 1][][channel][channelType] = epochChannel[p][q]
 			endif
 
-			epochWave[epochCnt, *][][channel][channelType] = ""
+			if(epochCnt < DimSize(epochWave, ROWS))
+				epochWave[epochCnt, *][][channel][channelType] = ""
+			endif
 		endfor
 	endfor
 End

--- a/Packages/tests/HardwareBasic/UTF_Epochs.ipf
+++ b/Packages/tests/HardwareBasic/UTF_Epochs.ipf
@@ -996,11 +996,16 @@ static Function EP_EpochTestTTL_REENTRY([STRUCT IUTF_mData &mData])
 	Duplicate/FREE/T epochTags, epochShortNames
 	epochShortNames[] = EP_GetShortName(epochTags[p])
 
-	Make/FREE/T nameRef = {"E0_PT_P0_P", "E0_PT_P0", "ST", "E0", "E0_PT_P0_B", "E0_PT_P1_P", "E0_PT_P1",        \
-								"E0_PT_P1_B", "E0_PT_P2_P", "E0_PT_P2", "E0_PT_P2_B", "E0_PT_P3_P", "E0_PT_P3", "E0_PT_P3_B", \
-								"E0_PT_P4_P", "E0_PT_P4", "E0_PT_P4_B", "E0_PT_P5_P", "E0_PT_P5", "E0_PT_P5_B", "E0_PT_P6_P", \
-								"E0_PT_P6", "E0_PT_P6_B", "E0_PT_P7_P", "E0_PT_P7", "E0_PT_P7_B", "E0_PT_P8_P", "E0_PT_P8",   \
-								"E0_PT_P8_B", "E0_PT_P9", "E0_PT_P9_P"}
+	Make/FREE/T nameRef = {"ST", "E0", "E0_PT_P0", "E0_PT_P0_P", "E0_PT_P0_B", \
+												"E0_PT_P1", "E0_PT_P1_P", "E0_PT_P1_B", \
+												"E0_PT_P2", "E0_PT_P2_P", "E0_PT_P2_B", \
+												"E0_PT_P3", "E0_PT_P3_P", "E0_PT_P3_B", \
+												"E0_PT_P4", "E0_PT_P4_P", "E0_PT_P4_B", \
+												"E0_PT_P5", "E0_PT_P5_P", "E0_PT_P5_B", \
+												"E0_PT_P6", "E0_PT_P6_P", "E0_PT_P6_B", \
+												"E0_PT_P7", "E0_PT_P7_P", "E0_PT_P7_B", \
+												"E0_PT_P8", "E0_PT_P8_P", "E0_PT_P8_B", \
+												"E0_PT_P9", "E0_PT_P9_P" }
 	if(mData.v2)
 		InsertPoints/M=(ROWS) 0, 1, nameRef
 		nameref[0] = "B0_OD"

--- a/Packages/tests/HardwareBasic/UTF_SweepFormulaHardware.ipf
+++ b/Packages/tests/HardwareBasic/UTF_SweepFormulaHardware.ipf
@@ -810,5 +810,5 @@ static Function SF_UnassociatedDATTL_Epochs_REENTRY([string str])
 	CHECK_EQUAL_VAR(DimSize(data, ROWS), 29)
 	WAVE/T epochDataT = data[0]
 	CHECK_WAVE(epochDataT, TEXT_WAVE)
-	CHECK_EQUAL_STR(epochDataT[0], "E0_PT_P0_P")
+	CHECK_EQUAL_STR(epochDataT[0], "E0_PT_P0")
 End


### PR DESCRIPTION
The epoch sorting had two issues:

1. The sorting was alphabetically such that 2.xxx was between
19.xxx and 20.xxx which is incorrect.

2. The function assumed that there is always some remaining rows to
cutoff at the end. If that was not the case then the epoch in the last
row is deleted.

- raised SWEEP_EPOCH_VERSION

1. since a2172f0 (Added generations of epoch information wave, 2019-05-22)
2. since 4ed816a (EP_SortEpochs: Teach it to remove epochs marked for removal, 2021-09-09)