### PR TITLE
Packages/doc/Doxyfile: Adapt rst aliases

### DIFF
--- a/Packages/doc/Doxyfile
+++ b/Packages/doc/Doxyfile
@@ -272,8 +272,8 @@ TAB_SIZE               = 4
 # with the commands \{ and \} for these it is advised to use the version @{ and
 # @} or use a double escape (\\{ and \\})
 
-ALIASES                = "rst    =@verbatim embed:rst:leading-asterisk" \
-                         "endrst =@endverbatim"
+ALIASES                = "rst=^^\verbatim embed:rst:leading-slashes^^" \
+                         "endrst=\endverbatim^^"
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For


### PR DESCRIPTION
Newer doxygen versions like 1.12.0 have a different behaviour for embedding rst.

After some playing around the following changes fixed it.
