### PR TITLE
Add SKIP_TESTCASE() for SUTTER hardware if requirements are not met

### DIFF
--- a/Packages/tests/UTF_HardwareHelperFunctions.ipf
+++ b/Packages/tests/UTF_HardwareHelperFunctions.ipf
@@ -1442,9 +1442,7 @@ Function AcquireData_NG(STRUCT DAQSettings &s, string device)
 	sutterRequirementCheck[] = s.aso[p] == 1 && s.hs[p] == 1
 	if(!(sum(sutterRequirementCheck) == 1 && sutterRequirementCheck[0] == 1))
 		INFO("SUTTER hardware currently supports only 1 HS")
-		CHECK(0)
-		UnRegisterIUTFMonitor()
-		Abort
+		SKIP_TESTCASE()
 	endif
 
 	WAVE deviceInfo = GetDeviceInfoWave(device)


### PR DESCRIPTION
Use the new Igortest assertion SKIP_TESTCASE() in AcquireData_NG in the hardware tests if the SUTTER hardware does not fulfill the requirements of the test case, e.g. too many active headstages

This skips the test case.
