### PR TITLE
GetPossiblePathsToGit: Fix paths on windows

### DIFF
--- a/Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf
+++ b/Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf
@@ -161,10 +161,10 @@ Function/WAVE GetPossiblePathsToGit()
 
 	// Atlassian Sourcetree (Embedded git)
 	userName = GetSystemUserName()
-	paths[3] = "C::Users:" + userName + ":AppData:Local:Atlassian:SourceTree:git_local:mingw32:bin:git.exe"
+	paths[3] = "C:Users:" + userName + ":AppData:Local:Atlassian:SourceTree:git_local:mingw32:bin:git.exe"
 
 	// user installation of git for windows
-	paths[4] = "C::Users:" + userName + ":AppData:Local:Programs:Git:cmd:git.exe"
+	paths[4] = "C:Users:" + userName + ":AppData:Local:Programs:Git:cmd:git.exe"
 #elif defined(MACINTOSH)
 	Make/T/FREE paths = {"Macintosh HD:usr:bin:git"}
 #else


### PR DESCRIPTION
We only want a single colon (:) when using HFS paths. Bug introduced in b68f43bc (CreateMiesVersion: Add support for MacOSX, 2023-08-25).

Close #2268