### PR TITLE
SF_OperationTPIterate: Handle non-existing sweep data

### DIFF
--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -3219,8 +3219,8 @@ static Function/WAVE SF_OperationTPIterate(string graph, WAVE/WAVE mode, WAVE/Z/
 			continue
 		endif
 
-		WAVE/Z    selectData = selectDataComp[%SELECTION]
-		WAVE/WAVE sweepData  = SF_OperationTPImpl(graph, mode, selectData, ignoreTPs, opShort)
+		WAVE/Z      selectData = selectDataComp[%SELECTION]
+		WAVE/Z/WAVE sweepData  = SF_OperationTPImpl(graph, mode, selectData, ignoreTPs, opShort)
 		if(!WaveExists(sweepData))
 			continue
 		endif

--- a/Packages/tests/Basic/UTF_SweepFormula_Operations.ipf
+++ b/Packages/tests/Basic/UTF_SweepFormula_Operations.ipf
@@ -328,6 +328,18 @@ static Function CheckTPFitResult(WAVE/WAVE wv, string fit, string result, variab
 	CHECK_EQUAL_VAR(trailLength, maxlength)
 End
 
+static Function TestOperationTP()
+
+	string win, formula
+
+	win = GetDataBrowserWithData()
+
+	formula = "tp(tpfit(exp, amp), select(selvis(all), selsweeps(1000)))"
+	WAVE/Z/WAVE output = SF_ExecuteFormula(formula, win, useVariables = 0)
+	CHECK_WAVE(output, WAVE_WAVE)
+	CHECK_EQUAL_VAR(DimSize(output, ROWS), 0)
+End
+
 static Function TestOperationTPfit()
 
 	string formula, strRef, dataType, dataTypeRef


### PR DESCRIPTION
Broken since 83713dd90 (SF Implement new select operation, 2024-10-02).
