### PR TITLE
DCR: Initalise s.TTLList wave with zero elements in case no TTL channels are on

### DIFF
--- a/Packages/MIES/MIES_DataConfiguratonRecreation.ipf
+++ b/Packages/MIES/MIES_DataConfiguratonRecreation.ipf
@@ -86,6 +86,7 @@ static Function DCR_RecreateDataConfigurationResultFromLNB_TTL(STRUCT DataConfig
 			s.numTTLEntries = DimSize(s.TTLList, ROWS)
 		else
 			s.numTTLEntries = 0
+			Make/FREE/N=(0) s.TTLList
 		endif
 	else
 		s.numTTLEntries = 0


### PR DESCRIPTION
For the case the "TTL channels" entry does not exist in the LNB we already do this. For consistency we should also do this when the LNB entry exists and no TTL channels are enabled.

The missing wave init had no side effect, but its more correct.