### PR TITLE
Debug: Add define DISABLE_WAVECACHE to disable caching of waves

### DIFF
--- a/Packages/MIES/MIES_Cache.ipf
+++ b/Packages/MIES/MIES_Cache.ipf
@@ -525,6 +525,10 @@ threadsafe Function CA_StoreEntryIntoCache(key, val, [options])
 
 	variable index, storeDuplicate, foundIndex
 
+#ifdef WAVECACHE_DISABLED
+	return NaN
+#endif
+
 	if(ParamIsDefault(options))
 		storeDuplicate = 1
 	else
@@ -597,6 +601,10 @@ threadsafe Function/WAVE CA_TryFetchingEntryFromCache(key, [options])
 	variable options
 
 	variable index, returnDuplicate
+
+#ifdef WAVECACHE_DISABLED
+	return $""
+#endif
 
 	if(ParamIsDefault(options))
 		returnDuplicate = 1

--- a/Packages/MIES/MIES_Debugging.ipf
+++ b/Packages/MIES/MIES_Debugging.ipf
@@ -500,6 +500,16 @@ Function EnableThreadsafeSupport()
 	Execute/P/Q "SetIgorOption DisableThreadsafe=0"
 End
 
+/// @brief Disable wave caching support
+Function DisableWaveCache()
+	Execute/P/Q "SetIgorOption poundDefine=WAVECACHE_DISABLED"
+End
+
+/// @brief Enable wave caching support again
+Function EnableWaveCache()
+	Execute/P/Q "SetIgorOption poundUnDefine=WAVECACHE_DISABLED"
+End
+
 /// @brief Enable dangerous debugging (allows to call user-defined functions in the debugger)
 Function EnableDangerousDebugging()
 

--- a/Packages/tests/Compilation/CompilationTester.ipf
+++ b/Packages/tests/Compilation/CompilationTester.ipf
@@ -66,6 +66,8 @@ Function/WAVE GetDefines()
 	                       "TESTS_WITH_ITC1600_HARDWARE",  \
 	                       "TESTS_WITH_ITC18USB_HARDWARE", \
 	                       "TESTS_WITH_NI_HARDWARE",       \
+	                       "TESTS_WITH_SUTTER_HARDWARE",   \
+	                       "WAVECACHE_DISABLED",           \
 	                       "THREADING_DISABLED"}
 
 	SetDimensionLabelsFromWaveContents(defines)


### PR DESCRIPTION
- added utility function EnableWaveCache and DisableWaveCache

When the define is set, all storing attempts and fetching attempts do nothing, i.e. fetching returns a null wave as if there is a cache miss.

When the define is set the cache state is not changed.

close #2090

requires https://github.com/byte-physics/igortest/pull/469