### PR TITLE
Add CI for IP10

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -109,13 +109,14 @@ jobs:
         run: tools/pre-commit/run.sh
 
   CompilationTest:
-    name: 👩🏾‍🔬 Compilation of ${{ matrix.source }} ${{ fromJSON('["","with XOP"]')[matrix.hardware] }}
+    name: 👩🏾‍🔬 Compilation of ${{ matrix.source }} ${{ fromJSON('["","with XOP"]')[matrix.hardware] }} v${{ matrix.version }}
     needs:
       - BuildInstaller
     strategy:
       matrix:
         source: [ git, installer ]
         hardware: [ false, true ]
+        version: [9, 10]
         exclude:
           # the git source is always checked with hardware support
           - source: git
@@ -127,8 +128,9 @@ jobs:
       experiment: Packages/tests/Compilation/CompilationTester.pxp
       installer_artifact_name: BuildInstaller-assets
       installer_flags: ${{ fromJSON('["-x skipHardwareXOPs",""]')[matrix.hardware] }} -s ${{ matrix.source }}
-      artifact_name: CompilationTest-${{ matrix.source }}-${{ fromJSON('["no-hardware","hardware"]')[matrix.hardware] }}-assets
+      artifact_name: CompilationTest-${{ matrix.source }}-${{ fromJSON('["no-hardware","hardware"]')[matrix.hardware] }}-v${{ matrix.version }}-assets
       timeout_minutes: 60
+      major_igorpro_version: ${{ matrix.version }}
 
   CompilationEachCommitTest:
     name: 👩🏾‍🔬 Compilation of each commit
@@ -165,13 +167,20 @@ jobs:
           if-no-files-found: error
 
   TestWithoutHardware:
-    name: 🧪 Test ${{ matrix.name }}
+    name: 🧪 Test ${{ matrix.name }} v${{ matrix.version }}
     needs:
       - BuildInstaller
       - Linting
       - CompilationTest
     strategy:
       matrix:
+        version:
+          - 9
+          - 10
+        name:
+          - Basic
+          - PAPlot
+          - HistoricData
         include:
           - experiment: Packages/tests/Basic/Basic.pxp
             name: Basic
@@ -179,15 +188,21 @@ jobs:
             name: PAPlot
           - experiment: Packages/tests/HistoricData/HistoricData.pxp
             name: HistoricData
+        exclude:
+          - version: 10
+            name: PAPlot
+          - version: 10
+            name: HistoricData
     uses: ./.github/workflows/test-igor-workflow.yml
     with:
       job_name: 🧪 Test ${{ matrix.name }}
       overwrite_job_name: ${{ inputs.is_called_workflow || false }}
       experiment: ${{ matrix.experiment }}
-      artifact_name: TestWithoutHardware-${{ matrix.name }}-assets
+      artifact_name: TestWithoutHardware-${{ matrix.name }}-v${{ matrix.version }}-assets
       expensive_checks: "1"
       instrument_tests: ${{ fromJson('["0", "1"]')[inputs.do_instrumentation] }}
       timeout_minutes: 60
+      major_igorpro_version: ${{ matrix.version }}
 
   TestNI:
     name: 🧪 Test NI ${{ matrix.name }}

--- a/.github/workflows/test-igor-rebase-exec-workflow.yml
+++ b/.github/workflows/test-igor-rebase-exec-workflow.yml
@@ -2,8 +2,9 @@ name: Test Rebase Exec Igor Workflow
 run-name: Test Rebase Exec Igor Workflow
 env:
   # if this environment variable is set it will use the igor version from
-  # C:\Program Files\WaveMetrics\Igor Pro 9 Folder\IgorBinaries_x64_${CI_IGOR_REVISION}
-  CI_IGOR_REVISION: "r56565"
+  # C:\Program Files\WaveMetrics\Igor Pro ${VERSION} Folder\IgorBinaries_x64_${CI_IGOR${VERSION}_REVISION}
+  CI_IGOR9_REVISION: "r56565"
+  CI_IGOR10_REVISION: "r29303"
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/test-igor-rebase-exec-workflow.yml
+++ b/.github/workflows/test-igor-rebase-exec-workflow.yml
@@ -57,6 +57,11 @@ on:
         default: 360
         type: number
         description: Defines the job timeout in minutes
+      major_igorpro_version:
+        required: false
+        default: 9
+        type: number
+        description: The major Igor Pro version to use
 defaults:
   run:
     shell: bash
@@ -95,7 +100,7 @@ jobs:
         run: |
              git rebase --exec "git log --pretty=ref -n1"                                                \
                         --exec "tools/clean_mies_installation.sh ${{ inputs.installer_flags }}"          \
-                        --exec "tools/autorun-test.sh -p ${{ inputs.experiment }} -v IP_9_64" ${{ env.CI_BASE_BRANCH }}
+                        --exec "tools/autorun-test.sh -p ${{ inputs.experiment }} -v IP_${{ inputs.major_igorpro_version }}_64" ${{ env.CI_BASE_BRANCH }}
       - name: Gather log files and crash dumps
         if: always()
         run: tools/gather-logfiles-and-crashdumps.sh

