### PR TITLE
Utils: Extend DeleteWavePoint with the option of an indice wave as argument

### DIFF
--- a/Packages/MIES/MIES_AnalysisBrowser.ipf
+++ b/Packages/MIES/MIES_AnalysisBrowser.ipf
@@ -1414,8 +1414,8 @@ static Function AB_CollapseListEntry(variable row, variable col)
 			endif
 		endfor
 		if(!hasTreeView)
-			DeleteWavePoint(expBrowserSel, ROWS, i)
-			DeleteWavePoint(expBrowserList, ROWS, i)
+			DeleteWavePoint(expBrowserSel, ROWS, index = i)
+			DeleteWavePoint(expBrowserList, ROWS, index = i)
 		endif
 	endfor
 End
@@ -2529,8 +2529,8 @@ static Function AB_RemoveExperimentEntry(string win, string entry)
 		if(!CmpStr(list[i][%type][1], entry, 1))
 			mapIndex = str2num(list[i][%file][1])
 			AB_RemoveMapEntry(mapIndex)
-			DeleteWavePoint(list, ROWS, i)
-			DeleteWavePoint(sel, ROWS, i)
+			DeleteWavePoint(list, ROWS, index = i)
+			DeleteWavePoint(sel, ROWS, index = i)
 			cnt += 1
 		endif
 	endfor
@@ -2819,8 +2819,8 @@ Function AB_ButtonProc_Refresh(ba) : ButtonControl
 				entry = folderList[index]
 				if(!FileExists(entry) && !FolderExists(entry))
 					AB_RemoveExperimentEntry(ba.win, folderList[index])
-					DeleteWavePoint(folderSelection, ROWS, index)
-					DeleteWavePoint(folderList, ROWS, index)
+					DeleteWavePoint(folderSelection, ROWS, index = index)
+					DeleteWavePoint(folderList, ROWS, index = index)
 				else
 					refreshList[refreshIndex] = entry
 					refreshIndex             += 1
@@ -2894,8 +2894,8 @@ Function AB_ButtonProc_Remove(ba) : ButtonControl
 			for(i = size - 1; i >= 0; i -= 1)
 				if(folderSelection[i] == 1)
 					AB_RemoveExperimentEntry(ba.win, folderList[i])
-					DeleteWavePoint(folderSelection, ROWS, i)
-					DeleteWavePoint(folderList, ROWS, i)
+					DeleteWavePoint(folderSelection, ROWS, index = i)
+					DeleteWavePoint(folderList, ROWS, index = i)
 				endif
 			endfor
 			AB_SaveSourceListInSettings()

--- a/Packages/MIES/MIES_Async.ipf
+++ b/Packages/MIES/MIES_Async.ipf
@@ -280,7 +280,7 @@ Function ASYNC_IsWorkloadClassDone(string workloadClass, [variable removeClass])
 	done = (track[%$workloadClass][%INPUTCOUNT] - track[%$workloadClass][%OUTPUTCOUNT]) == 0
 
 	if(removeClass && done)
-		DeleteWavePoint(track, ROWS, index)
+		DeleteWavePoint(track, ROWS, index = index)
 	endif
 
 	return done

--- a/Packages/MIES/MIES_DataAcquisition_Multi.ipf
+++ b/Packages/MIES/MIES_DataAcquisition_Multi.ipf
@@ -391,7 +391,7 @@ static Function DQM_RemoveDevice(device, deviceID)
 	WAVE ActiveDeviceList = GetDQMActiveDeviceList()
 
 	row = DQM_GetActiveDeviceRow(deviceID)
-	DeleteWavePoint(ActiveDeviceList, ROWS, row)
+	DeleteWavePoint(ActiveDeviceList, ROWS, index = row)
 End
 
 /// @brief Return the row into `ActiveDeviceList` for the given deviceID

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -4566,15 +4566,25 @@ End
 ///
 /// @param dim dimension 0 - rows, 1 - column, 2 - layer, 3 - chunk
 ///
-/// @param index index where one point in the given dimension is deleted
-Function DeleteWavePoint(wv, dim, index)
-	WAVE wv
-	variable dim, index
+/// @param index   [optional, default n/a] index where one point in the given dimension is deleted
+/// @param indices [optional, default n/a] 1d numerical wave with indices of points to delete
+Function DeleteWavePoint(WAVE wv, variable dim, [variable index, WAVE indices])
 
 	variable size
 
