### PR TITLE
MIES_AnalysisFunctionPrototypes.ipf: Assert out

### DIFF
--- a/Packages/MIES/MIES_AnalysisFunctionPrototypes.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctionPrototypes.ipf
@@ -25,6 +25,8 @@ Function AFP_ANALYSIS_FUNC_V1(device, eventType, DAQDataWave, headStage)
 	variable eventType
 	WAVE     DAQDataWave
 	variable headstage
+
+	ASSERT(0, "Prototype function which must not be called")
 End
 
 /// @deprecated Use AFP_ANALYSIS_FUNC_V3() instead
@@ -44,7 +46,7 @@ Function AFP_ANALYSIS_FUNC_V2(device, eventType, DAQDataWave, headStage, realDat
 	WAVE     DAQDataWave
 	variable headstage, realDataLength
 
-	return 0
+	ASSERT(0, "Prototype function which must not be called")
 End
 
 /// @param device device
@@ -55,13 +57,14 @@ Function AFP_ANALYSIS_FUNC_V3(device, s)
 	string                      device
 	STRUCT AnalysisFunction_V3 &s
 
-	return 0
+	ASSERT(0, "Prototype function which must not be called")
 End
 
 /// @brief Prototype function for the user supplied parameter getter functions
 ///
 Function/S AFP_PARAM_GETTER_V3()
 
+	ASSERT(0, "Prototype function which must not be called")
 End
 
 /// @brief Prototype function for the user supplied parameter help functions
@@ -69,14 +72,19 @@ End
 Function/S AFP_PARAM_HELP_GETTER_V3(name)
 	string name
 
+	ASSERT(0, "Prototype function which must not be called")
 End
 
 /// @brief Prototype function for the user supplied parameter check function (legacy signature)
 ///
 Function/S AFP_PARAM_CHECK_V1(string name, string params)
+
+	ASSERT(0, "Prototype function which must not be called")
 End
 
 /// @brief Prototype function for the user supplied parameter check function
 ///
 Function/S AFP_PARAM_CHECK_V2(string name, STRUCT CheckParametersStruct &s)
+
+	ASSERT(0, "Prototype function which must not be called")
 End

--- a/Packages/tests/Basic/UTF_AnalysisFunctionPrototypes.ipf
+++ b/Packages/tests/Basic/UTF_AnalysisFunctionPrototypes.ipf
@@ -1,0 +1,51 @@
+#pragma TextEncoding="UTF-8"
+#pragma rtGlobals=3 // Use modern global access method and strict wave access.
+#pragma rtFunctionErrors=1
+#pragma ModuleName=AnalysisFunctionPrototypeTests
+
+static Function CheckThatTheyAllAssertOut()
+
+	string funcList, func
+
+	funcList = FunctionList("*", ";", "WIN:MIES_AnalysisFunctionPrototypes.ipf")
+	CHECK_PROPER_STR(funcList)
+
+	WAVE/T funcs = ListToTextWave(funcList, ";")
+
+	for(func : funcs)
+		INFO("Function %s", s0 = func)
+
+		try
+			strswitch(func)
+				case "AFP_ANALYSIS_FUNC_V1":
+					AFP_ANALYSIS_FUNC_V1("", NaN, $"", NaN)
+					break
+				case "AFP_ANALYSIS_FUNC_V2":
+					AFP_ANALYSIS_FUNC_V2("", NaN, $"", NaN, NaN)
+					break
+				case "AFP_ANALYSIS_FUNC_V3":
+					STRUCT AnalysisFunction_V3 af
+					AFP_ANALYSIS_FUNC_V3("", af)
+					break
+				case "AFP_PARAM_GETTER_V3":
+					AFP_PARAM_GETTER_V3()
+					break
+				case "AFP_PARAM_HELP_GETTER_V3":
+					AFP_PARAM_HELP_GETTER_V3("")
+					break
+				case "AFP_PARAM_CHECK_V1":
+					AFP_PARAM_CHECK_V1("", "")
+					break
+				case "AFP_PARAM_CHECK_V2":
+					STRUCT CheckParametersStruct cp
+					AFP_PARAM_CHECK_V2("", cp)
+					break
+				default:
+					FAIL()
+			endswitch
+			FAIL()
+		catch
+			CHECK_NO_RTE()
+		endtry
+	endfor
+End

--- a/Packages/tests/Basic/UTF_Basic.ipf
+++ b/Packages/tests/Basic/UTF_Basic.ipf
@@ -9,6 +9,7 @@
 #include "UTF_AnalysisBrowserTest"
 #include "UTF_AnalysisFunctionHelpers"
 #include "UTF_AnalysisFunctionParameters"
+#include "UTF_AnalysisFunctionPrototypes"
 #include "UTF_AsynFrameworkTest"
 #include "UTF_Configuration"
 #include "UTF_DAEphyswoHardware"
@@ -122,6 +123,7 @@ Function RunWithOpts([string testcase, string testsuite, variable allowdebug, va
 	list = AddListItem("UTF_AnalysisBrowserTest.ipf", list, ";", Inf)
 	list = AddListItem("UTF_AnalysisFunctionHelpers.ipf", list, ";", Inf)
 	list = AddListItem("UTF_AnalysisFunctionParameters.ipf", list, ";", Inf)
+	list = AddListItem("UTF_AnalysisFunctionPrototypes.ipf", list, ";", Inf)
 	list = AddListItem("UTF_AsynFrameworkTest.ipf", list, ";", Inf)
 	list = AddListItem("UTF_Debugging.ipf", list, ";", Inf)
 	list = AddListItem("UTF_Configuration.ipf", list, ";", Inf)


### PR DESCRIPTION
A prototype function is used for creating function references (FUNCREF). And this also means they are never called.

Add an assertion to make that clear and also add some tests.

@timjarsky This should make it clearer that these are not the example analysis functions.

Will merge once CI passes.