### PR TITLE
Fix: Timeout on NI reliability test causes the test to fail on main branch

### DIFF
--- a/Packages/tests/UTF_HardwareHelperFunctions.ipf
+++ b/Packages/tests/UTF_HardwareHelperFunctions.ipf
@@ -342,7 +342,7 @@ Function RegisterReentryFunction(string testcase)
 	if(FuncRefIsAssigned(FuncRefInfo(reentryFuncPlain)) || FuncRefIsAssigned(FuncRefInfo(reentryFuncMDStr)) || FuncRefIsAssigned(FuncRefInfo(reentryFuncRefWave)) || FuncRefIsAssigned(FuncRefInfo(reentryFuncMDD)))
 		CtrlNamedBackGround DAQWatchdog, start, period=120, proc=WaitUntilDAQDone_IGNORE
 		CtrlNamedBackGround TPWatchdog, start, period=120, proc=WaitUntilTPDone_IGNORE
-		RegisterUTFMonitor(TASKNAMES + "DAQWatchdog;TPWatchdog", BACKGROUNDMONMODE_AND, reentryFuncName, timeout = 1200, failOnTimeout = 1)
+		RegisterUTFMonitor(TASKNAMES + "DAQWatchdog;TPWatchdog", BACKGROUNDMONMODE_AND, reentryFuncName, timeout = 2400, failOnTimeout = 1)
 	endif
 End
 


### PR DESCRIPTION
- main branch tests are run with instrumentation and thus, run slower than on a PR It turns out that the reentry for the NI reliability test times out while the acquisition task is still running.

This change increases the timeout from 20 mins to 40 mins.

close #2185 