### PR TITLE
.github/workflows/test-igor-rebase-exec-workflow.yml: Fix it for the …

### DIFF
--- a/.github/workflows/test-igor-rebase-exec-workflow.yml
+++ b/.github/workflows/test-igor-rebase-exec-workflow.yml
@@ -78,15 +78,23 @@ jobs:
           ref: ${{ github.sha }}
       - name: Initial repo config
         run: tools/initial-repo-config.sh
+      - name: Get latest release branch
+        run: |
+             CI_RELEASE_BRANCH=$(git branch --sort="version:refname" -rl "origin/release*" | tail -n1)
+             echo "CI_RELEASE_BRANCH=$CI_RELEASE_BRANCH" >> $GITHUB_ENV
+      - name: Gather base branch
+        run: |
+             CI_BASE_BRANCH=$((git merge-base --is-ancestor ${{ env.CI_RELEASE_BRANCH }} HEAD && echo "${{ env.CI_RELEASE_BRANCH }}") || echo "origin/main")
+             echo "CI_BASE_BRANCH=$CI_BASE_BRANCH" >> $GITHUB_ENV
       - name: List of commits to operate on
-        run: git log --pretty=ref origin/main..
+        run: git log --pretty=ref ${{ env.CI_BASE_BRANCH }}..
       - name: Cleanup earlier rebase invocations
         run: git rebase --quit 2>/dev/null || true
       - name: Compile check each commit with ${{ inputs.experiment }}
         run: |
              git rebase --exec "git log --pretty=ref -n1"                                                \
                         --exec "tools/clean_mies_installation.sh ${{ inputs.installer_flags }}"          \
-                        --exec "tools/autorun-test.sh -p ${{ inputs.experiment }} -v IP_9_64" origin/main
+                        --exec "tools/autorun-test.sh -p ${{ inputs.experiment }} -v IP_9_64" ${{ env.CI_BASE_BRANCH }}
       - name: Gather log files and crash dumps
         if: always()
         run: tools/gather-logfiles-and-crashdumps.sh


### PR DESCRIPTION
…release branch

In c3e7dc3a (.github/workflows: Add job to compile test each commit, 2023-12-22) we introduced a compilation test of each commit in the branch. But we assumed that the base branch, the branch we want to merge into, is origin/main. This is not true for the release branches.

As there is no way to gather the base branch for on.push workflows [1] we added some code to get the release branch with the highest version and then check if we are an ancestor of that or origin/main.

[1]: https://github.com/orgs/community/discussions/26243#discussioncomment-3250924
