### PR TITLE
ASYNC: Improved error status transfer from workers to main thread

### DIFF
--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -2307,3 +2307,13 @@ Constant SUTTER_MAX_MAX_TP_PULSES = 10000
 Constant INVALID_SWEEP_NUMBER = -1
 
 StrConstant PERCENT_F_MAX_PREC = "%.15f"
+
+/// @name Igor Internal Abort Codes
+///
+/// @anchor IgorAbortCodes
+///@{
+Constant ABORTCODE_ABORTONRTE    = -4
+Constant ABORTCODE_ABORT         = -3
+Constant ABORTCODE_STACKOVERFLOW = -2
+Constant ABORTCODE_USERABORT     = -1
+///@}

--- a/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
+++ b/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
@@ -366,13 +366,14 @@ threadsafe Function/DF NWB_ASYNC_Worker(DFREF dfr)
 	return $""
 End
 
-Function NWB_ASYNC_Readout(DFREF dfr, variable err, string errmsg)
+Function NWB_ASYNC_Readout(STRUCT ASYNC_ReadOutStruct &ar)
 
-	if(!err)
-		return NaN
+	if(ar.rtErr)
+		BUG("Async jobs finished with RTE: " + ar.rtErrMsg)
 	endif
-
-	BUG("Async jobs finished with: " + errmsg)
+	if(ar.abortCode)
+		BUG("Async jobs finished with Abort: " + GetErrMessage(ar.abortCode))
+	endif
 End
 
 threadsafe static Function NWB_WriteLabnoteBooksAndComments(STRUCT NWBAsyncParameters &s)

--- a/Packages/MIES/MIES_Structures.ipf
+++ b/Packages/MIES/MIES_Structures.ipf
@@ -637,3 +637,11 @@ Structure SF_PlotMetaData
 	string xAxisLabel // from SF_META_XAXISLABEL constant
 	string yAxisLabel // from SF_META_YAXISLABEL constant
 EndStructure
+
+/// @brief ReadOut Structure for ASYNC
+Structure ASYNC_ReadOutStruct
+	DFREF dfr // dfr with output data
+	variable rtErr // runtime error code
+	string rtErrMsg // runtime error message
+	variable abortCode // abort code
+EndStructure

--- a/Packages/MIES/MIES_TestPulse.ipf
+++ b/Packages/MIES/MIES_TestPulse.ipf
@@ -179,25 +179,20 @@ End
 /// results are base line level, steady state resistance, instantaneous resistance and their positions
 /// collected results for all channels of a measurement are send to TP_RecordTP(), DQ_ApplyAutoBias() when complete
 ///
-/// @param dfr output data folder from ASYNC frame work with results from workloads associated with this registered function
-///		  The output parameter in the data folder follow the definition as created in TP_TSAnalysis()
-///
-/// @param err error code of TP_TSAnalysis() function
-///
-/// @param errmsg error message of TP_TSAnalysis() function
-Function TP_ROAnalysis(dfr, err, errmsg)
-	DFREF    dfr
-	variable err
-	string   errmsg
+/// @param ar ASYNC_ReadOutStruct structure with dfr with input data
+Function TP_ROAnalysis(STRUCT ASYNC_ReadOutStruct &ar)
 
 	variable i, j, bufSize
 	variable posMarker, posAsync, tpBufferSize
 	variable posBaseline, posSSRes, posInstRes
 	variable posElevSS, posElevInst
 
-	if(err)
-		ASSERT(0, "RTError " + num2str(err) + " in TP_Analysis thread: " + errmsg)
+	if(ar.rtErr || ar.abortCode)
+		ASSERT(!ar.rtErr, "TP analysis thread encountered RTE " + ar.rtErrMsg)
+		ASSERT(!ar.abortCode, "TP analysis thread aborted with code: " + GetErrMessage(ar.abortCode))
 	endif
+
+	DFREF dfr = ar.dfr
 
 	WAVE/SDFR=dfr inData     = outData
 	NVAR/SDFR=dfr now        = now

--- a/Packages/tests/UTF_DataGenerators.ipf
+++ b/Packages/tests/UTF_DataGenerators.ipf
@@ -876,3 +876,17 @@ static Function/WAVE GetBasicMathOperations()
 
 	return op
 End
+
+static Function/WAVE GetASYNCReadOutErrorFunctions()
+	Make/FREE/T wt = {"FailReadOutAbort", "FailReadOut"}
+	SetDimensionLabels(wt, TextWaveToList(wt, ";"), ROWS)
+
+	return wt
+End
+
+static Function/WAVE GetASYNCThreadErrorFunctions()
+	Make/FREE/T wt = {"RunGenericWorkerAbortOnValue,FailThreadReadOutAbortOnValue,", "RunGenericWorkerRTE,FailThreadReadOutRTE,"}
+	SetDimensionLabels(wt, TextWaveToList(wt, ";"), ROWS)
+
+	return wt
+End


### PR DESCRIPTION
If a thread was aborted through a regular AbortOnValue this was caught but only a possible RTE was evaluated. Thus, the readout function could not determine if the thread was aborted or not.

Changes:
- The readout function now uses ASYNC_ReadOutStruct as single argument. This allows extensions without changing all function APIs. The structure includes the former values for dfr, RTE code, RTE message and now additionally the V_abortCode. The RTE message must be included here as it has to be retrieved as soon as it happened (in the thread) and needs to be trnasported then to the main thread as well.
- The user readout function can evaluate then both error conditions and react accordingly.
- Tests

close #2252 