--- a/.github/workflows/test-igor-workflow.yml
+++ b/.github/workflows/test-igor-workflow.yml
@@ -2,8 +2,9 @@ name: Test Igor Workflow
 run-name: Test Igor Workflow
 env:
   # if this environment variable is set it will use the igor version from
-  # C:\Program Files\WaveMetrics\Igor Pro 9 Folder\IgorBinaries_x64_${CI_IGOR_REVISION}
-  CI_IGOR_REVISION: "r56565"
+  # C:\Program Files\WaveMetrics\Igor Pro ${VERSION} Folder\IgorBinaries_x64_${CI_IGOR${VERSION}_REVISION}
+  CI_IGOR9_REVISION: "r56565"
+  CI_IGOR10_REVISION: "r29303"
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/test-igor-workflow.yml
+++ b/.github/workflows/test-igor-workflow.yml
@@ -57,6 +57,11 @@ on:
         default: 360
         type: number
         description: Defines the job timeout in minutes
+      major_igorpro_version:
+        required: false
+        default: 9
+        type: number
+        description: The major Igor Pro version to use
 defaults:
   run:
     shell: bash
@@ -85,7 +90,7 @@ jobs:
       - name: Clean MIES installation
         run: tools/clean_mies_installation.sh ${{ inputs.installer_flags }}
       - name: Test experiment ${{ inputs.experiment }}
-        run: tools/autorun-test.sh -p ${{ inputs.experiment }} -v IP_9_64
+        run: tools/autorun-test.sh -p ${{ inputs.experiment }} -v IP_${{ inputs.major_igorpro_version }}_64
       - name: Gather log files and crash dumps
         if: always()
         run: tools/gather-logfiles-and-crashdumps.sh

--- a/Packages/MIES_Include.ipf
+++ b/Packages/MIES_Include.ipf
@@ -20,11 +20,14 @@
 // They are defined here so that we can parse them from within IP.
 //
 // .. |IgorPro9WindowsNightly| replace:: `Igor Pro 9 (Windows) <https://www.byte-physics.de/Downloads/WinIgor9_01Dec2023.zip>`__
+// .. |IgorPro10WindowsNightly| replace:: `Igor Pro 10 (Windows) <https://www.wavemetrics.net/Downloads/latest10/>`__
 // .. |IgorPro9MacOSXNightly| replace:: `Igor Pro 9 (MacOSX) <https://www.byte-physics.de/Downloads/MacIgor9_01Dec2023.dmg>`__
 
 #pragma IgorVersion = 9.00
 
 #if IgorVersion() < 10 && (NumberByKey("BUILD", IgorInfo(0)) < 56565)
+#define TOO_OLD_IGOR
+#elif IgorVersion() == 10 && (NumberByKey("BUILD", IgorInfo(0)) < 29303)
 #define TOO_OLD_IGOR
 #endif
 
@@ -72,6 +75,10 @@ static Function/S GetDownloadLink()
 #else
 	FATAL_ERROR("Unsupported OS")
 #endif
+
+	if(cmpstr(igorMajorVersion, "9"))
+		Abort "Download for Igor Pro 10 is not yet supported.\r Please manually download the nightly build from the documentation link."
+	endif
 
 	text         = ProcedureText("", 0, "MIES_Include.ipf")
 	lineWithLink = GrepList(text, "\\Q|IgorPro" + igorMajorVersion + os + "Nightly|\\E", 0, "\r")

--- a/Packages/MIES_Include.ipf
+++ b/Packages/MIES_Include.ipf
@@ -7,8 +7,9 @@
 ///
 /// Developer instructions for raising the required nightly versions:
 ///
-/// - Update the revision numbers for IP9 below in the expression involving
-///   `BUILD`, and also `CI_IGOR_REVISION` in .github/workflows/test-igor-workflow.yml
+/// - Update the revision numbers for IP9/10 below in the expression involving
+///   `BUILD`, `CI_IGOR9_REVISION`, `CI_IGOR10_REVISION` in .github/workflows/test-igor-workflow.yml
+///   and .github/workflows/test-igor-rebase-exec-workflow.yml
 /// - Upload the nightly zip packages to the FTP (Thomas' job). Don't delete the
 ///   old zip packages, we still need them.
 /// - Update the below URLs

--- a/Packages/doc/installation.rst
+++ b/Packages/doc/installation.rst
@@ -38,6 +38,9 @@ In that case please perform the following steps:
 - MacOSX: Install from image as usual
 - Restart Igor Pro
 
+For Igor Pro 10, download the installer for |IgorPro10WindowsNightly|. This requires access to the beta
+program of WaveMetrics.
+
 Installation using the installer (preferred)
 --------------------------------------------
 

--- a/tools/clean_mies_installation.sh
+++ b/tools/clean_mies_installation.sh
@@ -155,6 +155,7 @@ do
     cp -r  "$base_folder"/XOPs-IP9-64bit/ZeroMQ*  "$xops64"
     cp -r  "$base_folder"/XOPs-IP9-64bit/TUF*  "$xops64"
     cp -r  "$base_folder"/XOPs-IP9-64bit/libzmq*  "$xops64"
