### PR TITLE
SF labnotebook: Fix multiple keys with wildcards

### DIFF
--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -6244,16 +6244,16 @@ static Function/WAVE SFH_OperationLabnotebookExpandKeys(string graph, WAVE/T LBN
 			continue
 		endif
 
-		Duplicate/FREE/T entries, filteredEntries
-
 		for(j = 0; j < numKeys; j += 1)
+			Duplicate/FREE/T entries, filteredEntries
+
 			key = LBNKeys[j]
 			MultiThread filteredEntries = SelectString(stringmatch(entries[p], key), "", entries[p])
+
+			RemoveTextWaveEntry1D(filteredEntries, "", all = 1)
+
+			Concatenate/NP=(ROWS)/T/FREE {filteredEntries}, allLBNKeys
 		endfor
-
-		RemoveTextWaveEntry1D(filteredEntries, "", all = 1)
-
-		Concatenate/NP=(ROWS)/T/FREE {filteredEntries}, allLBNKeys
 	endfor
 
 	if(DimSize(allLBNKeys, ROWS) == 0)

--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -6245,18 +6245,17 @@ static Function/WAVE SFH_OperationLabnotebookExpandKeys(string graph, WAVE/T LBN
 		endif
 
 		for(j = 0; j < numKeys; j += 1)
-			Duplicate/FREE/T entries, filteredEntries
-
 			key = LBNKeys[j]
-			MultiThread filteredEntries = SelectString(stringmatch(entries[p], key), "", entries[p])
+			WAVE/Z indizes = FindIndizes(entries, str = key, prop = PROP_WILDCARD)
 
-			RemoveTextWaveEntry1D(filteredEntries, "", all = 1)
-
-			Concatenate/NP=(ROWS)/T/FREE {filteredEntries}, allLBNKeys
+			if(WaveExists(indizes))
+				Make/FREE/N=(DimSize(indizes, ROWS))/T matches = entries[indizes[p]]
+				Concatenate/NP=(ROWS)/T/FREE {matches}, allLBNKeys
+			endif
 		endfor
 	endfor
 
-	if(DimSize(allLBNKeys, ROWS) == 0)
+	if(!WaveExists(allLBNKeys))
 		return $""
 	endif
 

--- a/Packages/tests/Basic/UTF_SweepFormula_Operations.ipf
+++ b/Packages/tests/Basic/UTF_SweepFormula_Operations.ipf
@@ -2159,6 +2159,18 @@ static Function TestOperationLabNotebook()
 	Make/D/FREE refContents = {1}
 	CHECK_EQUAL_WAVES(secondEntry, refContents, mode = WAVE_DATA)
 
+	// multiple keys with wildcard
+	str = "labnotebook([\"ADC\", \"Operating *\"], select(selchannels(AD2), selsweeps([0])), DATA_ACQUISITION_MODE)"
+	WAVE/WAVE dataRef = SF_ExecuteFormula(str, win, useVariables = 0)
+	CHECK_EQUAL_VAR(DimSize(dataRef, ROWS), 2)
+	WAVE firstEntry = dataRef[0]
+	Make/D/FREE refContents = {2}
+	CHECK_EQUAL_WAVES(firstEntry, refContents, mode = WAVE_DATA)
+
+	WAVE secondEntry = dataRef[1]
+	Make/D/FREE refContents = {1}
+	CHECK_EQUAL_WAVES(secondEntry, refContents, mode = WAVE_DATA)
+
 	// no match with wildcards
 	str = "labnotebook([\"eee*\"], select(selchannels(AD2), selsweeps([0])), DATA_ACQUISITION_MODE)"
 	WAVE/WAVE dataRef = SF_ExecuteFormula(str, win, useVariables = 0)


### PR DESCRIPTION
We need to check each given labnotebook key where the potential wildcard
matches.

Bug introduced in d301352 (SweepFormula labnotebook: Enhance it, 2024-09-10).

Will merge once CI passes.