+	ASSERT(ParamIsDefault(index) + ParamIsDefault(indices) == 1, "One of index or indices wave must be given as argument")
 	ASSERT(WaveExists(wv), "wave does not exist")
 	ASSERT(dim >= 0 && dim < 4, "dim must be 0, 1, 2 or 3")
+	if(!ParamIsDefault(indices))
+		ASSERT(WaveExists(indices), "indices wave is null")
+		ASSERT(IsNumericWave(indices), "indices wave must be numeric")
+		ASSERT(DimSize(indices, ROWS), "indices wave must have at least one element")
+		Sort/R {indices}, indices
+		for(index : indices)
+			DeleteWavePoint(wv, dim, index = index)
+		endfor
+		return NaN
+	endif
 	size = DimSize(wv, dim)
 	if(index >= 0 && index < size)
 		if(size > 1)

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -1152,7 +1152,7 @@ Function/WAVE GetDQMActiveDeviceList()
 			Redimension/D/N=(-1, -1) wv
 		endif
 		if(WaveVersionIsSmaller(wv, 3))
-			DeleteWavePoint(wv, COLS, 2)
+			DeleteWavePoint(wv, COLS, index = 2)
 		endif
 	else
 		Make/D/N=(0, 4) dfr:ActiveDeviceList/WAVE=wv

--- a/Packages/tests/Basic/UTF_Utils.ipf
+++ b/Packages/tests/Basic/UTF_Utils.ipf
@@ -2385,7 +2385,7 @@ Function DWP_InvalidWave()
 
 	WAVE/Z wv = $""
 	try
-		DeleteWavePoint(wv, ROWS, 0)
+		DeleteWavePoint(wv, ROWS, index = 0)
 		FAIL()
 	catch
 		PASS()
@@ -2401,7 +2401,7 @@ Function DWP_InvalidDim()
 
 	for(i = 0; i < numpnts(fDims); i += 1)
 		try
-			DeleteWavePoint(wv, fDims[i], 0)
+			DeleteWavePoint(wv, fDims[i], index = 0)
 			FAIL()
 		catch
 			PASS()
@@ -2418,12 +2418,68 @@ Function DWP_InvalidIndex()
 
 	for(i = 0; i < numpnts(fInd); i += 1)
 		try
-			DeleteWavePoint(wv, ROWS, fInd[i])
+			DeleteWavePoint(wv, ROWS, index = fInd[i])
 			FAIL()
 		catch
 			PASS()
 		endtry
 	endfor
+End
+
+static Function DWP_NoArg()
+
+	Make/FREE/N=1 wv
+	try
+		DeleteWavePoint(wv, ROWS)
+		FAIL()
+	catch
+		PASS()
+	endtry
+End
+
+static Function DWP_BothArgs()
+
+	Make/FREE/N=1 wv
+	try
+		DeleteWavePoint(wv, ROWS, index = 0, indices = {0})
+		FAIL()
+	catch
+		PASS()
+	endtry
+End
+
+static Function DWP_IndicesDontExist()
+
+	Make/FREE/N=1 wv
+	try
+		DeleteWavePoint(wv, ROWS, indices = $"")
+		FAIL()
+	catch
+		PASS()
+	endtry
+
+	Make/FREE/N=0 indices
+	try
+		DeleteWavePoint(wv, ROWS, indices = indices)
+		FAIL()
+	catch
+		PASS()
+	endtry
+End
+
+static Function DWP_InvalidIndices()
+
+	variable i
+
+	Make/FREE/N=1 wv
+	Make/FREE/N=4 fInd = {-1, 2, NaN, Inf}
+
+	try
+		DeleteWavePoint(wv, ROWS, index = fInd[i])
+		FAIL()
+	catch
+		PASS()
+	endtry
 End
 
 Function DWP_DeleteFromEmpty()
@@ -2433,7 +2489,7 @@ Function DWP_DeleteFromEmpty()
 	Make/FREE/N=0 wv
 
 	try
