### PR TITLE
CI: Rework ipt format check

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -39,7 +39,7 @@ concurrency:
 jobs:
 
   Ipt:
-    name: 🔎 IPT Format check
+    name: 🔎 IPT checks
     runs-on: [ self-hosted, Windows ]
     steps:
       - name: Checkout repository
@@ -49,8 +49,8 @@ jobs:
         run: curl -o ipt.exe "https://byte-physics.de/public-downloads/aistorage/transfer/ipt/0.6.0/ipt.exe"
       - name: IPT version
         run: ./ipt.exe --version
-      - name: Format code
-        run: tools/ipt-format.sh
+      - name: Format and lint code
+        run: tools/run-ipt.sh
       - name: Check for changed files
         run: git diff --name-only --ignore-submodules; git diff  --ignore-submodules --quiet
       - name: Create patch

--- a/tools/run-ipt.sh
+++ b/tools/run-ipt.sh
@@ -23,9 +23,8 @@ else
   ipt="ipt"
 fi
 
-echo "[format]" > config.toml
+echo "[lint]" > config.toml
 while read -r line; do
     echo "files = \"$line\"" >> config.toml
 done < <(git ls-files ':(attr:ipt)')
-
-(cd $top_level && $ipt --arg-file config.toml format -i)
+(cd $top_level && $ipt --arg-file config.toml lint -i)


### PR DESCRIPTION
We now name that step "IPT checks" as we also do linting. And this means we should also rename tools/ipt-format.sh.

Close #511 