### PR TITLE
tools/ftp-upload/Dockerfile: Use parallel transfer mode

### DIFF
--- a/tools/ftp-upload/Dockerfile
+++ b/tools/ftp-upload/Dockerfile
@@ -18,9 +18,11 @@ RUN groupadd -g ${GID} -o ${UNAME} && \
 
 USER ${UNAME}
 
-RUN mkdir ~/.lftp &&                                      \
-    echo "set ssl:check-hostname false" >> ~/.lftp/rc &&  \
-    echo "set ftp:ssl-force true" >> ~/.lftp/rc &&        \
-    echo "set ftp:ssl-protect-data true" >> ~/.lftp/rc && \
-    echo "set ftp:ssl-protect-fxp true" >> ~/.lftp/rc &&  \
-    echo "set ftp:ssl-protect-list true" >> ~/.lftp/rc
+RUN mkdir ~/.lftp                                             && \
+    echo "set ssl:check-hostname false" >> ~/.lftp/rc         && \
+    echo "set ftp:ssl-force true" >> ~/.lftp/rc               && \
+    echo "set ftp:ssl-protect-data true" >> ~/.lftp/rc        && \
+    echo "set ftp:ssl-protect-fxp true" >> ~/.lftp/rc         && \
+    echo "set ftp:ssl-protect-list true" >> ~/.lftp/rc        && \
+    echo "set mirror:parallel-directories true" >> ~/.lftp/rc && \
+    echo "set mirror:parallel-transfer-count 10" >> ~/.lftp/rc


### PR DESCRIPTION
It currently takes around 45 minutes on main, which is most likely due to the large number of files being transferred.

Let's try 10 at a time over all directories.

[1]: https://github.com/AllenInstitute/MIES/actions/runs/8639332642/job/23694913790

Will merge once CI passes.