-		DeleteWavePoint(wv, ROWS, 0)
+		DeleteWavePoint(wv, ROWS, index = 0)
 		FAIL()
 	catch
 		PASS()
@@ -2443,33 +2499,48 @@ End
 Function DWP_Check1D()
 
 	Make/FREE/N=3 wv = {0, 1, 2}
-	DeleteWavePoint(wv, ROWS, 1)
+	DeleteWavePoint(wv, ROWS, index = 1)
 	CHECK_EQUAL_WAVES(wv, {0, 2})
-	DeleteWavePoint(wv, ROWS, 1)
+	DeleteWavePoint(wv, ROWS, index = 1)
 	CHECK_EQUAL_WAVES(wv, {0})
-	DeleteWavePoint(wv, ROWS, 0)
+	DeleteWavePoint(wv, ROWS, index = 0)
 	CHECK_EQUAL_VAR(DimSize(wv, ROWS), 0)
+End
+
+static Function DWP_Check1DIndices()
+
+	Make/FREE/N=3 wv = {0, 1, 2}
+	DeleteWavePoint(wv, ROWS, indices = {1})
+	CHECK_EQUAL_WAVES(wv, {0, 2})
+	DeleteWavePoint(wv, ROWS, indices = {1})
+	CHECK_EQUAL_WAVES(wv, {0})
+	DeleteWavePoint(wv, ROWS, indices = {0})
+	CHECK_EQUAL_VAR(DimSize(wv, ROWS), 0)
+
+	Make/FREE/N=3 wv = {0, 1, 2}
+	DeleteWavePoint(wv, ROWS, indices = {0, 1})
+	CHECK_EQUAL_WAVES(wv, {2})
 End
 
 Function DWP_Check2D()
 
 	Make/FREE/N=(3, 3) wv
 	wv = p + DimSize(wv, COLS) * q
-	DeleteWavePoint(wv, ROWS, 1)
+	DeleteWavePoint(wv, ROWS, index = 1)
 	CHECK_EQUAL_WAVES(wv, {{0, 2}, {3, 5}, {6, 8}})
-	DeleteWavePoint(wv, ROWS, 1)
+	DeleteWavePoint(wv, ROWS, index = 1)
 	CHECK_EQUAL_WAVES(wv, {{0}, {3}, {6}})
-	DeleteWavePoint(wv, ROWS, 0)
+	DeleteWavePoint(wv, ROWS, index = 0)
 	CHECK_EQUAL_VAR(DimSize(wv, ROWS), 0)
 	CHECK_EQUAL_VAR(DimSize(wv, COLS), 3)
 
 	Make/O/FREE/N=(3, 3) wv
 	wv = p + DimSize(wv, COLS) * q
-	DeleteWavePoint(wv, COLS, 1)
+	DeleteWavePoint(wv, COLS, index = 1)
 	CHECK_EQUAL_WAVES(wv, {{0, 1, 2}, {6, 7, 8}})
-	DeleteWavePoint(wv, COLS, 1)
+	DeleteWavePoint(wv, COLS, index = 1)
 	CHECK_EQUAL_WAVES(wv, {{0, 1, 2}})
-	DeleteWavePoint(wv, COLS, 0)
+	DeleteWavePoint(wv, COLS, index = 0)
 	CHECK_EQUAL_VAR(DimSize(wv, ROWS), 3)
 	CHECK_EQUAL_VAR(DimSize(wv, COLS), 0)
 End
@@ -2478,33 +2549,33 @@ Function DWP_Check3D()
 
 	Make/FREE/N=(3, 3, 3) wv
 	wv = p + DimSize(wv, COLS) * q + DimSize(wv, COLS) * DimSize(wv, LAYERS) * r
-	DeleteWavePoint(wv, ROWS, 1)
+	DeleteWavePoint(wv, ROWS, index = 1)
 	CHECK_EQUAL_WAVES(wv, {{{0, 2}, {3, 5}, {6, 8}}, {{9, 11}, {12, 14}, {15, 17}}, {{18, 20}, {21, 23}, {24, 26}}})
-	DeleteWavePoint(wv, ROWS, 1)
+	DeleteWavePoint(wv, ROWS, index = 1)
 	CHECK_EQUAL_WAVES(wv, {{{0}, {3}, {6}}, {{9}, {12}, {15}}, {{18}, {21}, {24}}})
