### PR TITLE
Bugfix: CheckForBugMessage caused WaveLeak if storage not initialized

### DIFF
--- a/Packages/tests/Basic/UTF_PGCSetAndActivateControl.ipf
+++ b/Packages/tests/Basic/UTF_PGCSetAndActivateControl.ipf
@@ -7,6 +7,8 @@ static StrConstant PGCT_POPUPMENU_ENTRIES = "Entry1;Entry2;Entry3"
 
 static Function TEST_CASE_BEGIN_OVERRIDE(string testCase)
 
+	TestCaseBeginCommon(testCase)
+
 	CreatePGCTestPanel_IGNORE()
 
 	CA_FlushCache()


### PR DESCRIPTION
If the TSDS_BUGCOUNT storage in TUFXOP is not initialized before a test case then the readout in CheckForBugMessage creates the storage. With WaveTracking enabled, e.g. AUTOMATED_TESTING_EXPENSIVE is defined then these waves are counted as wave leak.

The TSDS_BUGCOUNT storage is initialized in AdditionalExperimentCleanup that is called from TestCaseBeginCommon.

The local TEST_CASE_BEGIN_OVERRIDE/TEST_CASE_END_OVERRIDE in UTF_PGCSetAndActivateControl.ipf only called CheckForBugMessage for the END but never TestCaseBeginCommon for the BEGIN.
This results in a wave leak reported for the very first TestCase run if from this TestSuite.

Fix:
Call TestCaseBeginCommon in the local TEST_CASE_BEGIN_OVERRIDE function.

since
0b0032e1 (RunAllTests/PA_Tests: Check for bug messages as well, 2022-07-29)
