### PR TITLE
AB: fix AB_LoadDataWrapper asserts if zero waves were loaded

### DIFF
--- a/Packages/MIES/MIES_AnalysisBrowser.ipf
+++ b/Packages/MIES/MIES_AnalysisBrowser.ipf
@@ -633,6 +633,9 @@ static Function AB_LoadDataWrapper(DFREF tmpDFR, string expFilePath, string data
 	ResetDebugOnError(debugOnError)
 
 	RemoveAllEmptyDataFolders(tmpDFR)
+	if(!DataFolderExistsDFR(tmpDFR))
+		return 0
+	endif
 
 	regexp = "(?i)" + ConvertListToRegexpWithAlternations(listOfNames)
 	list   = GetListOfObjects(tmpDFR, regexp, recursive = recursive, typeFlag = typeFlags)


### PR DESCRIPTION
When no matching waves could be found in the pxp file then AB_LoadDataWrapper causes an assertion because the recursive cleanup of empty DF results in a killed root DF of the loaded DF structure. A following GetListOfObjects was executed unchecked and caused an ASSERT_TS in that case.

Added check for removed DF.

since
23a4086e (RemoveAllEmptyDataFolders: Make it behave more intuitive, 2024-03-06)