-	DeleteWavePoint(wv, ROWS, 0)
+	DeleteWavePoint(wv, ROWS, index = 0)
 	CHECK_EQUAL_VAR(DimSize(wv, ROWS), 0)
 	CHECK_EQUAL_VAR(DimSize(wv, COLS), 3)
 	CHECK_EQUAL_VAR(DimSize(wv, LAYERS), 3)
 
 	Make/O/FREE/N=(3, 3, 3) wv
 	wv = p + DimSize(wv, COLS) * q + DimSize(wv, COLS) * DimSize(wv, LAYERS) * r
-	DeleteWavePoint(wv, COLS, 1)
+	DeleteWavePoint(wv, COLS, index = 1)
 	CHECK_EQUAL_WAVES(wv, {{{0, 1, 2}, {6, 7, 8}}, {{9, 10, 11}, {15, 16, 17}}, {{18, 19, 20}, {24, 25, 26}}})
-	DeleteWavePoint(wv, COLS, 1)
+	DeleteWavePoint(wv, COLS, index = 1)
 	CHECK_EQUAL_WAVES(wv, {{{0, 1, 2}}, {{9, 10, 11}}, {{18, 19, 20}}})
-	DeleteWavePoint(wv, COLS, 0)
+	DeleteWavePoint(wv, COLS, index = 0)
 	CHECK_EQUAL_VAR(DimSize(wv, ROWS), 3)
 	CHECK_EQUAL_VAR(DimSize(wv, COLS), 0)
 	CHECK_EQUAL_VAR(DimSize(wv, LAYERS), 3)
 
 	Make/O/FREE/N=(3, 3, 3) wv
 	wv = p + DimSize(wv, COLS) * q + DimSize(wv, COLS) * DimSize(wv, LAYERS) * r
-	DeleteWavePoint(wv, LAYERS, 1)
+	DeleteWavePoint(wv, LAYERS, index = 1)
 	CHECK_EQUAL_WAVES(wv, {{{0, 1, 2}, {3, 4, 5}, {6, 7, 8}}, {{18, 19, 20}, {21, 22, 23}, {24, 25, 26}}})
-	DeleteWavePoint(wv, LAYERS, 1)
+	DeleteWavePoint(wv, LAYERS, index = 1)
 	CHECK_EQUAL_WAVES(wv, {{{0, 1, 2}, {3, 4, 5}, {6, 7, 8}}})
-	DeleteWavePoint(wv, LAYERS, 0)
+	DeleteWavePoint(wv, LAYERS, index = 0)
 	CHECK_EQUAL_VAR(DimSize(wv, ROWS), 3)
 	CHECK_EQUAL_VAR(DimSize(wv, COLS), 3)
 	CHECK_EQUAL_VAR(DimSize(wv, LAYERS), 0)
@@ -2515,21 +2586,21 @@ Function DWP_Check4D()
 	Make/FREE/N=(3, 3, 3, 3) wv
 	wv = p + DimSize(wv, COLS) * q + DimSize(wv, COLS) * DimSize(wv, LAYERS) * r + +DimSize(wv, COLS) * DimSize(wv, LAYERS) * DimSize(wv, CHUNKS) * s
 
-	DeleteWavePoint(wv, ROWS, 1)
+	DeleteWavePoint(wv, ROWS, index = 1)
 	Make/FREE/N=(2, 3, 3, 3) comp
 	comp[][][][0] = {{{0, 2}, {3, 5}, {6, 8}}, {{9, 11}, {12, 14}, {15, 17}}, {{18, 20}, {21, 23}, {24, 26}}}
 	comp[][][][1] = {{{27, 29}, {30, 32}, {33, 35}}, {{36, 38}, {39, 41}, {42, 44}}, {{45, 47}, {48, 50}, {51, 53}}}
 	comp[][][][2] = {{{54, 56}, {57, 59}, {60, 62}}, {{63, 65}, {66, 68}, {69, 71}}, {{72, 74}, {75, 77}, {78, 80}}}
 	CHECK_EQUAL_WAVES(wv, comp)
 
