### PR TITLE
UTF_AsynFrameworkTest.ipf: Correct out-of-order check

### DIFF
--- a/Packages/tests/Basic/UTF_AsynFrameworkTest.ipf
+++ b/Packages/tests/Basic/UTF_AsynFrameworkTest.ipf
@@ -732,15 +732,8 @@ static Function TASYNC_RunOrderless()
 	endfor
 	CHECK(!timeout)
 
-	if(!timeout)
-		// There are chances the result is still in Order, so we give only a Warning
-		for(i = 0; i < WORK_COUNT_GENERIC; i += 1)
-			if(returnOrder[i] != i)
-				WARN(0)
-				break
-			endif
-		endfor
-	endif
+	Make/FREE/N=(WORK_COUNT_GENERIC) inOrder = p
+	CHECK_NEQ_VAR(EqualWaves(returnOrder, inOrder, EQWAVES_DATA), 1)
 
 	ASYNC_Stop(timeout = 1)
 End
@@ -963,15 +956,8 @@ static Function TASYNC_OrderlessDirectStop()
 	timeout = ASYNC_Stop(timeout = THREADING_TEST_TIMEOUT)
 	CHECK(!timeout)
 
-	if(!timeout)
-		// There are chances the result is still in Order, so we give only a Warning
-		for(i = 0; i < WORK_COUNT_GENERIC; i += 1)
-			if(returnOrder[i] != i)
-				WARN(0)
-				break
-			endif
-		endfor
-	endif
+	Make/FREE/N=(WORK_COUNT_GENERIC) inOrder = p
+	CHECK_NEQ_VAR(EqualWaves(returnOrder, inOrder, EQWAVES_DATA), 1)
 End
 
 #ifndef THREADING_DISABLED


### PR DESCRIPTION
Since the introduction of the tests in 14cd1ff8d6 (Add Async Framework, 2018-09-17) we tried to verify that the execution really happened out of order. The fix in b8ae7c65ce (Asyn: Fix WARN(1) in tests for orderless execution, 2022-11-03) did not fix it though as we actually need to check that the returnOrder array is not ascending.

As the workload in RunGenericWorker already does a randomized workload we feel lucky that it is never sorted and check that.
