### PR TITLE
Utils: Adapt FindIndizes with new property PROP_NOT to invert the matching

### DIFF
--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -305,12 +305,11 @@ StrConstant NOTE_INDEX = "Index"
 ///@name   Parameters for FindIndizes
 ///@anchor FindIndizesProps
 ///@{
-Constant PROP_NON_EMPTY                = 0x01 ///< Wave entry is not NaN or ""
-Constant PROP_EMPTY                    = 0x02 ///< Wave entry is NaN or ""
-Constant PROP_MATCHES_VAR_BIT_MASK     = 0x04 ///< Wave entry matches the bitmask given in var
-Constant PROP_NOT_MATCHES_VAR_BIT_MASK = 0x08 ///< Wave entry does not match the bitmask given in var
-Constant PROP_GREP                     = 0x10 ///< Wave entry matches the regular expression given in str
-Constant PROP_WILDCARD                 = 0x20 ///< Wave entry matches the wildcard expression given in str
+Constant PROP_NOT                  = 0x01 ///< Inverts the matching
+Constant PROP_EMPTY                = 0x02 ///< Wave entry is NaN or ""
+Constant PROP_MATCHES_VAR_BIT_MASK = 0x04 ///< Wave entry matches the bitmask given in var
+Constant PROP_GREP                 = 0x08 ///< Wave entry matches the regular expression given in str
+Constant PROP_WILDCARD             = 0x10 ///< Wave entry matches the wildcard expression given in str
 ///@}
 
 /// @name Parameters for GetPanelControl and IDX_GetSetsInRange, GetSetFolder, GetSetParamFolder and GetChanneListFromITCConfig

--- a/Packages/MIES/MIES_Debugging.ipf
+++ b/Packages/MIES/MIES_Debugging.ipf
@@ -678,7 +678,7 @@ threadsafe static Function/S CheckDimensionLabels(WAVE/Z wv)
 		Multithread results[] = CheckDimensionLabels(waveRef[p])
 
 		if(HasOneValidEntry(results))
-			WAVE/Z indizes = FindIndizes(results, prop = PROP_NON_EMPTY)
+			WAVE/Z indizes = FindIndizes(results, prop = PROP_EMPTY | PROP_NOT)
 			numMatches = WaveExists(indizes) ? DimSize(indizes, ROWS) : 0
 
 			for(i = 0; i < numMatches; i += 1)

--- a/Packages/MIES/MIES_Labnotebook.ipf
+++ b/Packages/MIES/MIES_Labnotebook.ipf
@@ -110,7 +110,7 @@ End
 /// at least once, an empty string otherwise
 threadsafe static Function/S LBV_IsLabnotebookColumnFilled(WAVE values, variable col)
 
-	WAVE/Z indizes = FindIndizes(values, col = col, prop = PROP_NON_EMPTY, startLayer = 0, endLayer = LABNOTEBOOK_LAYER_COUNT - 1)
+	WAVE/Z indizes = FindIndizes(values, col = col, prop = PROP_EMPTY | PROP_NOT, startLayer = 0, endLayer = LABNOTEBOOK_LAYER_COUNT - 1)
 
 	if(WaveExists(indizes))
 		return GetDimLabel(values, COLS, col)

