### PR TITLE
Labnotebook querying: Fix querying the NaN sweep with unknown mode

### DIFF
--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -38,7 +38,7 @@ Constant SWEEP_EPOCH_VERSION = 9
 /// - New/Changed layers of entries
 ///
 ///@{
-Constant LABNOTEBOOK_VERSION = 76
+Constant LABNOTEBOOK_VERSION = 77
 Constant RESULTS_VERSION     = 3
 ///@}
 

--- a/Packages/MIES/MIES_MiesUtilities_Logbook.ipf
+++ b/Packages/MIES/MIES_MiesUtilities_Logbook.ipf
@@ -1368,18 +1368,30 @@ threadsafe static Function FindRange(wv, col, val, entrySourceType, first, last)
 	variable col, val, entrySourceType
 	variable &first, &last
 
-	variable numRows, i, j, sourceTypeCol, firstRow, lastRow, isNumeric, index
+	variable numRows, i, j, sourceTypeCol, firstRow, lastRow, isNumeric, index, startRow, endRow
 
 	first     = NaN
 	last      = NaN
 	isNumeric = IsNumericWave(wv)
 
+	startRow = 0
+	endRow   = GetNumberFromWaveNote(wv, NOTE_INDEX) - 1
+
+	if(IsNaN(endRow))
+		endRow = DimSize(wv, ROWS) - 1
+	endif
+
+	if(endRow < 0)
+		// empty labnotebook
+		return NaN
+	endif
+
 	// still correct without startLayer/endLayer coordinates
 	// as we always have sweepNumber/etc. in the first layer
 	if(IsNaN(val) && isNumeric)
-		WAVE/Z indizesSetting = FindIndizes(wv, col = col, prop = PROP_EMPTY)
+		WAVE/Z indizesSetting = FindIndizes(wv, col = col, prop = PROP_EMPTY, startRow = startRow, endRow = endRow)
 	else
-		WAVE/Z indizesSetting = FindIndizes(wv, col = col, var = val)
+		WAVE/Z indizesSetting = FindIndizes(wv, col = col, var = val, startRow = startRow, endRow = endRow)
 	endif
 
 	if(!WaveExists(indizesSetting))

--- a/Packages/tests/Basic/UTF_Labnotebook.ipf
+++ b/Packages/tests/Basic/UTF_Labnotebook.ipf
@@ -216,6 +216,10 @@ Function GetLastSettingFindsNaNSweep()
 
 	Make/D/FREE settingsRef = {10.0010900497437, 10.001935005188, NaN, NaN, NaN, NaN, NaN, NaN, NaN}
 	CHECK_EQUAL_WAVES(settings, settingsRef, mode = WAVE_DATA, tol = 1e-13)
+
+	// and also with unknown mode
+	WAVE/Z settings = GetLastSetting(numericalValues, NaN, "TP Steady State Resistance", UNKNOWN_MODE)
+	CHECK_EQUAL_WAVES(settings, settingsRef, mode = WAVE_DATA, tol = 1e-13)
 End
 
 static Function GetLastSettingFindsWithinNonConsecutiveSweepOrder()

--- a/Packages/tests/Basic/UTF_Labnotebook.ipf
+++ b/Packages/tests/Basic/UTF_Labnotebook.ipf
@@ -1347,3 +1347,93 @@ Function GetUniqueSettingsWorks()
 	CHECK_WAVE(resultsTxt, TEXT_WAVE)
 	CHECK_EQUAL_TEXTWAVES(resultsTxt, {"131415", "192021", "161718", "222324", "252627"})
 End
