### PR TITLE
Bugfix: lnb sweepnumber overlap readout

### DIFF
--- a/Packages/MIES/MIES_MiesUtilities.ipf
+++ b/Packages/MIES/MIES_MiesUtilities.ipf
@@ -546,14 +546,15 @@ threadsafe static Function FindRange(wv, col, val, forwardORBackward, entrySourc
 	variable col, val, forwardORBackward, entrySourceType
 	variable &first, &last
 
-	variable numRows, i, sourceTypeCol, firstRow, lastRow
+	variable numRows, i, j, sourceTypeCol, firstRow, lastRow, isNumeric, index
 
-	first = NaN
-	last  = NaN
+	first     = NaN
+	last      = NaN
+	isNumeric = IsNumericWave(wv)
 
 	// still correct without startLayer/endLayer coordinates
 	// as we always have sweepNumber/etc. in the first layer
-	if(IsNaN(val) && IsNumericWave(wv))
+	if(IsNaN(val) && isNumeric)
 		WAVE/Z indizesSetting = FindIndizes(wv, col = col, prop = PROP_EMPTY)
 	else
 		WAVE/Z indizesSetting = FindIndizes(wv, col = col, var = val)
@@ -563,8 +564,8 @@ threadsafe static Function FindRange(wv, col, val, forwardORBackward, entrySourc
 		return NaN
 	endif
 
+	sourceTypeCol = FindDimLabel(wv, COLS, "EntrySourceType")
 	if(IsFinite(entrySourceType))
-		sourceTypeCol = FindDimLabel(wv, COLS, "EntrySourceType")
 
 		if(sourceTypeCol >= 0) // labnotebook has a entrySourceType column
 			[firstRow, lastRow] = WaveMinAndMax(indizesSetting)
@@ -628,17 +629,32 @@ threadsafe static Function FindRange(wv, col, val, forwardORBackward, entrySourc
 			last = indizes[i]
 		endfor
 	else
+		if(!IsNumeric)
+			WAVE/T wt = wv
+		endif
 
 		first = indizes[numRows - 1]
 		last  = indizes[numRows - 1]
 
 		for(i = numRows - 2; i >= 0; i -= 1)
+			index = indizes[i]
 			// a backward search stops when the beginning of the last sequence was found
-			if(indizes[i] < first - 1)
-				return NaN
+			if(index < first - 1)
+				if(IsNumeric)
+					for(j = index + 1; j < first; j += 1)
+						if(!IsNaN(wv[j][sourceTypeCol][0]))
+							return NaN
+						endif
+					endfor
+				else
+					for(j = index + 1; j < first; j += 1)
+						if(!IsEmpty(wt[j][sourceTypeCol][0]))
+							return NaN
+						endif
+					endfor
+				endif
 			endif
-
-			first = indizes[i]
+			first = index
 		endfor
 	endif
 End
@@ -1157,7 +1173,7 @@ threadsafe Function/WAVE GetLastSettingNoCache(values, sweepNo, setting, entrySo
 	variable settingCol, numLayers, i, sweepCol, numEntries
 	variable firstValue, lastValue, sourceTypeCol, peakResistanceCol, pulseDurationCol
 	variable testpulseBlockLength, blockType, hasValidTPPulseDurationEntry
-	variable mode
+	variable mode, sweepNoInLNB
 
 	if(!ParamIsDefault(rowIndex))
 		rowIndex = LABNOTEBOOK_MISSING_VALUE
@@ -1184,8 +1200,8 @@ threadsafe Function/WAVE GetLastSettingNoCache(values, sweepNo, setting, entrySo
 		return $""
 	endif
 
+	sweepCol = GetSweepColumn(values)
 	if(mode == GET_LB_MODE_NONE || mode == GET_LB_MODE_WRITE)
-		sweepCol = GetSweepColumn(values)
 		FindRange(values, sweepCol, sweepNo, 0, entrySourceType, firstValue, lastValue)
 
 		if(!IsFinite(firstValue) && !IsFinite(lastValue)) // sweep number is unknown
@@ -1209,6 +1225,12 @@ threadsafe Function/WAVE GetLastSettingNoCache(values, sweepNo, setting, entrySo
 		Make/FREE/N=(numLayers) lengths
 
 		for(i = lastValue; i >= firstValue; i -= 1)
+
+			sweepNoInLNB = str2num(textualValues[i][sweepCol][0])
+			if(!IsNaN(sweepNoInLNB) && sweepNoInLNB != sweepNo)
+				continue
+			endif
+
 			if(IsFinite(entrySourceType))
 				if(!sourceTypeCol)
 					sourceTypeCol = FindDimLabel(textualValues, COLS, "EntrySourceType")
@@ -1244,6 +1266,10 @@ threadsafe Function/WAVE GetLastSettingNoCache(values, sweepNo, setting, entrySo
 		Make/D/FREE/N=(numLayers) status
 
 		for(i = lastValue; i >= firstValue; i -= 1)
+
+			if(!IsNaN(sweepNo) && numericalValues[i][sweepCol][0] != sweepNo)
+				continue
+			endif
 
 			if(IsFinite(entrySourceType))
 				if(!sourceTypeCol)

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -2047,7 +2047,7 @@ threadsafe Function/WAVE GetLBRowCache(values)
 	variable actual, sweepNo, first, last
 	string key, name
 
-	variable versionOfNewWave = 5
+	variable versionOfNewWave = 6
 
 	actual = WaveModCountWrapper(values)
 	name   = GetWavesDataFolder(values, 2)

--- a/Packages/tests/Basic/UTF_Labnotebook.ipf
+++ b/Packages/tests/Basic/UTF_Labnotebook.ipf
@@ -150,6 +150,20 @@ Function GetLastSettingFindsNaNSweep()
 	CHECK_EQUAL_WAVES(settings, settingsRef, mode = WAVE_DATA, tol = 1e-13)
 End
 
+static Function GetLastSettingFindsWithinNonConsecutiveSweepOrder()
+
+	string   key
+	variable chunkPassed
+	variable sweepNo = 41
+	DFREF    dfr     = root:Labnotebook_misc:
+
+	WAVE/SDFR=dfr numericalValuesTest
+
+	key         = CreateAnaFuncLBNKey(PSQ_RHEOBASE, PSQ_FMT_LBN_CHUNK_PASS, chunk = 0, query = 1)
+	chunkPassed = GetLastSettingIndep(numericalValuesTest, sweepNo, key, UNKNOWN_MODE, defValue = NaN)
+	CHECK_EQUAL_VAR(chunkPassed, 0)
+End
+
 Function GetLastSettingQueryWoMatch()
 
 	variable first, last


### PR DESCRIPTION
Fixes a LNB readout issue that appears if sweep numbers are not consecutively increasing in the LNB due to speculative LNB entries written from analysisfunctions.

- [x] tests