### PR TITLE
Allow accessing the logbook waves from ZeroMQ

### DIFF
--- a/Packages/MIES/MIES_ForeignFunctionInterface.ipf
+++ b/Packages/MIES/MIES_ForeignFunctionInterface.ipf
@@ -84,3 +84,33 @@ Function FFI_SetCellElectrodeName(string device, variable headstage, string name
 
 	cellElectrodeNames[headstage] = name
 End
+
+/// @brief Query logbook entries from devices
+///
+/// This allows to query labnotebook/results entries from associated channels.
+///
+/// @param device          Name of the hardware device panel, @sa GetLockedDevices()
+/// @param logbookType     One of #LBT_LABNOTEBOOK or #LBT_RESULTS
+/// @param sweepNo         Sweep number
+/// @param setting         Name of the entry
+/// @param entrySourceType One of #DATA_ACQUISITION_MODE/#UNKNOWN_MODE/#TEST_PULSE_MODE
+///
+/// @return Numerical/Textual wave with #LABNOTEBOOK_LAYER_COUNT rows or a null wave reference if nothing could be found
+Function/WAVE FFI_QueryLogbook(string device, variable logbookType, variable sweepNo, string setting, variable entrySourceType)
+
+	ASSERT(logbookType != LBT_TPSTORAGE, "Invalid logbook type")
+
+	WAVE/T numericalValues = GetLogbookWaves(logbookType, LBN_NUMERICAL_VALUES, device = device)
+
+	WAVE/Z settings = GetLastSetting(numericalValues, sweepNo, setting, entrySourceType)
+
+	if(WaveExists(settings))
+		return settings
+	endif
+
+	WAVE/T textualValues = GetLogbookWaves(logbookType, LBN_TEXTUAL_VALUES, device = device)
+
+	WAVE/Z settings = GetLastSetting(textualValues, sweepNo, setting, entrySourceType)
+
+	return settings
+End

--- a/Packages/tests/Basic/UTF_Basic.ipf
+++ b/Packages/tests/Basic/UTF_Basic.ipf
@@ -14,6 +14,7 @@
 #include "UTF_DAEphyswoHardware"
 #include "UTF_Debugging"
 #include "UTF_EpochswoHardware"
+#include "UTF_ForeignFunctionInterface"
 #include "UTF_GuiUtilities"
 #include "UTF_JSONWaveNotes"
 #include "UTF_Labnotebook"
@@ -126,6 +127,7 @@ Function RunWithOpts([string testcase, string testsuite, variable allowdebug, va
 	list = AddListItem("UTF_Configuration.ipf", list, ";", Inf)
 	list = AddListItem("UTF_DAEphyswoHardware.ipf", list, ";", Inf)
 	list = AddListItem("UTF_EpochswoHardware.ipf", list, ";", Inf)
+	list = AddListItem("UTF_ForeignFunctionInterface.ipf", list, ";", Inf)
 	list = AddListItem("UTF_GuiUtilities.ipf", list, ";", Inf)
 	list = AddListItem("UTF_JSONWaveNotes.ipf", list, ";", Inf)
 	list = AddListItem("UTF_Labnotebook.ipf", list, ";", Inf)

--- a/Packages/tests/Basic/UTF_ForeignFunctionInterface.ipf
+++ b/Packages/tests/Basic/UTF_ForeignFunctionInterface.ipf
@@ -1,0 +1,17 @@
+#pragma TextEncoding="UTF-8"
+#pragma rtGlobals=3 // Use modern global access method and strict wave access.
+#pragma rtFunctionErrors=1
+#pragma ModuleName=ForeignFunctionTests
+
+static Function TestMessageFilters()
+
+	string wvNote
+
+	WAVE/T/Z filters = FFI_GetAvailableMessageFilters()
+	CHECK_WAVE(filters, FREE_WAVE | TEXT_WAVE)
+	CHECK_GT_VAR(DimSize(filters, ROWS), 0)
+
+	wvNote = note(filters)
+
+	CHECK_PROPER_STR(wvNote)
+End

--- a/Packages/tests/Basic/UTF_ForeignFunctionInterface.ipf
+++ b/Packages/tests/Basic/UTF_ForeignFunctionInterface.ipf
@@ -15,3 +15,16 @@ static Function TestMessageFilters()
 
 	CHECK_PROPER_STR(wvNote)
 End
+
+static Function TestLogbookQuery()
+	string key, keyTxT, device
+
+	device = "ITC16USB_0_DEV"
+	[key, keyTxt] = PrepareLBN_IGNORE(device)
+
+	WAVE/Z settings = FFI_QueryLogbook(device, LBT_LABNOTEBOOK, 0, key, DATA_ACQUISITION_MODE)
+	CHECK_WAVE(settings, NUMERIC_WAVE)
+
+	WAVE/Z settings = FFI_QueryLogbook(device, LBT_LABNOTEBOOK, 0, keyTxt, DATA_ACQUISITION_MODE)
+	CHECK_WAVE(settings, TEXT_WAVE)
+End


### PR DESCRIPTION
Surprisingly I have realized that you can't call a function with a wave argument over zeromq. Until https://github.com/AllenInstitute/ZeroMQ-XOP/issues/60 is fixed, the new function FFI_QueryLogbook allows to query the labnotebook/results waves.