+
+Function LabnotebookUpgradeMissingNoteIndexNumerical()
+
+	variable idx, idxRedone
+	string device, key, keyTxt
+
+	device = "ITC16USB_0_DEV"
+	[key, keyTxt] = PrepareLBN_IGNORE(device)
+
+	WAVE/Z   numericalValues = GetLBNumericalValues(device)
+	WAVE/T/Z numericalKeys   = GetLBNumericalKeys(device)
+
+	idx = GetNumberFromWaveNote(numericalValues, NOTE_INDEX)
+	CHECK_GT_VAR(idx, 0)
+
+	Note/K numericalKeys
+
+	MIES_WAVEGETTERS#UpgradeLabNotebook(device)
+
+	idxRedone = GetNumberFromWaveNote(numericalValues, NOTE_INDEX)
+	CHECK_EQUAL_VAR(idxRedone, idx)
+
+	Note/K numericalKeys
+	Note/K numericalValues
+
+	numericalValues[][][] = NaN
+	Redimension/N=(0, -1, -1) numericalValues
+
+	MIES_WAVEGETTERS#UpgradeLabNotebook(device)
+
+	idxRedone = GetNumberFromWaveNote(numericalValues, NOTE_INDEX)
+	CHECK_EQUAL_VAR(idxRedone, 0)
+End
+
+Function LabnotebookUpgradeMissingNoteIndexTextual()
+
+	variable idx, idxRedone
+	string device, key, keyTxt
+
+	device = "ITC16USB_0_DEV"
+	[key, keyTxt] = PrepareLBN_IGNORE(device)
+
+	WAVE/T/Z textualValues = GetLBTextualValues(device)
+	WAVE/T/Z textualKeys   = GetLBTextualKeys(device)
+
+	idx = GetNumberFromWaveNote(textualValues, NOTE_INDEX)
+	CHECK_GT_VAR(idx, 0)
+
+	Note/K textualKeys
+
+	MIES_WAVEGETTERS#UpgradeLabNotebook(device)
+
+	idxRedone = GetNumberFromWaveNote(textualValues, NOTE_INDEX)
+	CHECK_EQUAL_VAR(idxRedone, idx)
+
+	Note/K textualValues
+	Note/K textualKeys
+
+	textualValues[][][] = ""
+	Redimension/N=(0, -1, -1) textualValues
+
+	MIES_WAVEGETTERS#UpgradeLabNotebook(device)
+
+	idxRedone = GetNumberFromWaveNote(textualValues, NOTE_INDEX)
+	CHECK_EQUAL_VAR(idxRedone, 0)
+End
+
+Function EmptyLabnotebookWorks()
+
+	string device
+
+	device = "ITC16USB_0_DEV"
+	WAVE/Z numericalValues = GetLBNumericalValues(device)
+	CHECK_WAVE(numericalValues, NUMERIC_WAVE)
+
+	WAVE/Z entries = GetLastSetting(numericalValues, NaN, "Sweep Number", UNKNOWN_MODE)
+	CHECK_WAVE(entries, NULL_WAVE)
+
+	WAVE/Z entries = GetLastSetting(numericalValues, 0, "Sweep Number", UNKNOWN_MODE)
+	CHECK_WAVE(entries, NULL_WAVE)
+
+	WAVE/Z textualValues = GetLBTextualValues(device)
+	CHECK_WAVE(textualValues, TEXT_WAVE)
+
+	WAVE/Z entries = GetLastSetting(textualValues, NaN, "Sweep Number", UNKNOWN_MODE)
+	CHECK_WAVE(entries, NULL_WAVE)
+
+	WAVE/Z entries = GetLastSetting(textualValues, 0, "Sweep Number", UNKNOWN_MODE)
+	CHECK_WAVE(entries, NULL_WAVE)
+End

--- a/Packages/tests/Basic/UTF_Labnotebook.ipf
+++ b/Packages/tests/Basic/UTF_Labnotebook.ipf
@@ -12,17 +12,25 @@ End
 
 static Function/WAVE PrepareLBNNumericalValues(WAVE numericalValuesSrc)
 
-	variable numCols
+	variable numCols, nextFreeRow, numRows
 
 	WAVE/T numericalKeysTemplate = GetLBNumericalKeys("dummyDevice")
 	numCols = DimSize(numericalValuesSrc, COLS)
 	Redimension/N=(-1, numCols, -1, -1) numericalKeysTemplate
 	numericalKeysTemplate[0][] = GetDimLabel(numericalValuesSrc, COLS, q)
 
-	Duplicate/O numericalValuesSrc, $LBN_NUMERICAL_VALUES_NAME
+	Duplicate/O numericalValuesSrc, $LBN_NUMERICAL_VALUES_NAME/WAVE=numericalValues
 	Duplicate/O numericalKeysTemplate, $LBN_NUMERICAL_KEYS_NAME
 
-	return $LBN_NUMERICAL_VALUES_NAME
+	// fixup NOTE_INDEX which is wrong due to optimizing the wave sizes for the tests
+	nextFreeRow = GetNumberFromWaveNote(numericalValues, NOTE_INDEX)
+	numRows     = DimSize(numericalValues, ROWS)
+
+	if(nextFreeRow > numRows)
+		SetNumberInWaveNote(numericalValues, NOTE_INDEX, numRows)
+	endif
+
+	return numericalValues
 End
 
 static Function/WAVE PrepareLBNTextualValues(WAVE textualValuesSrc)


### PR DESCRIPTION
Found while working on #2184. No backport as that is an edgy-edge case.

Will merge once CI passes.
