### PR TITLE
Fix version number style of ACL_UserDataEditor.ipf

### DIFF
--- a/Packages/MIES/ACL_UserdataEditor.ipf
+++ b/Packages/MIES/ACL_UserdataEditor.ipf
@@ -1,5 +1,5 @@
 #pragma rtGlobals=1		// Use modern global access method.
-#pragma version = 1.0.0.0
+#pragma version = 1.0
 #pragma IgorVersion = 6		// requires Igor 6 or later
 #pragma IndependentModule=ACL_UserDataEditor
 // ********************


### PR DESCRIPTION
Igor doesn't allow [semver](https://semver.org/) like versions like `1.0.0.0` and ignores anything after the first floating point number `1.0`.

This is not a bug per se, but it looks cleaner if any invalid characters are removed.