-	DeleteWavePoint(wv, ROWS, 1)
+	DeleteWavePoint(wv, ROWS, index = 1)
 	Make/O/FREE/N=(1, 3, 3, 3) comp
 	comp[][][][0] = {{{0}, {3}, {6}}, {{9}, {12}, {15}}, {{18}, {21}, {24}}}
 	comp[][][][1] = {{{27}, {30}, {33}}, {{36}, {39}, {42}}, {{45}, {48}, {51}}}
 	comp[][][][2] = {{{54}, {57}, {60}}, {{63}, {66}, {69}}, {{72}, {75}, {78}}}
 	CHECK_EQUAL_WAVES(wv, comp)
 
-	DeleteWavePoint(wv, ROWS, 0)
+	DeleteWavePoint(wv, ROWS, index = 0)
 	CHECK_EQUAL_VAR(DimSize(wv, ROWS), 0)
 	CHECK_EQUAL_VAR(DimSize(wv, COLS), 3)
 	CHECK_EQUAL_VAR(DimSize(wv, LAYERS), 3)
@@ -2538,21 +2609,21 @@ Function DWP_Check4D()
 	Make/O/FREE/N=(3, 3, 3, 3) wv
 	wv = p + DimSize(wv, COLS) * q + DimSize(wv, COLS) * DimSize(wv, LAYERS) * r + +DimSize(wv, COLS) * DimSize(wv, LAYERS) * DimSize(wv, CHUNKS) * s
 
-	DeleteWavePoint(wv, COLS, 1)
+	DeleteWavePoint(wv, COLS, index = 1)
 	Make/O/FREE/N=(3, 2, 3, 3) comp
 	comp[][][][0] = {{{0, 1, 2}, {6, 7, 8}}, {{9, 10, 11}, {15, 16, 17}}, {{18, 19, 20}, {24, 25, 26}}}
 	comp[][][][1] = {{{27, 28, 29}, {33, 34, 35}}, {{36, 37, 38}, {42, 43, 44}}, {{45, 46, 47}, {51, 52, 53}}}
 	comp[][][][2] = {{{54, 55, 56}, {60, 61, 62}}, {{63, 64, 65}, {69, 70, 71}}, {{72, 73, 74}, {78, 79, 80}}}
 	CHECK_EQUAL_WAVES(wv, comp)
 
-	DeleteWavePoint(wv, COLS, 1)
+	DeleteWavePoint(wv, COLS, index = 1)
 	Make/O/FREE/N=(3, 1, 3, 3) comp
 	comp[][][][0] = {{{0, 1, 2}}, {{9, 10, 11}}, {{18, 19, 20}}}
 	comp[][][][1] = {{{27, 28, 29}}, {{36, 37, 38}}, {{45, 46, 47}}}
 	comp[][][][2] = {{{54, 55, 56}}, {{63, 64, 65}}, {{72, 73, 74}}}
 	CHECK_EQUAL_WAVES(wv, comp)
 
-	DeleteWavePoint(wv, COLS, 0)
+	DeleteWavePoint(wv, COLS, index = 0)
 	CHECK_EQUAL_VAR(DimSize(wv, ROWS), 3)
 	CHECK_EQUAL_VAR(DimSize(wv, COLS), 0)
 	CHECK_EQUAL_VAR(DimSize(wv, LAYERS), 3)
@@ -2561,21 +2632,21 @@ Function DWP_Check4D()
 	Make/O/FREE/N=(3, 3, 3, 3) wv
 	wv = p + DimSize(wv, COLS) * q + DimSize(wv, COLS) * DimSize(wv, LAYERS) * r + +DimSize(wv, COLS) * DimSize(wv, LAYERS) * DimSize(wv, CHUNKS) * s
 
-	DeleteWavePoint(wv, LAYERS, 1)
+	DeleteWavePoint(wv, LAYERS, index = 1)
 	Make/O/FREE/N=(3, 3, 2, 3) comp
 	comp[][][][0] = {{{0, 1, 2}, {3, 4, 5}, {6, 7, 8}}, {{18, 19, 20}, {21, 22, 23}, {24, 25, 26}}}
 	comp[][][][1] = {{{27, 28, 29}, {30, 31, 32}, {33, 34, 35}}, {{45, 46, 47}, {48, 49, 50}, {51, 52, 53}}}
 	comp[][][][2] = {{{54, 55, 56}, {57, 58, 59}, {60, 61, 62}}, {{72, 73, 74}, {75, 76, 77}, {78, 79, 80}}}
 	CHECK_EQUAL_WAVES(wv, comp)
 
