### PR TITLE
tests/CheckThatTheyAllAssertOut: Ignore igortest marker function

### DIFF
--- a/Packages/tests/Basic/UTF_AnalysisFunctionPrototypes.ipf
+++ b/Packages/tests/Basic/UTF_AnalysisFunctionPrototypes.ipf
@@ -10,6 +10,8 @@ static Function CheckThatTheyAllAssertOut()
 	funcList = FunctionList("*", ";", "WIN:MIES_AnalysisFunctionPrototypes.ipf")
 	CHECK_PROPER_STR(funcList)
 
+	funcList = GrepList(funcList, "^IUTF_TagFunc.*", 1)
+
 	WAVE/T funcs = ListToTextWave(funcList, ";")
 
 	for(func : funcs)


### PR DESCRIPTION
When compiling with instrumentation igortest adds a function to mark the file as instrumented. But as we require all functions in the file to assert out this makes the test case fail with [1]:

  0: is false. Assertion "FAIL()" failed in AnalysisFunctionPrototypeTests#CheckThatTheyAllAssertOut (UTF_AnalysisFunctionPrototypes.ipf, line 43)

    ? Function IUTF_TagFunc_bd1f27ca745da4aa90f393ef89b21e4aa84abb5a97b8b36526b552cdeffad1d2_IGNORE

Therefore we have to remove these tag functions from our function list.

Broken since 2d62af695 (MIES_AnalysisFunctionPrototypes.ipf: Assert out, 2024-10-22).

[1]: https://github.com/AllenInstitute/MIES/actions/runs/11467629096/job/31913142347

Close #2287

Will merge when CI passes.