--- a/Packages/MIES/MIES_LogbookViewer.ipf
+++ b/Packages/MIES/MIES_LogbookViewer.ipf
@@ -682,7 +682,7 @@ static Function LBV_AddTraceToLBGraphTPStorage(string graph, DFREF dfr, string k
 			// ignore completely empty headstages
 			if(!legacyActiveADColumns)
 				searchLayer = FindDimLabel(TPStorage, LAYERS, "Headstage")
-				WAVE/Z indizes = FindIndizes(TPStorage, col = j, prop = PROP_NON_EMPTY, startLayer = searchLayer, endLayer = searchLayer)
+				WAVE/Z indizes = FindIndizes(TPStorage, col = j, prop = PROP_EMPTY | PROP_NOT, startLayer = searchLayer, endLayer = searchLayer)
 
 				if(!WaveExists(indizes))
 					continue

--- a/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
+++ b/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
@@ -1083,7 +1083,7 @@ threadsafe static Function NWB_AppendSweepLowLevel(STRUCT NWBAsyncParameters &s)
 	if(!WaveExists(electrodeNames))
 		Make/FREE/T/N=(NUM_HEADSTAGES) electrodeNames = GetDefaultElectrodeName(p)
 	else
-		WAVE/Z nonEmptyElectrodes = FindIndizes(electrodeNames, prop = PROP_NON_EMPTY)
+		WAVE/Z nonEmptyElectrodes = FindIndizes(electrodeNames, prop = PROP_EMPTY | PROP_NOT)
 		if(!WaveExists(nonEmptyElectrodes)) // all are empty
 			electrodeNames[] = GetDefaultElectrodeName(p)
 		endif

--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -5467,16 +5467,31 @@ End
 /// @brief Turn a list of entries into a regular expression with alternations.
 ///
 /// Can be used for GetListOfObjects() if you know in advance which entries to filter out.
-Function/S ConvertListToRegexpWithAlternations(list)
-	string list
+///
+/// @param list    semicolon separated list of strings to match
+/// @param literal [optional, default = 1] when this flag is cleared the string elements of the list are treated as regular expressions
+/// @param sep     [optional, default = ";"] separator for list
+Function/S ConvertListToRegexpWithAlternations(string list, [variable literal, string sep])
 
 	variable i, numEntries
-	string entry
-	string regexpList = ""
+	string regexpList    = ""
+	string literalPrefix = "\\Q"
+	string literalSuffix = "\\E"
 
-	numEntries = ItemsInList(list)
+	literal = ParamIsDefault(literal) ? 1 : !!literal
+	if(ParamIsDefault(sep))
+		sep = ";"
+	else
+		ASSERT(!IsEmpty(sep), "separator can not be empty.")
+	endif
+
+	if(!literal)
+		literalPrefix = ""
+		literalSuffix = ""
+	endif
+	numEntries = ItemsInList(list, sep)
 	for(i = 0; i < numEntries; i += 1)
-		regexpList = AddListItem("\\Q" + StringFromList(i, list) + "\\E", regexpList, "|", Inf)
+		regexpList = AddListItem(literalPrefix + StringFromList(i, list, sep) + literalSuffix, regexpList, "|", Inf)
 	endfor
 
 	regexpList = "(?:" + RemoveEnding(regexpList, "|") + ")"

--- a/Packages/tests/Basic/UTF_Utils.ipf
+++ b/Packages/tests/Basic/UTF_Utils.ipf
@@ -1124,6 +1124,14 @@ Function FI_NumSearchWithCol1()
 	CHECK_EQUAL_WAVES(indizes, {0, 1, 2}, mode = WAVE_DATA)
 End
 
+static Function FI_NumSearchWithCol1Inverted()
+	DFREF dfr = root:FindIndizes
+	WAVE/SDFR=dfr numeric
+
+	WAVE/Z indizes = FindIndizes(numeric, var = 1, prop = PROP_NOT)
+	CHECK_EQUAL_WAVES(indizes, {3, 4}, mode = WAVE_DATA)
+End
+
 Function FI_NumSearchWithColAndLayer1()
 	DFREF dfr = root:FindIndizes
 	WAVE/SDFR=dfr numeric
@@ -1176,7 +1184,7 @@ Function FI_NumSearchWithColAndProp1()
 	DFREF dfr = root:FindIndizes
 	WAVE/SDFR=dfr numeric
 
-	WAVE/Z indizes = FindIndizes(numeric, colLabel = "abcd", prop = PROP_NON_EMPTY)
+	WAVE/Z indizes = FindIndizes(numeric, colLabel = "abcd", prop = PROP_EMPTY | PROP_NOT)
 	CHECK_EQUAL_WAVES(indizes, {0, 1, 2}, mode = WAVE_DATA)
 End
 
@@ -1200,7 +1208,7 @@ Function FI_NumSearchWithColAndProp4()
 	DFREF dfr = root:FindIndizes
 	WAVE/SDFR=dfr numeric
 
-	WAVE/Z indizes = FindIndizes(numeric, col = 1, var = 2, prop = PROP_NOT_MATCHES_VAR_BIT_MASK)
+	WAVE/Z indizes = FindIndizes(numeric, col = 1, var = 2, prop = PROP_MATCHES_VAR_BIT_MASK | PROP_NOT)
 	CHECK_EQUAL_WAVES(indizes, {0}, mode = WAVE_DATA)
 End
 
@@ -1212,12 +1220,28 @@ Function FI_NumSearchWithColAndProp5()
 	CHECK_EQUAL_WAVES(indizes, {3}, mode = WAVE_DATA)
 End
 
+static Function FI_NumSearchWithColAndProp5Inverted()
+	DFREF dfr = root:FindIndizes
+	WAVE/SDFR=dfr numeric
+
+	WAVE/Z indizes = FindIndizes(numeric, col = 1, str = "6+", prop = PROP_GREP | PROP_NOT)
+	CHECK_EQUAL_WAVES(indizes, {0, 1, 2, 4}, mode = WAVE_DATA)
+End
+
 Function FI_NumSearchWithColAndProp6()
 	DFREF dfr = root:FindIndizes
 	WAVE/SDFR=dfr numeric
 
 	WAVE/Z indizes = FindIndizes(numeric, col = 1, str = "6*", prop = PROP_WILDCARD)
 	CHECK_EQUAL_WAVES(indizes, {3}, mode = WAVE_DATA)
+End
+
+static Function FI_NumSearchWithColAndProp6Inverted()
+	DFREF dfr = root:FindIndizes
+	WAVE/SDFR=dfr numeric
+
+	WAVE/Z indizes = FindIndizes(numeric, col = 1, str = "6*", prop = PROP_WILDCARD | PROP_NOT)
+	CHECK_EQUAL_WAVES(indizes, {0, 1, 2, 4}, mode = WAVE_DATA)
 End
 
 Function FI_NumSearchWithColAndProp6a()
@@ -1304,7 +1328,7 @@ Function FI_TextSearchWithColAndProp1()
 	DFREF dfr = root:FindIndizes
 	WAVE/SDFR=dfr text
 
-	WAVE/Z indizes = FindIndizes(text, colLabel = "efgh", prop = PROP_NON_EMPTY)
+	WAVE/Z indizes = FindIndizes(text, colLabel = "efgh", prop = PROP_EMPTY | PROP_NOT)
 	CHECK_EQUAL_WAVES(indizes, {0, 1, 2}, mode = WAVE_DATA)
 End
 
@@ -1328,7 +1352,7 @@ Function FI_TextSearchWithColAndProp4()
 	DFREF dfr = root:FindIndizes
 	WAVE/SDFR=dfr text
 
-	WAVE/Z indizes = FindIndizes(text, col = 1, str = "2", prop = PROP_NOT_MATCHES_VAR_BIT_MASK)
+	WAVE/Z indizes = FindIndizes(text, col = 1, str = "2", prop = PROP_MATCHES_VAR_BIT_MASK | PROP_NOT)
 	CHECK_EQUAL_WAVES(indizes, {0}, mode = WAVE_DATA)
 End
 

--- a/Packages/tests/Basic/UTF_Utils.ipf
+++ b/Packages/tests/Basic/UTF_Utils.ipf
@@ -8077,3 +8077,27 @@ static Function HWS_Works()
 	CHECK_EQUAL_VAR(HasWildcardSyntax("!a"), 1)
 	CHECK_EQUAL_VAR(HasWildcardSyntax("a*b"), 1)
 End
+
+static Function ConvertListToRegexpWithAlternations_Test()
+
+	string str, ref
+
+	str = ConvertListToRegexpWithAlternations("1;2;")
+	ref = "(?:\\Q1\\E|\\Q2\\E)"
+	CHECK_EQUAL_STR(ref, str)
+
+	str = ConvertListToRegexpWithAlternations("1;2;", literal = 0)
+	ref = "(?:1|2)"
+	CHECK_EQUAL_STR(ref, str)
+
+	str = ConvertListToRegexpWithAlternations("1#2#", literal = 0, sep = "#")
+	ref = "(?:1|2)"
+	CHECK_EQUAL_STR(ref, str)
+
+	try
+		str = ConvertListToRegexpWithAlternations("1#2#", sep = "")
+		FAIL()
+	catch
+		PASS()
+	endtry
+End

--- a/Packages/tests/HardwareBasic/UTF_Epochs.ipf
+++ b/Packages/tests/HardwareBasic/UTF_Epochs.ipf
@@ -66,7 +66,7 @@ static Function [WAVE startT, WAVE endT, WAVE levels, WAVE/T description] Remove
 	WAVE/Z levels = ZapNans(levels_sub)
 	CHECK_WAVE(levels, NUMERIC_WAVE)
 
-	WAVE/Z indizes = FindIndizes(description_sub, prop = PROP_NON_EMPTY)
+	WAVE/Z indizes = FindIndizes(description_sub, prop = PROP_EMPTY | PROP_NOT)
 	if(WaveExists(indizes))
 		Make/N=(DimSize(indizes, ROWS))/T/FREE description = description_sub[indizes[p]]
 	endif

--- a/Packages/tests/UTF_HelperFunctions.ipf
+++ b/Packages/tests/UTF_HelperFunctions.ipf
@@ -1011,7 +1011,7 @@ Function [string abWin, string sweepBrowsers] OpenAnalysisBrowser(WAVE/T files, 
 	WAVE/T expBrowserList = GetExperimentBrowserGUIList()
 	WAVE   expBrowserSel  = GetExperimentBrowserGUISel()
 
-	WAVE/Z indizes = FindIndizes(expBrowserList, colLabel = "file", prop = PROP_NON_EMPTY)
+	WAVE/Z indizes = FindIndizes(expBrowserList, colLabel = "file", prop = PROP_EMPTY | PROP_NOT)
 
 	if(loadSweeps)
 		for(idx : indizes)

--- a/Packages/tests/UTF_HelperFunctions.ipf
+++ b/Packages/tests/UTF_HelperFunctions.ipf
@@ -1146,16 +1146,14 @@ static Function TestEpochRecreationRemoveUnsupportedUserEpochs(WAVE/T epochChann
 	if(type == PSQ_CHIRP)
 		Concatenate/FREE/T/NP {psqChirpEpochs}, supportedUserEpochs
 	endif
-	supportedUserEpochsRegExp = TextWaveToList(supportedUserEpochs, "|")
-	supportedUserEpochsRegExp = RemoveEnding(supportedUserEpochsRegExp, "|")
-	supportedUserEpochsRegExp = "^(?![\s\S]*" + supportedUserEpochsRegExp + ")[\s\S]*$"
+	supportedUserEpochsRegExp = ConvertListToRegexpWithAlternations(RemoveEnding(TextWaveToList(supportedUserEpochs, ";"), ";"), literal = 0)
 	Make/FREE/T/N=(DimSize(epochChannel, ROWS)) shortnames = EP_GetShortName(epochChannel[p][EPOCH_COL_TAGS])
 	WAVE/Z userEpochIndices = FindIndizes(shortNames, str = regexpUserEpochs, prop = PROP_GREP)
 	if(!WaveExists(userEpochIndices))
 		return NaN
 	endif
 	Make/FREE/T/N=(DimSize(userEpochIndices, ROWS)) userEpochShortNames = shortnames[userEpochIndices[p]]
-	WAVE/Z matches = FindIndizes(userEpochShortNames, str = supportedUserEpochsRegExp, prop = PROP_GREP)
+	WAVE/Z matches = FindIndizes(userEpochShortNames, str = supportedUserEpochsRegExp, prop = PROP_GREP | PROP_NOT)
 	if(!WaveExists(matches))
 		return NaN
 	endif


### PR DESCRIPTION
- PROP_NOT can be set additionally to the other properties and also alone
- PROP_NON_EMPTY and PROP_NOT_MATCHES_VAR_BIT_MASK were removed as these are now obsolete
- adapted the argument checking in FindIndizes
- adapted call sites for FindIndizes that were using now obsolete constants

- added tests for setting PROP_NOT only

- Extended ConvertListToRegexpWithAlternations with required features, added tests
- adapted TestEpochRecreationRemoveUnsupportedUserEpochs

close #2095