### PR TITLE
Packages/doc/developers.rst: Add ITC1600 tag

### DIFF
--- a/Packages/doc/developers.rst
+++ b/Packages/doc/developers.rst
@@ -249,9 +249,13 @@ The following labels are in use:
   - ITC18-USB hardware, 2 AD/DA channels are looped
   - MCC demo amplifier only
 
-- ``NI``: Agent can execute hardware tests with NI/ITC1600 hardware
+- ``ITC1600``: Agent can execute hardware tests with ITC1600 hardware
 
   - ITC-1600 hardware with one rack, 2 AD/DA channels are looped
+  - MCC demo amplifier only
+
+- ``NI``: Agent can execute hardware tests with NI hardware
+
   - NI PCIe-6343, 2 AD/DA channels are looped
   - MCC demo amplifier only
 


### PR DESCRIPTION
We do use a separate tag for ITC1600 testing although we have currently only one machine for it together with the NI hardware.

Bug introduced in f983d27b (CI: Add testing with ITC1600, 2023-09-25).

Will merge once CI passes.