### PR TITLE
SFH: Allow a single promotion of datasets to higher level for range specification

### DIFF
--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -5392,19 +5392,12 @@ End
 
 static Function/WAVE SF_ResolveDataset(WAVE input)
 
-	string wName, tmpStr
-
 	ASSERT(IsTextWave(input) && DimSize(input, ROWS) == 1 && DimSize(input, COLS) == 0, "Unknown SF argument input format")
 
-	WAVE/T wvt = input
-	ASSERT(strsearch(wvt[0], SF_WREF_MARKER, 0) == 0, "Marker not found in SF argument")
+	WAVE/Z resolve = SFH_AttemptDatasetResolve(WaveText(input, row = 0))
+	ASSERT(WaveExists(resolve), "Could not resolve dataset from wave element")
 
-	tmpStr = wvt[0]
-	wName  = tmpStr[strlen(SF_WREF_MARKER), Inf]
-	WAVE/Z out = $wName
-	ASSERT(WaveExists(out), "Referenced wave not found: " + wName)
-
-	return out
+	return resolve
 End
 
 Function/S SF_GetDefaultFormula()

--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -1675,6 +1675,8 @@ static Function SF_FormulaPlotter(string graph, string formula, [DFREF dfr, vari
 				continue
 			endif
 
+			SF_FormulaPlotterExtendResultsIfCompatible(formulaResults)
+
 			numData = DimSize(formulaResults, ROWS)
 			for(k = 0; k < numData; k += 1)
 
@@ -5627,4 +5629,55 @@ static Function [WAVE outNum, WAVE/T outText] SF_ExecutorCreateOrCheckTextual(WA
 	endif
 
 	return [out, outT]
+End
+
+/// @brief This function extends formulaResults if possible. For each result from a Y formula it is attempted to move datasets from inside an array outside in the form
+///        [dataset(1, 2), dataset(3, 4)] -> dataset([1, 3], [3, 4])
+///        because the plotter can iterate over datasets only at the outermost occurrence.
+///        As result the inside elements may be plottable after this transformation.
+///        algorithm details:
+///        Each Y formula result is 'repackaged' in an array and attempted to be transformed
+///        Case 1: On a failed transformation the initial array is returned.
+///        Case 2: On a successful transformation a dataset with one or more elements is returned
+///        Regarding the plotter the array of case 1 is treated as a single dataset.
+///        All the results from case 1 and case 2 are gathered in a waveref wave collectY.
+///        The X formula results are associated multiple times for case 2 if multiple datasets were returned and are
+///        gathered in a waveref wave collectX that grows identical to collectY.
+///        The formulaResults wave gets modified to store the new transformed results.
+static Function SF_FormulaPlotterExtendResultsIfCompatible(WAVE/WAVE formulaResults)
+
+	variable i, numResults
+
+	numResults = DimSize(formulaResults, ROWS)
+	if(!numResults)
+		return NaN
+	endif
+
+	WAVE/ZZ/WAVE collectX, collectY
+	for(i = 0; i < numResults; i += 1)
+
+		WAVE/Z wvResultX = formulaResults[i][%FORMULAX]
+		WAVE/Z wvResultY = formulaResults[i][%FORMULAY]
+		if(!WaveExists(wvResultY))
+			continue
+		endif
+		Make/FREE/WAVE array = {wvResultY}
+		WAVE/WAVE extended = SFH_MoveDatasetHigherIfCompatible(array)
+		if(!WaveExists(collectY))
+			WAVE/WAVE collectY = extended
+			Duplicate/FREE/WAVE extended, collectX
+			collectX[] = wvResultX
+		else
+			Concatenate/FREE/NP/WAVE {extended}, collectY
+			extended[] = wvResultX
+			Concatenate/FREE/NP/WAVE {extended}, collectX
+		endif
+	endfor
+
+	if(!WaveExists(collectY))
+		return NaN
+	endif
+	Redimension/N=(DimSize(collectY, ROWS), -1, -1, -1) formulaResults
+	formulaResults[][%FORMULAX] = collectX[p]
+	formulaResults[][%FORMULAY] = collectY[p]
 End

--- a/Packages/tests/Basic/UTF_SweepFormula.ipf
+++ b/Packages/tests/Basic/UTF_SweepFormula.ipf
@@ -4548,3 +4548,92 @@ static Function DataTypePromotionInPrimitiveOperations()
 	type = JWN_GetStringFromWaveNote(output, SF_META_DATATYPE)
 	CHECK_EQUAL_STR(type, "")
 End
+
+static Function HelperMoveDatasetToHigherIfCompatible()
+
+	string win, device, code, type
+
+	[win, device] = CreateEmptyUnlockedDataBrowserWindow()
+
+	win = CreateFakeSweepData(win, device, sweepNo = 0)
+
+	code = "[dataset(1, 2), dataset(3, 4)]"
+	WAVE/WAVE output = SF_ExecuteFormula(code, win, useVariables = 0)
+	CHECK(SFH_IsArray(output))
+	WAVE/WAVE moved = SFH_MoveDatasetHigherIfCompatible(output)
+	CHECK_WAVE(moved, WAVE_WAVE)
+	CHECK_EQUAL_VAR(DimSize(moved, ROWS), 2)
+	WAVE set0 = moved[0]
+	Make/FREE/D ref = {1, 3}
+	CHECK_EQUAL_WAVES(set0, ref, mode = WAVE_DATA | DIMENSION_SIZES)
+	WAVE set1 = moved[1]
+	Make/FREE/D ref = {2, 4}
+	CHECK_EQUAL_WAVES(set1, ref, mode = WAVE_DATA | DIMENSION_SIZES)
+
+	code = "[dataset(1, 2, 3), dataset(4, 5, 6)]"
+	WAVE/WAVE output = SF_ExecuteFormula(code, win, useVariables = 0)
+	CHECK(SFH_IsArray(output))
+	WAVE/WAVE moved = SFH_MoveDatasetHigherIfCompatible(output)
+	CHECK_WAVE(moved, WAVE_WAVE)
+	CHECK_EQUAL_VAR(DimSize(moved, ROWS), 3)
+	WAVE set0 = moved[0]
+	Make/FREE/D ref = {1, 4}
+	CHECK_EQUAL_WAVES(set0, ref, mode = WAVE_DATA | DIMENSION_SIZES)
+	WAVE set1 = moved[1]
+	Make/FREE/D ref = {2, 5}
+	CHECK_EQUAL_WAVES(set1, ref, mode = WAVE_DATA | DIMENSION_SIZES)
+	WAVE set2 = moved[2]
+	Make/FREE/D ref = {3, 6}
+	CHECK_EQUAL_WAVES(set2, ref, mode = WAVE_DATA | DIMENSION_SIZES)
+
+	code = "[dataset(1, 2), dataset(3, 4), dataset(5, 6)]"
+	WAVE/WAVE output = SF_ExecuteFormula(code, win, useVariables = 0)
+	CHECK(SFH_IsArray(output))
+	WAVE/WAVE moved = SFH_MoveDatasetHigherIfCompatible(output)
+	CHECK_WAVE(moved, WAVE_WAVE)
+	CHECK_EQUAL_VAR(DimSize(moved, ROWS), 2)
+	WAVE set0 = moved[0]
+	Make/FREE/D ref = {1, 3, 5}
+	CHECK_EQUAL_WAVES(set0, ref, mode = WAVE_DATA | DIMENSION_SIZES)
+	WAVE set1 = moved[1]
+	Make/FREE/D ref = {2, 4, 6}
+	CHECK_EQUAL_WAVES(set1, ref, mode = WAVE_DATA | DIMENSION_SIZES)
+
+	code = "[dataset([1, 2], [3, 4]), dataset([5, 6], [7, 8])]"
+	WAVE/WAVE output = SF_ExecuteFormula(code, win, useVariables = 0)
+	CHECK(SFH_IsArray(output))
+	WAVE/WAVE moved = SFH_MoveDatasetHigherIfCompatible(output)
+	CHECK_WAVE(moved, WAVE_WAVE)
+	CHECK_EQUAL_VAR(DimSize(moved, ROWS), 2)
+	WAVE set0 = moved[0]
+	Make/FREE/D ref = {{1, 5}, {2, 6}}
+	CHECK_EQUAL_WAVES(set0, ref, mode = WAVE_DATA | DIMENSION_SIZES)
+	WAVE set1 = moved[1]
+	Make/FREE/D ref = {{3, 7}, {4, 8}}
+	CHECK_EQUAL_WAVES(set1, ref, mode = WAVE_DATA | DIMENSION_SIZES)
+
+	code = "[dataset([a, b], [c, d]), dataset([e, f], [g, h])]"
+	WAVE/WAVE output = SF_ExecuteFormula(code, win, useVariables = 0)
+	CHECK(SFH_IsArray(output))
+	WAVE/WAVE moved = SFH_MoveDatasetHigherIfCompatible(output)
+	CHECK_WAVE(moved, WAVE_WAVE)
+	CHECK_EQUAL_VAR(DimSize(moved, ROWS), 2)
+	WAVE set0 = moved[0]
+	Make/FREE/T refT = {{"a", "e"}, {"b", "f"}}
+	CHECK_EQUAL_WAVES(set0, refT, mode = WAVE_DATA | DIMENSION_SIZES)
+	WAVE set1 = moved[1]
+	Make/FREE/T refT = {{"c", "g"}, {"d", "h"}}
+	CHECK_EQUAL_WAVES(set1, refT, mode = WAVE_DATA | DIMENSION_SIZES)
+
+	code = "[dataset(1, 2), dataset(3, abc)]"
+	WAVE/WAVE output = SF_ExecuteFormula(code, win, useVariables = 0)
+	CHECK(SFH_IsArray(output))
+	WAVE/WAVE moved = SFH_MoveDatasetHigherIfCompatible(output)
+	CHECK(SFH_IsArray(moved))
+
+	code = "[dataset(1, 2), dataset(3, 4, 5)]"
+	WAVE/WAVE output = SF_ExecuteFormula(code, win, useVariables = 0)
+	CHECK(SFH_IsArray(output))
+	WAVE/WAVE moved = SFH_MoveDatasetHigherIfCompatible(output)
+	CHECK(SFH_IsArray(moved))
+End


### PR DESCRIPTION
- This new function allows to move datasets from array elements one level up

```igorpro
e.g. [dataset(1, 2), dataset(3, 4)] -> dataset([1, 3], [3, 4]) 
e.g. [dataset(1, 2, 3), dataset(4, 5, 6)] -> dataset([1, 4], [2, 5], [3, 6]) 
e.g. [dataset(1, 2), dataset(4, 5), dataset(6, 7)] -> dataset([1, 4, 6], [2, 5, 7]) 

```
Requirements that this is possible are:
- all initial array elements must resolve to datasets
- all dataset waves of the initial array elements must be non-null, have the same size and must be 1d
- all elements of these datasets must be non-null, have the same type and the same size and must be max 3d
- only numeric and text is supported as type, thus the datasets may not contain datasets themselves If none of the requirements are met the input data is returned.

Add this logic when ranges are resolved for constructs like

```igorpro
selDA=select(channels(DA), sweeps())
selAD=select(channels(AD), sweeps())

data([min(epochs(E0, $selDA)), max(epochs(E0, $selDA))], $selAD)

```
where epochs returns multiple datasets for > 1 sweep and/or more than one AD/DA channel.

close #2142