### PR TITLE
.github/workflows: Prefer on.push

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,10 +1,12 @@
-name: Build Pull Request
-run-name: Build PR ${{ github.event.number }} «${{ github.event.pull_request.title }}» (${{ github.actor}})
+name: Build Branch
+run-name: Build «${{ github.ref_name }}» (${{ github.actor}})
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
+  push:
+    branches-ignore:
+      - main
+      - release/*
+    tags-ignore:
+      - '*'
   workflow_call:
     inputs:
       is_called_workflow:
@@ -336,4 +338,4 @@ jobs:
             -u "${{ secrets.GHA_MIES_FTP_ARTEFACT_STORAGE_USER }}" \
             -p "${{ secrets.GHA_MIES_FTP_ARTEFACT_STORAGE_PWD }}" \
             -d "${{ steps.download.outputs.download-path }}" \
-            -t "pr/$(echo "${{ github.event.pull_request.head.ref }}" | sed "s@/@_@g")/${{ github.event.pull_request.head.sha }}/${{ github.run_attempt }}"
+            -t "branch/$(echo "${{ github.ref_name }}" | sed "s@/@_@g")/${{ github.sha }}/${{ github.run_attempt }}"

--- a/.github/workflows/test-igor-rebase-exec-workflow.yml
+++ b/.github/workflows/test-igor-rebase-exec-workflow.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.sha }}
       - name: Initial repo config
         run: tools/initial-repo-config.sh
       - name: List of commits to operate on


### PR DESCRIPTION
We currently use on.pull_request for running CI on feature branches. This creates a merge commit against the base branch to run the CI against. This means that the git revision of that CI run is not the HEAD of the branch PR but a transient revision.

This is bad for traceability for us, as we sometimes have long-living branches in semi-production.

By using on.push we can avoid these issues.

- [x] Check uploaded files on aistorage
- [x] Check git commit of installer this needs to match branch HEAD

Close #2117

Will merge once CI passes.
