### PR TITLE
OOD: fix for oodDAQ cutting off one point too much from BL trail

### DIFF
--- a/Packages/MIES/MIES_OptimzedOverlapDistributedAcquisition.ipf
+++ b/Packages/MIES/MIES_OptimzedOverlapDistributedAcquisition.ipf
@@ -358,6 +358,8 @@ static Function/WAVE OOD_CreateStimSet(params)
 	return stimSetsWithOffset
 End
 
+/// @brief Here the trailing baseline is of the stimset column removed (postFeatureTime)
+///        The last feature amplitude should stay as DA signal until the whole stimset (all columns) ends
 Function/WAVE OOD_OffsetStimSetColAndCutoff(WAVE stimSet, variable column, variable offset, variable postFeaturePoints)
 
 	variable length, cutoff
@@ -376,7 +378,7 @@ Function/WAVE OOD_OffsetStimSetColAndCutoff(WAVE stimSet, variable column, varia
 	FindLevel/P/EDGE=2/Q/R=[DimSize(acc, ROWS) - 1, 0] acc, level
 
 	if(!V_flag && acc[length - 1] < level)
-		cutoff = V_levelX + postFeaturePoints
+		cutoff = round(V_levelX) + postFeaturePoints
 		Redimension/N=(cutoff) acc
 	endif
 


### PR DESCRIPTION
Due to a missing proper rounding to an integer index before using the index in Redimension where internally trunc(index) is used, oodDAQ was cutting off one point too much from the stimset. The effect was that e.g. preceding pulses were shortened by one sample point.

since
d102c07d (Add new data acquisition mode: Optimized overlap distributed acquisition, 2016-08-10)

- [x] test

close #1993