### PR TITLE
tools/nwb-read-tests/Dockerfile: Don't install additional dependencies

### DIFF
--- a/tools/nwb-read-tests/Dockerfile
+++ b/tools/nwb-read-tests/Dockerfile
@@ -30,7 +30,7 @@ COPY requirements.txt .
 # https://stackoverflow.com/a/75696359
 RUN python -m venv --system-site-packages /home/ci/.venv && \
     . /home/ci/.venv/bin/activate                        && \
-    pip3 install -r requirements.txt
+    pip3 install --no-deps -r requirements.txt
 
 # https://stackoverflow.com/a/56286534
 ENV PATH=/home/ci/.venv/bin:${PATH}


### PR DESCRIPTION
This is another incarnation of [1] where is it unclear how this worked
before. According to documentation not allowing any additional
dependencies fixes the issue.

[1]: https://github.com/pypa/pip/issues/9644