-	DeleteWavePoint(wv, LAYERS, 1)
+	DeleteWavePoint(wv, LAYERS, index = 1)
 	Make/O/FREE/N=(3, 3, 1, 3) comp
 	comp[][][][0] = {{{0, 1, 2}, {3, 4, 5}, {6, 7, 8}}}
 	comp[][][][1] = {{{27, 28, 29}, {30, 31, 32}, {33, 34, 35}}}
 	comp[][][][2] = {{{54, 55, 56}, {57, 58, 59}, {60, 61, 62}}}
 	CHECK_EQUAL_WAVES(wv, comp)
 
-	DeleteWavePoint(wv, LAYERS, 0)
+	DeleteWavePoint(wv, LAYERS, index = 0)
 	CHECK_EQUAL_VAR(DimSize(wv, ROWS), 3)
 	CHECK_EQUAL_VAR(DimSize(wv, COLS), 3)
 	CHECK_EQUAL_VAR(DimSize(wv, LAYERS), 0)
@@ -2584,18 +2655,18 @@ Function DWP_Check4D()
 	Make/O/FREE/N=(3, 3, 3, 3) wv
 	wv = p + DimSize(wv, COLS) * q + DimSize(wv, COLS) * DimSize(wv, LAYERS) * r + +DimSize(wv, COLS) * DimSize(wv, LAYERS) * DimSize(wv, CHUNKS) * s
 
-	DeleteWavePoint(wv, CHUNKS, 1)
+	DeleteWavePoint(wv, CHUNKS, index = 1)
 	Make/O/FREE/N=(3, 3, 3, 2) comp
 	comp[][][][0] = {{{0, 1, 2}, {3, 4, 5}, {6, 7, 8}}, {{9, 10, 11}, {12, 13, 14}, {15, 16, 17}}, {{18, 19, 20}, {21, 22, 23}, {24, 25, 26}}}
 	comp[][][][1] = {{{54, 55, 56}, {57, 58, 59}, {60, 61, 62}}, {{63, 64, 65}, {66, 67, 68}, {69, 70, 71}}, {{72, 73, 74}, {75, 76, 77}, {78, 79, 80}}}
 	CHECK_EQUAL_WAVES(wv, comp)
 
-	DeleteWavePoint(wv, CHUNKS, 1)
+	DeleteWavePoint(wv, CHUNKS, index = 1)
 	Make/O/FREE/N=(3, 3, 3, 1) comp
 	comp[][][][0] = {{{0, 1, 2}, {3, 4, 5}, {6, 7, 8}}, {{9, 10, 11}, {12, 13, 14}, {15, 16, 17}}, {{18, 19, 20}, {21, 22, 23}, {24, 25, 26}}}
 	CHECK_EQUAL_WAVES(wv, comp)
 
-	DeleteWavePoint(wv, CHUNKS, 0)
+	DeleteWavePoint(wv, CHUNKS, index = 0)
 	CHECK_EQUAL_VAR(DimSize(wv, ROWS), 3)
 	CHECK_EQUAL_VAR(DimSize(wv, COLS), 3)
 	CHECK_EQUAL_VAR(DimSize(wv, LAYERS), 3)

--- a/Packages/tests/UTF_HelperFunctions.ipf
+++ b/Packages/tests/UTF_HelperFunctions.ipf
@@ -1160,10 +1160,7 @@ static Function TestEpochRecreationRemoveUnsupportedUserEpochs(WAVE/T epochChann
 		return NaN
 	endif
 	matches[] = userEpochIndices[matches[p]]
-	Sort/R matches, matches
-	for(index : matches)
-		DeleteWavePoint(epochChannel, ROWS, index)
-	endfor
+	DeleteWavePoint(epochChannel, ROWS, indices = matches)
 End
 
 Function TestEpochRecreation(string device, variable sweepNo)


### PR DESCRIPTION
- changed the API of DeleteWavePoint to accept either a single index value or a numerical wave with indices
- Added tests and adapted tests
- adapted call sites

close #2096 