### PR TITLE
tools/ftp-upload/Dockerfile: User fewer parallel connections

### DIFF
--- a/tools/ftp-upload/Dockerfile
+++ b/tools/ftp-upload/Dockerfile
@@ -25,4 +25,4 @@ RUN mkdir ~/.lftp                                             && \
     echo "set ftp:ssl-protect-fxp true" >> ~/.lftp/rc         && \
     echo "set ftp:ssl-protect-list true" >> ~/.lftp/rc        && \
     echo "set mirror:parallel-directories true" >> ~/.lftp/rc && \
-    echo "set mirror:parallel-transfer-count 10" >> ~/.lftp/rc
+    echo "set mirror:parallel-transfer-count 5" >> ~/.lftp/rc


### PR DESCRIPTION
The CI job using the ftp download/upload does currently fail [1] and that was due to b19387e5 (tools/ftp-upload/Dockerfile: Use parallel transfer mode, 2024-04-11).

Documentation of the FTP server hoster [2] mentions that only up to 8 parallel connections are supported, so let's use 5 which is in the range of 2 to 8.

[1]: https://github.com/AllenInstitute/MIES/actions/runs/8659318873/job/23761414453
[2]: https://www.hosteurope.de/faq/webhosting/hochladen-von-webinhalten-ftp/filezilla-konfigurieren
