### PR TITLE
Increase timeout for acquisition in tests to 20 mins

### DIFF
--- a/Packages/tests/UTF_HardwareHelperFunctions.ipf
+++ b/Packages/tests/UTF_HardwareHelperFunctions.ipf
@@ -342,7 +342,7 @@ Function RegisterReentryFunction(string testcase)
 	if(FuncRefIsAssigned(FuncRefInfo(reentryFuncPlain)) || FuncRefIsAssigned(FuncRefInfo(reentryFuncMDStr)) || FuncRefIsAssigned(FuncRefInfo(reentryFuncRefWave)) || FuncRefIsAssigned(FuncRefInfo(reentryFuncMDD)))
 		CtrlNamedBackGround DAQWatchdog, start, period=120, proc=WaitUntilDAQDone_IGNORE
 		CtrlNamedBackGround TPWatchdog, start, period=120, proc=WaitUntilTPDone_IGNORE
-		RegisterUTFMonitor(TASKNAMES + "DAQWatchdog;TPWatchdog", BACKGROUNDMONMODE_AND, reentryFuncName, timeout = 600, failOnTimeout = 1)
+		RegisterUTFMonitor(TASKNAMES + "DAQWatchdog;TPWatchdog", BACKGROUNDMONMODE_AND, reentryFuncName, timeout = 1200, failOnTimeout = 1)
 	endif
 End
 


### PR DESCRIPTION
The NI reliability test is running rather slow on the CI machine and exceeds 10 mins timeout for the acquisition. This results in a fail.

From the esitmation of 0.96 acquisition/s of the CI machine, a raise to 1200 s should be enough.

An alternative would be to upgrade the CI machine, as a factor of 2.5 times slower than my 4 year old development machine is questionable. (Also with respect to the time a full CI run takes)

close #2069