### PR TITLE
Adapt nwbv2 export tests to check against custom electrode names

### DIFF
--- a/Packages/tests/HardwareBasic/UTF_BasicHardwareTests.ipf
+++ b/Packages/tests/HardwareBasic/UTF_BasicHardwareTests.ipf
@@ -2470,3 +2470,28 @@ static Function RoundTripDepStimsetsRecursionThroughSweeps_REENTRY([STRUCT IUTF_
 	KillVariables/Z m_amplitude
 	KillStrings/Z m_setNameB, m_refList, m_customWavePath
 End
+
+static Function TestCustomElectrodeNamesInNWB_preAcq(string device)
+
+	WAVE/T cellElectrodeNames = GetCellElectrodeNames(device)
+	// must be valid HDF5 identifiers
+	cellElectrodeNames[0] = "Electric Dreams of Voltage"
+	cellElectrodeNames[1] = "Electric Dreams of Current"
+End
+
+// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+static Function TestCustomElectrodeNamesInNWB([string str])
+
+	STRUCT DAQSettings s
+	InitDAQSettingsFromString(s, "MD1_RA1_I0_L0_BKG1"                       + \
+	                             "__HS0_DA0_AD0_CM:VC:_ST:EpochTest6_DA_0:" + \
+	                             "__HS1_DA1_AD1_CM:IC:_ST:EpochTest6_DA_0:")
+
+	AcquireData_NG(s, str)
+End
+
+static Function TestCustomElectrodeNamesInNWB_REENTRY([string str])
+
+	CHECK_EQUAL_VAR(GetSetVariable(str, "SetVar_Sweep"), 1)
+	TestNwbExportV2()
+End

--- a/Packages/tests/UTF_TestNWBExportV2.ipf
+++ b/Packages/tests/UTF_TestNWBExportV2.ipf
@@ -422,8 +422,9 @@ static Function TestTimeSeries(fileID, filepath, device, groupID, channel, sweep
 
 	// electrode_name, only present for associated channels
 	if(IsFinite(params.electrodeNumber))
-		electrode_name     = ReadElectrodeName(filePath, channel, NWB_VERSION)
-		electrode_name_ref = num2str(params.electrodeNumber)
+		electrode_name = ReadElectrodeName(filePath, channel, NWB_VERSION)
+		WAVE/T cellElectrodeNames = GetCellElectrodeNames(device)
+		electrode_name_ref = cellElectrodeNames[params.electrodeNumber]
 		CHECK_EQUAL_STR(electrode_name, electrode_name_ref)
 	endif
 


### PR DESCRIPTION
- previously the test checked only against the standard electrode names
- Add test with a custom electrode name set

close https://github.com/AllenInstitute/MIES/issues/2156
