### PR TITLE
SF_button_sweepFormula_tofront: Retrieve Sweepformula plot window

### DIFF
--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -6715,6 +6715,7 @@ Function SF_button_sweepFormula_tofront(STRUCT WMButtonAction &ba) : ButtonContr
 			for(i = 0; i < numWins; i += 1)
 				wName = StringFromList(i, wList)
 				DoWindow/F $wName
+				DoIgorMenu "Control", "Retrieve Window"
 			endfor
 
 			break


### PR DESCRIPTION
When the windows is moved to the front we now also retrieve it, i.e. move fully into the IP window so that it is always visible.

Found during live testing yesterday.
