### PR TITLE
MIES_GlobalStringAndVariableAccess.ipf: fix return in mac code

### DIFF
--- a/Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf
+++ b/Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf
@@ -304,7 +304,7 @@ static Function ExecuteGitForMIESVersion(string gitPathOrName, string gitDir, st
 	if(V_flag)
 		printf "Missing functional git executable, please install the \"Xcode commandline tools\" via \"xcode-select --install\" in Terminal.\r"
 		ControlWindowToFront()
-		break
+		abort
 	endif
 
 	sprintf cmd, "do shell script \"%s --git-dir='%s' describe --always --tags --match 'Release_*' > '%sversion.txt' 2>&1\"", gitPathOrName, gitDir, topDir


### PR DESCRIPTION
The function `ExecuteGitForMIESVersion()` contained MacOSX specific code with an invalid break statement. This one doesn't compile, because it wasn't used inside a loop or switch statement and is now replaced with an abort according to the function documentation.

Thanks for opening a PR in MIES :sparkles:!

- Code can only be merged if the continous integration tests pass
- [x] Please ensure that the branch is named correctly. See
  [here](https://alleninstitute.github.io/MIES/developers.html#branch-naming-scheme) for the detailed explanation.