+    cp -r  "$base_folder"/XOPs-IP9-64bit/mies-nwb2-compound*  "$xops64"
   fi
 
   if [ "$sourceLoc" = "git" ]

--- a/tools/clean_mies_installation.sh
+++ b/tools/clean_mies_installation.sh
@@ -110,7 +110,7 @@ then
   fi
 fi
 
-versions="9"
+versions="9 10"
 
 for i in $versions
 do
@@ -148,13 +148,13 @@ do
 
   if [ "$skipHardwareXOPs" = "0" ]
   then
-    cp -r  "$base_folder"/XOPs-IP${i}-64bit/*  "$xops64"
+    cp -r  "$base_folder"/XOPs-IP9-64bit/*  "$xops64"
   else
-    cp -r  "$base_folder"/XOPs-IP${i}-64bit/MIESUtils*  "$xops64"
-    cp -r  "$base_folder"/XOPs-IP${i}-64bit/JSON*  "$xops64"
-    cp -r  "$base_folder"/XOPs-IP${i}-64bit/ZeroMQ*  "$xops64"
-    cp -r  "$base_folder"/XOPs-IP${i}-64bit/TUF*  "$xops64"
-    cp -r  "$base_folder"/XOPs-IP${i}-64bit/libzmq*  "$xops64"
+    cp -r  "$base_folder"/XOPs-IP9-64bit/MIESUtils*  "$xops64"
+    cp -r  "$base_folder"/XOPs-IP9-64bit/JSON*  "$xops64"
+    cp -r  "$base_folder"/XOPs-IP9-64bit/ZeroMQ*  "$xops64"
+    cp -r  "$base_folder"/XOPs-IP9-64bit/TUF*  "$xops64"
+    cp -r  "$base_folder"/XOPs-IP9-64bit/libzmq*  "$xops64"
   fi
 
   if [ "$sourceLoc" = "git" ]

--- a/tools/get-igor-path.sh
+++ b/tools/get-igor-path.sh
@@ -10,10 +10,22 @@ versionString=$1
 version=$(echo $versionString | cut -f 2 -d "_")
 bitness=$(echo $versionString | cut -f 3 -d "_")
 
-if [ "$CI_IGOR_REVISION" = "" ]; then
+if [ "$CI_IGOR9_REVISION" = "" -a "$CI_IGOR10_REVISION" = "" ]
+then
   revision=""
 else
-  revision="_$CI_IGOR_REVISION"
+  # not using indirection here, see https://mywiki.wooledge.org/BashFAQ/006#Indirection
+  # as that seems to be not stable enough
+  if [ $version -eq 9 ]
+  then
+    revision="_$CI_IGOR9_REVISION"
+  elif [ $version -eq 10 ]
+  then
+    revision="_$CI_IGOR10_REVISION"
+  else
+    echo "Invalid version" > /dev/stderr
+    exit 1
+  fi
 fi
 
 if [ $bitness -eq 32 ]

--- a/tools/installer/installer.nsi
+++ b/tools/installer/installer.nsi
@@ -26,10 +26,10 @@
 !define IGOR64EXTENSIONPATH "Igor Extensions (64-bit)"
 # Endings for Helpfiles
 !define IGOR9DIRTEMPL "IP9"
-!define IGOR10DIRTEMPL "IP10"
+!define IGOR10DIRTEMPL "IP9"
 # source folder name for installation with XOPs
 !define IGOR964XOPSOURCETEMPL "XOPs-IP9-64bit"
-!define IGOR1064XOPSOURCETEMPL "XOPs-IP10-64bit"
+!define IGOR1064XOPSOURCETEMPL "XOPs-IP9-64bit"
 
 # source file names for XOPs for installation without Hardware XOPs
 !define IGORUTILXOPSOURCETEMPL "MIESUtils-64.xop"

--- a/tools/installer/installer.nsi
+++ b/tools/installer/installer.nsi
@@ -24,7 +24,7 @@
 
 # This section defines paths
 !define IGOR64EXTENSIONPATH "Igor Extensions (64-bit)"
-# Endings for Helpfiles- and Packages\HDF- folders
+# Endings for Helpfiles
 !define IGOR9DIRTEMPL "IP9"
 !define IGOR10DIRTEMPL "IP10"
 # source folder name for installation with XOPs


### PR DESCRIPTION
- [x] https://github.com/byte-physics/igortest/issues/492
- [x] Add IP10 on the CI machines
- [x] Add IgorPro10 runner tag
- [x] IP10: Fix path on gw1/gw2 machines to have rXXX in the same way as for IP9
- [x] Make CI_IGOR_REVISION per IP major version and adapt get-igor-path.sh
- [x] Add TestWithoutHardware variant where we execute Basic.pxp for IP10
- [x] Polish commits
- [x] Get IP10 installed on the XXXmb machine
- [x] Remove IgoprProXX labels and their use
- [x] Register IP10 with IP9 credentials on all machines
- [x] Let it finish and check what was run
- [x] Adapt required jobs in github UI
- [x] Merge

Close #2405 