### PR TITLE
tools/ftp-upload: Compress the Cobertura/JUNIT reports as well

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -327,8 +327,8 @@ jobs:
         run: |
           find "${{ steps.download.outputs.download-path }}" -mindepth 1 -maxdepth 1 -type d |\
             xargs -I {} tools/ftp-upload/flatten-files.sh "{}"
-      - name: Compress NWB artifacts
-        run: tools/ftp-upload/compress-nwb-files.sh "${{ steps.download.outputs.download-path }}"
+      - name: Compress some artifacts
+        run: tools/ftp-upload/compress-files.sh "${{ steps.download.outputs.download-path }}"
       - name: Upload artifacts using FTP
         run: |
           tools/ftp-upload/upload-files.sh \

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -142,8 +142,8 @@ jobs:
         run: |
           find "${{ steps.download.outputs.download-path }}" -mindepth 1 -maxdepth 1 -type d |\
             xargs -I {} tools/ftp-upload/flatten-files.sh "{}"
-      - name: Compress NWB artifacts
-        run: tools/ftp-upload/compress-nwb-files.sh "${{ steps.download.outputs.download-path }}"
+      - name: Compress some artifacts
+        run: tools/ftp-upload/compress-files.sh "${{ steps.download.outputs.download-path }}"
       - name: Upload artifacts using FTP
         run: |
           tools/ftp-upload/upload-files.sh \

--- a/tools/ftp-upload/compress-files.sh
+++ b/tools/ftp-upload/compress-files.sh
@@ -13,4 +13,6 @@ do
   fi
 
   tar --remove-files --use-compress-program=zstd -cvf $dir/NWB.tar.zst $dir/*nwb
+
+  tar --remove-files --use-compress-program=zstd -cvf $dir/CoberturaAndJUNIT.tar.zst $dir/*xml
 done


### PR DESCRIPTION
This makes uploading them much faster. And also takes less storage.