### PR TITLE
FindIndizes: Fix argument checking

### DIFF
--- a/Packages/MIES/MIES_MiesUtilities_Algorithm.ipf
+++ b/Packages/MIES/MIES_MiesUtilities_Algorithm.ipf
@@ -407,14 +407,12 @@ threadsafe Function/WAVE FindIndizes(WAVE numericOrTextWave, [variable col, stri
 	variable numCols, numRows, numLayers, maskedProp
 	string key
 
-	ASSERT_TS(ParamIsDefault(prop) + ParamIsDefault(var) + ParamIsDefault(str) == 2                               \
-	          || (!ParamIsDefault(prop)                                                                           \
-	              && (                                                                                            \
-	                  prop == PROP_NOT                                                                            \
-	                  || ((prop & PROP_MATCHES_VAR_BIT_MASK) && (ParamIsDefault(var) + ParamIsDefault(str)) == 1) \
-	                  || (prop & PROP_GREP && !ParamIsDefault(str) && ParamIsDefault(var))                        \
-	                  || (prop & PROP_WILDCARD && !ParamIsDefault(str) && ParamIsDefault(var))                    \
-	                 )),                                                                                          \
+	ASSERT_TS((ParamIsDefault(prop) && (ParamIsDefault(var) + ParamIsDefault(str)) == 1)                  \
+	          || ((prop & PROP_EMPTY) && (ParamIsDefault(var) + ParamIsDefault(str)) == 2)                \
+	          || ((prop & PROP_NOT) && (ParamIsDefault(var) + ParamIsDefault(str)) == 1)                  \
+	          || ((prop & PROP_MATCHES_VAR_BIT_MASK) && (ParamIsDefault(var) + ParamIsDefault(str)) == 1) \
+	          || ((prop & PROP_GREP) && !ParamIsDefault(str) && ParamIsDefault(var))                      \
+	          || ((prop & PROP_WILDCARD) && !ParamIsDefault(str) && ParamIsDefault(var)),                 \
 	          "Invalid combination of var/str/prop arguments")
 
 	ASSERT_TS(WaveExists(numericOrTextWave), "numericOrTextWave does not exist")

--- a/Packages/tests/Basic/UTF_Utils_Mies_Algorithm.ipf
+++ b/Packages/tests/Basic/UTF_Utils_Mies_Algorithm.ipf
@@ -803,6 +803,35 @@ Function FI_AbortsWithInvalidParams12()
 	endtry
 End
 
+Function FI_AbortsWithInvalidParams13()
+
+	Make/FREE data
+	try
+		WAVE/Z indizes = FindIndizes(data, prop = PROP_NOT)
+		FAIL()
+	catch
+		PASS()
+	endtry
+End
+
+Function FI_AbortsWithInvalidParams14()
+
+	Make/FREE data
+	try
+		WAVE/Z indizes = FindIndizes(data, var = 0, prop = PROP_EMPTY)
+		FAIL()
+	catch
+		PASS()
+	endtry
+
+	try
+		WAVE/Z indizes = FindIndizes(data, str = "", prop = PROP_EMPTY)
+		FAIL()
+	catch
+		PASS()
+	endtry
+End
+
 Function FI_AbortsWithInvalidWave()
 
 	try


### PR DESCRIPTION
We now bail out if we have PROP_NOT without var or str. And PROP_EMPTY now also always requires neither var nor string.

Close #2323 

Will merge once CI passes.