### PR TITLE
Fix: Add UTF_SweepFormula_Operations.ipf to list of testsuites

### DIFF
--- a/Packages/tests/Basic/UTF_Basic.ipf
+++ b/Packages/tests/Basic/UTF_Basic.ipf
@@ -135,6 +135,7 @@ Function RunWithOpts([string testcase, string testsuite, variable allowdebug, va
 	list = AddListItem("UTF_PGCSetAndActivateControl.ipf", list, ";", Inf)
 	list = AddListItem("UTF_StimsetAPI.ipf", list, ";", Inf)
 	list = AddListItem("UTF_SweepFormula.ipf", list, ";", Inf)
+	list = AddListItem("UTF_SweepFormula_Operations.ipf", list, ";", Inf)
 	list = AddListItem("UTF_SweepFormula_PSX.ipf", list, ";", Inf)
 	list = AddListItem("UTF_Testpulse.ipf", list, ";", Inf)
 	list = AddListItem("UTF_TraceUserData.ipf", list, ";", Inf)


### PR DESCRIPTION
The refactoring in
1228f739 (Remaining UTF_Utils function refactoring to separate files, 2024-07-18) missed, that the new testsuite also needs to be added to the list for testing.

This commit fixes this.

