### PR TITLE
Utils: Add additional checks to GetSetIntersection, GetSetDifference

### DIFF
--- a/Packages/MIES/MIES_Utilities.ipf
+++ b/Packages/MIES/MIES_Utilities.ipf
@@ -3747,11 +3747,10 @@ threadsafe Function/WAVE GetSetUnion(WAVE wave1, WAVE wave2)
 End
 
 /// @brief Return a wave were all elements which are in both wave1 and wave2 have been removed from wave1
+///        wave1 must be 1d, the returned wave is 1d.
 ///
 /// @sa GetListDifference for string lists
-threadsafe Function/WAVE GetSetDifference(wave1, wave2)
-	WAVE wave1
-	WAVE wave2
+threadsafe Function/WAVE GetSetDifference(WAVE wave1, WAVE wave2)
 
 	variable isText, index
 
@@ -3759,6 +3758,7 @@ threadsafe Function/WAVE GetSetDifference(wave1, wave2)
 
 	ASSERT_TS((IsFloatingPointWave(wave1) && IsFloatingPointWave(wave2)) || isText, "Non matching wave types (both float or both text).")
 	ASSERT_TS(WaveType(wave1) == WaveType(wave2), "Wave type mismatch")
+	ASSERT_TS(!DimSize(wave1, COLS), "input wave1 must be 1d")
 
 	WAVE/Z result
 
@@ -3841,6 +3841,7 @@ threadsafe Function/WAVE GetSetIntersection(WAVE wave1, WAVE wave2, [variable ge
 
 	ASSERT_TS((IsNumericWave(wave1) && IsNumericWave(wave2))                  \
 	          || (IsTextWave(wave1) && IsTextWave(wave2)), "Invalid wave type")
+	ASSERT_TS(!DimSize(wave1, COLS) && !DimSize(wave2, COLS), "input waves must be 1d")
 
 	getIndices = ParamIsDefault(getIndices) ? 0 : !!getIndices
 

--- a/Packages/tests/Basic/UTF_Utils.ipf
+++ b/Packages/tests/Basic/UTF_Utils.ipf
@@ -352,6 +352,28 @@ Function GSD_ExpectsSameWaveType()
 	endtry
 End
 
+static Function GSD_Expects1dWave1()
+
+	Make/FREE/D/N=(1, 10) data1
+	Make/FREE/D data2
+
+	try
+		WAVE/Z matches = GetSetDifference(data1, data2)
+		FAIL()
+	catch
+		PASS()
+	endtry
+End
+
+static Function GSD_WorksWithNdWave2()
+
+	Make/FREE/D/N=5 data1 = p
+	Make/FREE/D/N=(1, 3) data2 = q
+
+	WAVE/Z matches = GetSetDifference(data1, data2)
+	CHECK_EQUAL_WAVES(matches, {3, 4}, mode = WAVE_DATA | DIMENSION_SIZES)
+End
+
 Function GSD_ExpectsFPWaveType()
 
 	Make/FREE/D data1
@@ -489,6 +511,29 @@ Function GSI_ExpectsSameWaveType()
 
 	Make/FREE/D data1
 	Make/FREE/R data2
+
+	try
+		WAVE/Z matches = GetSetIntersection(data1, data2)
+		FAIL()
+	catch
+		PASS()
+	endtry
+End
+
+static Function GSI_Expects1dWave()
+
+	Make/FREE/D/N=(1, 10) data1
+	Make/FREE/D data2
+
+	try
+		WAVE/Z matches = GetSetIntersection(data1, data2)
+		FAIL()
+	catch
+		PASS()
+	endtry
+
+	Make/FREE/D data1
+	Make/FREE/D/N=(1, 10) data2
 
 	try
 		WAVE/Z matches = GetSetIntersection(data1, data2)


### PR DESCRIPTION
- both functions did not check properly if the input waves were actually one-dimensional

This check was added as well as tests.
For GetSetDifference it is sufficient if the first wave argument is 1d as the second one is evaluated through FindValue.
