### PR TITLE
CONF_GetSettingsPath: Create the global settings folder if required

### DIFF
--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -369,18 +369,19 @@ static Function/S CONF_GetSettingsPath(variable type)
 
 			path = RemoveListItem(numItems - 1, path, ":")
 			path = RemoveListItem(numItems - 2, path, ":") + EXPCONFIG_SETTINGS_FOLDER + ":"
-			ASSERT(FolderExists(path), "Unable to resolve MIES Settings folder path. Is it present and readable in Packages\\Settings ?")
+
 			break
 		case CONF_AUTO_LOADER_USER:
 			path = CONF_AUTO_LOADER_USER_PATH
-			if(!FolderExists(path))
-				CreateFolderOnDisk(path)
-			endif
 			break
 		default:
 			ASSERT(0, "Invalid type parameter")
 			break
 	endswitch
+
+	if(!FolderExists(path))
+		CreateFolderOnDisk(path)
+	endif
 
 	if(FolderExists(path))
 		symbPath = "PathSettings"


### PR DESCRIPTION
This is nicer for the user. Although that folder should always exist.
