### PR TITLE
treewide: Prefer relative font sizes for graphs

### DIFF
--- a/Packages/MIES/MIES_Browser_Plotter.ipf
+++ b/Packages/MIES/MIES_Browser_Plotter.ipf
@@ -485,7 +485,7 @@ Function CreateTiledChannelGraph(string graph, WAVE config, variable sweepNo, WA
 							unit = "a.u."
 						endif
 
-						axisLabel = "\Z08" + traceType + "\r(" + unit + ")"
+						axisLabel = "\Zr085" + traceType + "\r(" + unit + ")"
 
 						FindValue/TXOP=4/TEXT=(vertAxis) axisLabelCache
 						axisIndex = V_Value

--- a/Packages/MIES/MIES_PulseAveraging.ipf
+++ b/Packages/MIES/MIES_PulseAveraging.ipf
@@ -2980,7 +2980,7 @@ static Function PA_LayoutGraphs(string win, STRUCT PulseAverageSettings &pa, STR
 
 			headstage = headstages[0]
 
-			sprintf str, "\\Z08\\Zr075#Pulses %g / #Swps. %d", DimSize(pulses, ROWS), DimSize(sweeps, ROWS)
+			sprintf str, "\\Zr075#Pulses %g / #Swps. %d", DimSize(pulses, ROWS), DimSize(sweeps, ROWS)
 			Textbox/W=$graph/C/N=leg/X=-5.00/Y=-5.00 str
 
 			[s] = GetTraceColor(headstage)


### PR DESCRIPTION
This scales better for different monitor sizes.

Close #2013