### PR TITLE
GetAllFilesRecursivelyFromPath: Speed it up with custom extension

### DIFF
--- a/Packages/Conversion/MIES_MassExperimentProcessing.ipf
+++ b/Packages/Conversion/MIES_MassExperimentProcessing.ipf
@@ -296,17 +296,16 @@ Function StartMultiExperimentProcessWrapper()
 	outputFolder = S_Path
 	ASSERT(V_flag, "Invalid path")
 
-	files = GetAllFilesRecursivelyFromPath("MultiExperimentInputFolder", extension = ".pxp")
+	WAVE/Z files = GetAllFilesRecursivelyFromPath("MultiExperimentInputFolder", regex = "(?i)\.pxp$")
 
-	// 16: Case-insensitive alphanumeric sort that sorts wave0 and wave9 before wave10.
-	// ...
-	// 64: Ignore + and - in the alphanumeric sort so that "Text-09" sorts before "Text-10". Set options to 80 or 81.
-	files = SortList(files, FILE_LIST_SEP, 80)
-
-	WAVE/Z/T inputPXPs = ListToTextWave(files, FILE_LIST_SEP)
+	if(WaveExists(files))
+		Sort/A=2 files, files
+	else
+		Make/FREE/T/N=0 files
+	endif
 
 	jsonID = JSON_New()
-	JSON_AddWave(jsonID, "/inputFiles", inputPXPs)
+	JSON_AddWave(jsonID, "/inputFiles", files)
 	JSON_AddString(jsonID, "/inputFolder", inputFolder)
 	JSON_AddString(jsonID, "/outputFolder", outputFolder)
 	JSON_AddVariable(jsonID, "/index", 0)

--- a/Packages/MIES/MIES_AnalysisBrowser.ipf
+++ b/Packages/MIES/MIES_AnalysisBrowser.ipf
@@ -2649,19 +2649,24 @@ static Function AB_AddExperimentEntries(string win, WAVE/T entries)
 			symbPath = GetUniqueSymbolicPath()
 			NewPath/O/Q/Z $symbPath, entry
 			if(GetCheckBoxState(win, "check_load_pxp"))
-				pxpList = GetAllFilesRecursivelyFromPath(symbPath, extension = ".pxp")
-				uxpList = GetAllFilesRecursivelyFromPath(symbPath, extension = ".uxp")
-			else
-				pxpList = ""
-				uxpList = ""
+				WAVE/Z/T pxps = GetAllFilesRecursivelyFromPath(symbPath, regex = "(?i)\.(pxp|uxp)$")
 			endif
 			if(GetCheckBoxState(win, "check_load_nwb"))
-				nwbList = GetAllFilesRecursivelyFromPath(symbPath, extension = ".nwb")
-			else
-				nwbList = ""
+				WAVE/Z/T nwbs = GetAllFilesRecursivelyFromPath(symbPath, regex = "(?i)\.nwb$")
 			endif
 			KillPath/Z $symbPath
-			WAVE/T fileList = ListToTextWave(SortList(pxpList + uxpList + nwbList, FILE_LIST_SEP), FILE_LIST_SEP)
+
+			if(WaveExists(pxps) && WaveExists(nwbs))
+				Concatenate/NP=(ROWS)/FREE/T {nwbs, pxps}, fileList
+			elseif(WaveExists(pxps))
+				WAVE/T fileList = pxps
+			elseif(WaveExists(nwbs))
+				WAVE/T fileList = nwbs
+			else
+				break
+			endif
+
+			Sort fileList, fileList
 		elseif(FileExists(entry))
 			Make/FREE/T fileList = {entry}
 		else

--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -297,25 +297,26 @@ End
 /// @brief Return a text wave with absolute paths to the JSON configuration files
 static Function/WAVE CONF_GetConfigFiles([string customIPath])
 
-	string settingsPath, fileList
+	string settingsPath
 
 	if(ParamIsDefault(customIPath))
 		settingsPath = CONF_GetSettingsPath(CONF_AUTO_LOADER_GLOBAL)
 	else
 		settingsPath = customIPath
 	endif
-	fileList = GetAllFilesRecursivelyFromPath(settingsPath, extension = ".json")
 
-	if(IsEmpty(fileList) && !ParamIsDefault(customIPath))
+	WAVE/Z/T fileList = GetAllFilesRecursivelyFromPath(settingsPath, regex = "(?i)\.json$")
+
+	if(!WaveExists(fileList) && !ParamIsDefault(customIPath))
 		settingsPath = CONF_GetSettingsPath(CONF_AUTO_LOADER_USER)
-		fileList     = GetAllFilesRecursivelyFromPath(settingsPath, extension = ".json")
+		WAVE/Z/T fileList = GetAllFilesRecursivelyFromPath(settingsPath, regex = "(?i)\.json$")
 	endif
 
-	if(IsEmpty(fileList))
+	if(!WaveExists(fileList))
 		return $""
 	endif
 
-	return ListToTextWave(fileList, FILE_LIST_SEP)
+	return fileList
 End
 
 /// @brief Automatically loads all *.json files from MIES Settings folder and opens and restores the corresponding windows

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -4711,8 +4711,7 @@ End
 
 static Function DAP_LoadBuiltinStimsets()
 
-	string symbPath, stimset, files, filename
-	variable i, numEntries
+	string symbPath, filename
 
 	symbPath = GetUniqueSymbolicPath()
 	NewPath/Q $symbPath, GetFolder(FunctionPath("")) + ":Stimsets"
@@ -4723,10 +4722,13 @@ static Function DAP_LoadBuiltinStimsets()
 		return NaN
 	endif
 
-	files      = GetAllFilesRecursivelyFromPath(symbPath, extension = ".nwb")
-	numEntries = ItemsInList(files, FILE_LIST_SEP)
-	for(i = 0; i < numEntries; i += 1)
-		filename = StringFromList(i, files, FILE_LIST_SEP)
+	WAVE/Z/T files = GetAllFilesRecursivelyFromPath(symbPath, regex = "(?i)\.nwb$")
+
+	if(!WaveExists(files))
+		return NaN
+	endif
+
+	for(filename : files)
 		NWB_LoadAllStimsets(filename = filename, overwrite = 1, loadOnlyBuiltins = 1)
 	endfor
 

--- a/Packages/MIES/MIES_DebugPanel.ipf
+++ b/Packages/MIES/MIES_DebugPanel.ipf
@@ -75,7 +75,7 @@ End
 
 static Function DP_FillDebugPanelWaves()
 
-	string symbPath, path, allProcFiles
+	string symbPath, path
 
 	WAVE/T listWave    = GetDebugPanelListWave()
 	WAVE   listSelWave = GetDebugPanelListSelWave()
@@ -84,15 +84,17 @@ static Function DP_FillDebugPanelWaves()
 
 	path = FunctionPath("") + "::"
 	NewPath/Q/O $symbPath, path
-	allProcFiles = GetAllFilesRecursivelyFromPath(symbPath, extension = ".ipf")
+	WAVE/Z allProcFilesMIES = GetAllFilesRecursivelyFromPath(symbPath, regex = "(?i)\.ipf$")
+	ASSERT(WaveExists(allProcFilesMIES), "Expected some MIES procedure files")
 
 	path += ":IPNWB"
 	NewPath/Q/O $symbPath, path
-	allProcFiles = AddListItem(allProcFiles, GetAllFilesRecursivelyFromPath(symbPath, extension = ".ipf"), FILE_LIST_SEP)
+	WAVE/Z allProcFilesIPNWB = GetAllFilesRecursivelyFromPath(symbPath, regex = "(?i)\.ipf$")
+	ASSERT(WaveExists(allProcFilesIPNWB), "Expected some IPNWB procedure files")
 
 	KillPath $symbPath
 
-	WAVE/T list = ListToTextWave(allProcFiles, FILE_LIST_SEP)
+	Concatenate/FREE/NP=(ROWS)/T {allProcFilesMIES, allProcFilesIPNWB}, list
 	// remove path components
 	list = GetFile(list[p])
 	// remove non mies files

--- a/Packages/MIES/MIES_MiesUtilities_Uploads.ipf
+++ b/Packages/MIES/MIES_MiesUtilities_Uploads.ipf
@@ -182,12 +182,10 @@ Function UploadCrashDumps()
 
 	diagSymbPath = GetSymbolicPathForDiagnosticsDirectory()
 
-	WAVE/T files = ListTotextWave(GetAllFilesRecursivelyFromPath(diagSymbPath, extension = ".dmp"), FILE_LIST_SEP)
-	WAVE/T logs  = ListTotextWave(GetAllFilesRecursivelyFromPath(diagSymbPath, extension = ".txt"), FILE_LIST_SEP)
-	numFiles = DimSize(files, ROWS)
-	numLogs  = DimSize(logs, ROWS)
+	WAVE/Z/T files = GetAllFilesRecursivelyFromPath(diagSymbPath, regex = "(?i)\.dmp$")
+	WAVE/Z/T logs  = GetAllFilesRecursivelyFromPath(diagSymbPath, regex = "(?i)\.txt$")
 
-	if(!numFiles && !numLogs)
+	if(!WaveExists(files) && !WaveExists(logs))
 		return NaN
 	endif
 

--- a/Packages/MIES/MIES_Utilities_File.ipf
+++ b/Packages/MIES/MIES_Utilities_File.ipf
@@ -223,95 +223,161 @@ Function/S GetUniqueSymbolicPath([string prefix])
 End
 
 /// @brief Return a list of all files from the given symbolic path
-///        and its subfolders. The list is pipe (`FILE_LIST_SEP`) separated as
-///        the semicolon (`;`) is a valid character in filenames.
-///
-/// Note: This function does *not* work on MacOSX as there filenames are allowed
-///       to have pipe symbols in them.
+///        and its subfolders.
 ///
 /// @param pathName igor symbolic path to search recursively
-/// @param extension [optional, defaults to all files] file suffixes to search for
-Function/S GetAllFilesRecursivelyFromPath(string pathName, [string extension])
+/// @param regex [optional, defaults to all files] regular expression to match the absolute file path against
+/// @param resolveAliases [optional, defaults to false] attempt to resolve aliases/shortcuts (slows down execution!)
+Function/WAVE GetAllFilesRecursivelyFromPath(string pathName, [string regex, variable resolveAliases])
 
-	string fileOrPath, folders, subFolderPathName, fileName
-	string files, allFilesList
-	string allFiles         = ""
-	string foldersFromAlias = ""
-	variable err, isWindows
+	string files, subFoldersList, subFilesList, cdf, workPath
+	variable err
+	variable numFolders, numFiles, needsAliasResolving, i, needsFiltering
 
-#ifdef WINDOWS
-	isWindows = 1
-#endif // WINDOWS
+	if(ParamIsDefault(regex))
+		regex = ".*"
+	else
+		ASSERT(IsValidRegexp(regex), "Expected a valid regex")
+		needsFiltering = 1
+	endif
+
+	if(ParamIsDefault(resolveAliases))
+		resolveAliases = 0
+	else
+		resolveAliases = !!resolveAliases
+	endif
+
+	Make/FREE/N=(MINIMUM_WAVE_SIZE_LARGE)/T resultFiles
+	SetNumberInWaveNote(resultFiles, NOTE_INDEX, 0)
+
+	Make/FREE/N=(MINIMUM_WAVE_SIZE)/T folders
+	SetNumberInWaveNote(folders, NOTE_INDEX, 0)
 
 	PathInfo $pathName
 	ASSERT(V_flag, "Given symbolic path does not exist")
+	Make/T/FREE startFolder = {S_path}
+	numFolders = ConcatenateWavesWithNoteIndex(folders, startFolder)
 
-	if(ParamIsDefault(extension))
-		extension = "????"
-	endif
+	workPath = GetUniqueSymbolicPath()
 
 	AssertOnAndClearRTError()
-	allFilesList = IndexedFile($pathName, -1, extension, "????", FILE_LIST_SEP); err = GetRTError(1)
+	for(i = 0; i < numFolders; i += 1)
 
-	if(isWindows && cmpstr(extension, "????") && cmpstr(extension, ".lnk"))
-		allFiles = AddPrefixToEachListItem(S_path, allFilesList, sep = FILE_LIST_SEP)
-	else
-		// try to resolve aliases/shortcuts when we can have them
-		WAVE/T allFilesInDir = ListToTextWave(allFilesList, FILE_LIST_SEP)
-		for(fileName : allFilesInDir)
+		cdf = folders[i]
+		NewPath/Q/O/Z $workPath, cdf
 
-			GetFileFolderInfo/P=$pathName/Q/Z fileName
+		subFoldersList = IndexedDir($workPath, -1, 1, FILE_LIST_SEP); err = GetRTError(1)
+		if(!err)
+			WAVE/T subFolders = ListToTextWave(subFoldersList, FILE_LIST_SEP)
+			// add trailing colon
+			Multithread subFolders[] += ":"
 
-			if(V_Flag != 0)
-				// error querying file
-				continue
-			endif
+			ConcatenateWavesWithNoteIndex(folders, subFolders)
+		endif
 
-			if(V_IsAliasShortcut)
-				fileOrPath = ResolveAlias(fileName, pathName = pathName)
+		subFilesList = IndexedFile($workPath, -1, "????", "????", FILE_LIST_SEP); err = GetRTError(1)
+		if(!err)
+			WAVE/T subFiles = ListToTextWave(subFilesList, FILE_LIST_SEP)
+			// make them absolute
+			Multithread subFiles[] = cdf + subFiles[p]
 
-				if(IsEmpty(fileOrPath))
-					// dead alias
-					continue
-				endif
-
-				// redo the check
-				GetFileFolderInfo/P=$pathName/Q/Z fileOrPath
-
-				if(V_Flag != 0)
-					// error querying file/folder pointed to by alias
-					continue
-				endif
-			endif
-
-			if(V_isFile)
-				allFiles = AddListItem(S_path, allFiles, FILE_LIST_SEP, Inf)
-			elseif(V_isFolder)
-				foldersFromAlias = AddListItem(S_path, foldersFromAlias, FILE_LIST_SEP, Inf)
+			if(resolveAliases)
+				[WAVE/T filesResolved, WAVE/T foldersResolved] = GetAllFilesAliasHelper(subFiles)
 			else
-				ASSERT(0, "Unexpected file type")
+				WAVE/T filesResolved = subFiles
+				WAVE/ZZ/T foldersResolved
 			endif
-		endfor
-	endif
 
-	AssertOnAndClearRTError()
-	folders = IndexedDir($pathName, -1, 1, FILE_LIST_SEP); err = GetRTError(1)
-	folders = folders + foldersFromAlias
-	WAVE/T wFolders = ListToTextWave(folders, FILE_LIST_SEP)
-	for(folder : wFolders)
-
-		subFolderPathName = GetUniqueSymbolicPath()
-
-		NewPath/Q/O $subFolderPathName, folder
-		files = GetAllFilesRecursivelyFromPath(subFolderPathName, extension = extension)
-		KillPath/Z $subFolderPathName
-
-		if(!isEmpty(files))
-			allFiles = AddListItem(RemoveEnding(files, FILE_LIST_SEP), allFiles, FILE_LIST_SEP, Inf)
+			numFiles   = ConcatenateWavesWithNoteIndex(resultFiles, filesResolved)
+			numFolders = ConcatenateWavesWithNoteIndex(folders, foldersResolved)
 		endif
 	endfor
 
-	return allFiles
+	if(!numFiles)
+		return $""
+	endif
+
+	Redimension/N=(numFiles) resultFiles
+	Note/K resultFiles
+
+	if(needsFiltering)
+		WAVE/Z/T resultFilesFiltered = GrepTextWave(resultFiles, regex)
+	else
+		WAVE/T resultFilesFiltered = resultFiles
+	endif
+
+	return resultFilesFiltered
+End
+
+static Function [WAVE/Z/T filesResolved, WAVE/Z/T foldersResolved] GetAllFilesAliasHelper(WAVE/T files)
+
+	string fileName, fileOrPath
+	variable numFiles, numFolders
+
+	if(DimSize(files, ROWS) == 0)
+		return [$"", $""]
+	endif
+
+#ifdef WINDOWS
+	WAVE/Z/T aliasFiles = GrepTextWave(files, "\.lnk$")
+
+	if(!WaveExists(aliasFiles))
+		return [files, $""]
+	endif
+
+	WAVE/Z/T filesWithoutAliases = GrepTextWave(files, "\.lnk$", invert = 1)
+#else
+	WAVE aliasFiles = files
+	WAVE/ZZ filesWithoutAliases
+#endif // WINDOWS
+
+	Make/T/FREE/N=(MINIMUM_WAVE_SIZE) filesResolved, foldersResolved
+
+	for(fileName : aliasFiles)
+		fileOrPath = ResolveAlias(fileName)
+
+		if(IsEmpty(fileOrPath))
+			// broken alias
+			continue
+		elseif(!cmpstr(fileOrPath, fileName))
+			EnsureLargeEnoughWave(filesResolved, indexShouldExist = numFiles)
+			filesResolved[numFiles++] = fileOrPath
+			continue
+		endif
+
+		GetFileFolderInfo/Q/Z fileOrPath
+		ASSERT(!V_Flag, "Expected fileOrPath to exist")
+
+		if(V_isFile)
+			EnsureLargeEnoughWave(filesResolved, indexShouldExist = numFiles)
+			filesResolved[numFiles++] = S_path
+		elseif(V_isFolder)
+			EnsureLargeEnoughWave(foldersResolved, indexShouldExist = numFolders)
+			foldersResolved[numFolders++] = S_path
+		else
+			ASSERT(0, "Unexpected file type")
+		endif
+	endfor
+
+	if(numFiles == 0)
+		KillWaves filesResolved
+	else
+		Redimension/N=(numFiles) filesResolved
+	endif
+
+	if(numFolders == 0)
+		KillWaves foldersResolved
+	else
+		Redimension/N=(numFolders) foldersResolved
+	endif
+
+#ifdef WINDOWS
+	if(WaveExists(filesWithoutAliases))
+		Concatenate/NP=(ROWS)/FREE/T {filesWithoutAliases}, filesResolved
+	endif
+#endif // WINDOWS
+
+	return [filesResolved, foldersResolved]
 End
 
 /// @brief Open a folder selection dialog
@@ -727,18 +793,19 @@ End
 
 /// @brief Check if the file paths referenced in `list` are pointing
 ///        to identical files
-Function CheckIfPathsRefIdenticalFiles(string list)
+Function CheckIfPathsRefIdenticalFiles(WAVE/T list)
 
 	variable i, numEntries
 	string path, refHash, newHash
 
-	if(ItemsInList(list, FILE_LIST_SEP) <= 1)
+	numEntries = DimSize(list, ROWS)
+
+	if(numEntries <= 1)
 		return 1
 	endif
 
-	numEntries = ItemsInList(list, FILE_LIST_SEP)
 	for(i = 0; i < numEntries; i += 1)
-		path = StringFromList(i, list, FILE_LIST_SEP)
+		path = list[i]
 
 		if(i == 0)
 			refHash = CalcHashForFile(path)

--- a/Packages/MIES/MIES_Utilities_File.ipf
+++ b/Packages/MIES/MIES_Utilities_File.ipf
@@ -196,7 +196,7 @@ Function/S ResolveAlias(string path, [string pathName])
 	endif
 
 	if(!V_IsAliasShortcut)
-		return path
+		return S_path
 	endif
 
 	if(ParamIsDefault(pathName))

--- a/Packages/MIES/MIES_Utilities_File.ipf
+++ b/Packages/MIES/MIES_Utilities_File.ipf
@@ -195,15 +195,11 @@ Function/S ResolveAlias(string path, [string pathName])
 		return ""
 	endif
 
-	if(!V_IsAliasShortcut)
-		return S_path
+	if(V_IsAliasShortcut)
+		return S_aliasPath
 	endif
 
-	if(ParamIsDefault(pathName))
-		return ResolveAlias(S_aliasPath)
-	endif
-
-	return ResolveAlias(S_aliasPath, pathName = pathName)
+	return S_path
 End
 
 /// @brief Return a unique symbolic path name

--- a/Packages/MIES/MIES_Utilities_JSON.ipf
+++ b/Packages/MIES/MIES_Utilities_JSON.ipf
@@ -12,12 +12,12 @@
 /// @brief Helper function for UploadCrashDumps
 ///
 /// Fill `payload` array with content from files
-Function AddPayloadEntriesFromFiles(variable jsonID, WAVE/T paths, [variable isBinary])
+Function AddPayloadEntriesFromFiles(variable jsonID, WAVE/Z/T paths, [variable isBinary])
 
 	string data, fName, filepath, jsonpath
 	variable numEntries, i, offset
 
-	numEntries = DimSize(paths, ROWS)
+	numEntries = WaveExists(paths) ? DimSize(paths, ROWS) : 0
 	Make/FREE/N=(numEntries)/T values, keys
 
 	for(i = 0; i < numEntries; i += 1)

--- a/Packages/MIES/MIES_Utilities_Numeric.ipf
+++ b/Packages/MIES/MIES_Utilities_Numeric.ipf
@@ -110,8 +110,11 @@ End
 threadsafe Function FindNextPower(variable a, variable p)
 
 	ASSERT_TS(p > 1, "Invalid power")
-	ASSERT_TS(a > 0, "Invalid value")
 	ASSERT_TS(IsInteger(a), "Value has to be an integer")
+
+	if(a == 0)
+		return 1
+	endif
 
 	return ceil(log(a) / log(p))
 End

--- a/Packages/MIES/MIES_Utilities_WaveHandling.ipf
+++ b/Packages/MIES/MIES_Utilities_WaveHandling.ipf
@@ -45,6 +45,8 @@ threadsafe Function EnsureLargeEnoughWave(WAVE wv, [variable indexShouldExist, v
 
 	if(ParamIsDefault(dimension))
 		dimension = ROWS
+	else
+		ASSERT_TS(dimension == ROWS || dimension == COLS || dimension == LAYERS || dimension == CHUNKS, "Invalid dimension")
 	endif
 
 	if(ParamIsDefault(checkFreeMemory))
@@ -53,21 +55,18 @@ threadsafe Function EnsureLargeEnoughWave(WAVE wv, [variable indexShouldExist, v
 		checkFreeMemory = !!checkFreeMemory
 	endif
 
-	ASSERT_TS(dimension == ROWS || dimension == COLS || dimension == LAYERS || dimension == CHUNKS, "Invalid dimension")
 	ASSERT_TS(WaveExists(wv), "Wave does not exist")
 	ASSERT_TS(IsFinite(indexShouldExist) && indexShouldExist >= 0, "Invalid minimum size")
 
 	if(ParamIsDefault(indexShouldExist))
 		indexShouldExist = MINIMUM_WAVE_SIZE - 1
-	else
-		indexShouldExist = max(MINIMUM_WAVE_SIZE - 1, indexShouldExist)
 	endif
 
 	if(indexShouldExist < DimSize(wv, dimension))
 		return 0
 	endif
 
-	indexShouldExist *= 2
+	indexShouldExist = max(max(2^FindNextPower(indexShouldExist, 2), 2 * DimSize(wv, dimension)), MINIMUM_WAVE_SIZE)
 
 	if(checkFreeMemory)
 		if((GetWaveSize(wv) * (indexShouldExist / DimSize(wv, dimension)) / 1024 / 1024 / 1024) >= GetFreeMemory())

--- a/Packages/tests/Basic/UTF_Utils_File.ipf
+++ b/Packages/tests/Basic/UTF_Utils_File.ipf
@@ -268,6 +268,9 @@ static Function TestResolveAlias()
 	result = ResolveAlias(filePath)
 	CHECK_EQUAL_STR(result, filePath)
 
+	result = ResolveAlias("file.txt", pathName = symbPath)
+	CHECK_EQUAL_STR(result, filePath)
+
 	// plain folder
 	result = ResolveAlias(folder)
 	CHECK_EQUAL_STR(result, folder)

--- a/Packages/tests/Basic/UTF_Utils_Numeric.ipf
+++ b/Packages/tests/Basic/UTF_Utils_Numeric.ipf
@@ -162,14 +162,6 @@ End
 /// @{
 static Function TestFindNextPower()
 
-	// invalid a (zero)
-	try
-		FindNextPower(0, 2)
-		FAIL()
-	catch
-		CHECK_NO_RTE()
-	endtry
-
 	// invalid a (fractional)
 	try
 		FindNextPower(1.5, 2)
@@ -187,6 +179,7 @@ static Function TestFindNextPower()
 	endtry
 
 	// works
+	CHECK_EQUAL_VAR(1, FindNextPower(0, 100))
 	CHECK_EQUAL_VAR(2, FindNextPower(3, 2))
 	CHECK_EQUAL_VAR(3, FindNextPower(25, 3))
 End

--- a/Packages/tests/Basic/UTF_Utils_Numeric.ipf
+++ b/Packages/tests/Basic/UTF_Utils_Numeric.ipf
@@ -10,7 +10,6 @@
 // SetBit
 // ClearBit
 // MinMax
-// FindNextPower
 // FindPreviousPower
 // GetAlignment
 // CalculateLCM
@@ -157,4 +156,38 @@ static Function TestIndexAfterDecimation([STRUCT IUTF_mData &md])
 	CHECK_EQUAL_VAR(edgeLeft, edgeLeftCalculated)
 End
 
+/// @}
+
+/// FindNextPower
+/// @{
+static Function TestFindNextPower()
+
+	// invalid a (zero)
+	try
+		FindNextPower(0, 2)
+		FAIL()
+	catch
+		CHECK_NO_RTE()
+	endtry
+
+	// invalid a (fractional)
+	try
+		FindNextPower(1.5, 2)
+		FAIL()
+	catch
+		CHECK_NO_RTE()
+	endtry
+
+	// invalid p
+	try
+		FindNextPower(1, 1)
+		FAIL()
+	catch
+		CHECK_NO_RTE()
+	endtry
+
+	// works
+	CHECK_EQUAL_VAR(2, FindNextPower(3, 2))
+	CHECK_EQUAL_VAR(3, FindNextPower(25, 3))
+End
 /// @}

--- a/Packages/tests/Basic/UTF_Utils_WaveHandling.ipf
+++ b/Packages/tests/Basic/UTF_Utils_WaveHandling.ipf
@@ -160,6 +160,33 @@ Function ELE_AbortsWithTooLargeValue()
 	endtry
 End
 
+Function ELE_DoesNothingIfIndexIsGood()
+
+	Make/FREE/N=(1) wv
+	EnsurelargeEnoughWave(wv, indexShouldExist = 0)
+	CHECK_EQUAL_VAR(DimSize(wv, ROWS), 1)
+End
+
+Function ELE_ResizesGeometrically()
+
+	Make/FREE/N=(MINIMUM_WAVE_SIZE) wv
+	EnsurelargeEnoughWave(wv, indexShouldExist = MINIMUM_WAVE_SIZE + 1)
+	CHECK_EQUAL_VAR(DimSize(wv, ROWS), 2 * MINIMUM_WAVE_SIZE)
+
+	EnsurelargeEnoughWave(wv, indexShouldExist = 2 * MINIMUM_WAVE_SIZE + 1)
+	CHECK_EQUAL_VAR(DimSize(wv, ROWS), 4 * MINIMUM_WAVE_SIZE)
+
+	EnsurelargeEnoughWave(wv, indexShouldExist = 9 * MINIMUM_WAVE_SIZE)
+	CHECK_EQUAL_VAR(DimSize(wv, ROWS), 16 * MINIMUM_WAVE_SIZE)
+End
+
+Function ELE_WorksWithEmtpyInitialSize()
+
+	Make/FREE/N=(0) wv
+	EnsurelargeEnoughWave(wv, indexShouldExist = 0)
+	CHECK_EQUAL_VAR(DimSize(wv, ROWS), MINIMUM_WAVE_SIZE)
+End
+
 /// @}
 
 // GetWaveSize

--- a/Packages/tests/Basic/UTF_Utils_WaveHandling.ipf
+++ b/Packages/tests/Basic/UTF_Utils_WaveHandling.ipf
@@ -2087,3 +2087,157 @@ Function WTSOne()
 	endtry
 End
 /// @}
+
+/// ConcatenateWavesWithNoteIndex
+/// @{
+Function TestConcat_MissingDest()
+
+	try
+		ConcatenateWavesWithNoteIndex($"", $"")
+		FAIL()
+	catch
+		CHECK_NO_RTE()
+		PASS()
+	endtry
+End
+
+Function TestConcat_NoNote()
+
+	try
+		Make/FREE dest
+		ConcatenateWavesWithNoteIndex(dest, $"")
+		FAIL()
+	catch
+		CHECK_NO_RTE()
+		PASS()
+	endtry
+End
+
+Function TestConcat_UnmatchedTypes0()
+
+	try
+		Make/FREE dest
+		SetNumberInWaveNote(dest, NOTE_INDEX, 0)
+
+		Make/FREE/T src
+		ConcatenateWavesWithNoteIndex(dest, src)
+		FAIL()
+	catch
+		CHECK_NO_RTE()
+		PASS()
+	endtry
+End
+
+Function TestConcat_UnmatchedTypes1()
+
+	try
+		Make/FREE/D dest
+		SetNumberInWaveNote(dest, NOTE_INDEX, 0)
+
+		Make/FREE/R src
+		ConcatenateWavesWithNoteIndex(dest, src)
+		FAIL()
+	catch
+		CHECK_NO_RTE()
+		PASS()
+	endtry
+End
+
+Function TestConcat_OneDWaves()
+
+	try
+		Make/FREE dest
+		SetNumberInWaveNote(dest, NOTE_INDEX, 0)
+
+		Make/FREE/N=(1, 1) src
+		ConcatenateWavesWithNoteIndex(dest, src)
+		FAIL()
+	catch
+		CHECK_NO_RTE()
+		PASS()
+	endtry
+
+	try
+		Make/FREE/N=(1, 1) dest
+		SetNumberInWaveNote(dest, NOTE_INDEX, 0)
+
+		Make/FREE src
+		ConcatenateWavesWithNoteIndex(dest, src)
+		FAIL()
+	catch
+		CHECK_NO_RTE()
+		PASS()
+	endtry
+End
+
+Function TestConcat_NullSrc()
+
+	variable index
+
+	Make/FREE/N=1 dest
+	SetNumberInWaveNote(dest, NOTE_INDEX, 0)
+
+	index = ConcatenateWavesWithNoteIndex(dest, $"")
+	CHECK_EQUAL_VAR(index, 0)
+	CHECK_EQUAL_VAR(dest[0], 0)
+	CHECK_EQUAL_VAR(DimSize(dest, ROWS), 1)
+End
+
+Function TestConcat_EmptySrc()
+
+	variable index
+
+	Make/FREE/N=1 dest
+	SetNumberInWaveNote(dest, NOTE_INDEX, 0)
+
+	Make/FREE/N=0 src
+	index = ConcatenateWavesWithNoteIndex(dest, src)
+	CHECK_EQUAL_VAR(index, 0)
+	CHECK_EQUAL_VAR(dest[0], 0)
+	CHECK_EQUAL_VAR(DimSize(dest, ROWS), 1)
+End
+
+// UTF_TD_GENERATOR DataGenerators#GetConcatSingleElementWaves
+Function TestConcat_AddingSingleElement([WAVE src])
+
+	variable index
+
+	Duplicate/FREE src, dest
+	Redimension/N=(1) dest
+	SetNumberInWaveNote(dest, NOTE_INDEX, 0)
+
+	index = ConcatenateWavesWithNoteIndex(dest, src)
+	CHECK_EQUAL_VAR(index, 1)
+
+	CHECK_EQUAL_WAVES(dest, src, mode = WAVE_DATA)
+	CHECK_EQUAL_VAR(DimSize(dest, ROWS), 1)
+End
+
+Function TestConcat_AddingMoreElements()
+
+	variable index
+
+	Make/N=(1)/FREE dest
+	SetNumberInWaveNote(dest, NOTE_INDEX, 0)
+
+	Make/FREE src = p
+
+	index = ConcatenateWavesWithNoteIndex(dest, src)
+	CHECK_EQUAL_VAR(index, 128)
+
+	CHECK_EQUAL_WAVES(dest, src, mode = WAVE_DATA)
+	CHECK_EQUAL_VAR(DimSize(dest, ROWS), 128)
+
+	// and again
+	index = ConcatenateWavesWithNoteIndex(dest, src)
+	CHECK_EQUAL_VAR(index, 256)
+	CHECK_EQUAL_VAR(DimSize(dest, ROWS), 256)
+
+	Duplicate/FREE/R=[0, 127] dest, slice
+	CHECK_EQUAL_WAVES(slice, src, mode = WAVE_DATA)
+
+	Duplicate/FREE/R=[128, 255] dest, slice
+	CHECK_EQUAL_WAVES(slice, src, mode = WAVE_DATA)
+End
+
+/// @}

--- a/Packages/tests/HardwareBasic/UTF_ConfigurationHardware.ipf
+++ b/Packages/tests/HardwareBasic/UTF_ConfigurationHardware.ipf
@@ -26,7 +26,7 @@ End
 static Function RestoreAndSaveConfiguration([string str])
 
 	string settingsIPath, settingsFolder, templateFolder, workingFolder
-	string fileList, fName, fContent, fContentRig, wList
+	string fName, fContent, fContentRig, wList
 	variable jsonId
 	string templateIPath    = "templateConf"
 	string tempIPath        = "tempConf"
@@ -48,9 +48,9 @@ static Function RestoreAndSaveConfiguration([string str])
 	NewPath/O/Q $tempIPath, workingFolder
 
 	NewPath/O/Q $templateIPath, templateFolder
-	fileList = GetAllFilesRecursivelyFromPath(templateIPath, extension = ".json")
-	WAVE/T wFileList = ListToTextWave(fileList, "|")
-	for(fileName : wFileList)
+	WAVE/Z/T fileList = GetAllFilesRecursivelyFromPath(templateIPath, regex = "(?i)\.json$")
+	CHECK_WAVE(fileList, TEXT_WAVE | FREE_WAVE)
+	for(fileName : fileList)
 		[fContent, fName] = LoadTextFile(fileName)
 		jsonId            = JSON_Parse(fContent)
 

--- a/Packages/tests/UTF_DataGenerators.ipf
+++ b/Packages/tests/UTF_DataGenerators.ipf
@@ -1013,3 +1013,24 @@ static Function/WAVE PUB_TPFiltersWithoutData()
 
 	return wv
 End
+
+static Function/WAVE GetConcatSingleElementWaves()
+
+	Make/FREE/N=4/WAVE waves
+
+	Make/FREE srcNum = {4711}
+	waves[0] = srcNum
+
+	Make/FREE/T srcText = {"baccab"}
+	waves[1] = srcText
+
+	Make/FREE/DF srcDFR = {NewfreeDataFolder()}
+	waves[2] = srcDFR
+
+	Make/FREE/WAVE srcWv = {NewFreeWave(IGOR_TYPE_16BIT_INT, 0)}
+	waves[3] = srcWv
+
+	SetDimensionLabels(waves, "Numeric;Text;DFREF;WAVE", ROWS)
+
+	return waves
+End


### PR DESCRIPTION
We used to always perform alias/shortcut handling even when we only look for certain file suffixes.

But we only have to try following these if they can be part of the returned list.

So for the common case of Windows OS and a extension which does not match .lnk we can skip the alias resolving.

When we do have aliases we also first call GetFileFolderInfo and only if we have an alias ResolveAlias again, skipping another GetFileFolderInfo for the case when the pointed to file is not an alias.

This allows to gather 100k files on a 1Gb/s network link in under 60s.

```igorpro
Function Dostuff()

	Newpath/O testPath "Y:"

	beginfunctionProfiling(testTime = 50000)
	string result = getAllfilesRecursivelyFromPath("testPath", extension = ".mp3")
	endfunctionProfiling()
	printf  "Number of files: %d\r", ItemsInList(result, "|")
End
```

gives

```
Total time: 54.4173, Time in Function code: 54.3973 (100%)
Top function percentages:
Function MIES_Utilities_File.ipf GetAllFilesRecursivelyFromPath: 99%

Annotated Top Functions:

*******************************************************************************************
Function: MIES_Utilities_File.ipf MIES_Utilities_File.ipf#GetAllFilesRecursivelyFromPath; Percent total 99%
*******************************************************************************************
[00]          	|Function/S GetAllFilesRecursivelyFromPath(string pathName, [string extension])
[00]          	|
[00]          	|	string fileOrPath, folders, subFolderPathName, fileName
[00]          	|	string files, allFilesList
[00]          	|	string allFiles         = ""
[00]*         	|	string foldersFromAlias = ""
[00]          	|	variable err, isWindows
[00]          	|
[00]          	|#ifdef WINDOWS
[00]          	|	isWindows = 1
[00]          	|#endif
[00]          	|
[01]*         	|	PathInfo $pathName
[00]          	|	ASSERT(V_flag, "Given symbolic path does not exist")
[00]          	|
[00]          	|	if(ParamIsDefault(extension))
[00]          	|		extension = "????"
[00]          	|	endif
[00]          	|
[00]          	|	AssertOnAndClearRTError()
[70]*******   	|	allFilesList = IndexedFile($pathName, -1, extension, "????", FILE_LIST_SEP); err = GetRTError(1)
[00]          	|
[00]*         	|	if(isWindows && cmpstr(extension, "????") && cmpstr(extension, ".lnk"))
[00]          	|		allFiles = AddPrefixToEachListItem(S_path, allFilesList, sep = FILE_LIST_SEP)
[00]          	|	else
[00]          	|		// try to resolve aliases/shortcuts when we can have them
[00]          	|		WAVE/T allFilesInDir = ListToTextWave(allFilesList, FILE_LIST_SEP)
[00]          	|		for(fileName : allFilesInDir)
[00]          	|
[00]          	|			GetFileFolderInfo/P=$pathName/Q/Z fileName
[00]          	|
[00]          	|			if(V_Flag != 0)
[00]          	|				// error querying file
[00]          	|				continue
[00]          	|			endif
[00]          	|
[00]          	|			if(V_IsAliasShortcut)
[00]          	|				fileOrPath = ResolveAlias(fileName, pathName = pathName)
[00]          	|
[00]          	|				// redo the check
[00]          	|				GetFileFolderInfo/P=$pathName/Q/Z fileOrPath
[00]          	|
[00]          	|				if(V_Flag != 0)
[00]          	|					// error querying file/folder pointed to by alias
[00]          	|					continue
[00]          	|				endif
[00]          	|			endif
[00]          	|
[00]          	|			if(V_isFile)
[00]          	|				allFiles = AddListItem(S_path, allFiles, FILE_LIST_SEP, Inf)
[00]          	|			elseif(V_isFolder)
[00]          	|				foldersFromAlias = AddListItem(S_path, foldersFromAlias, FILE_LIST_SEP, Inf)
[00]          	|			else
[00]          	|				ASSERT(0, "Unexpected file type")
[00]          	|			endif
[00]          	|		endfor
[00]          	|	endif
[00]          	|
[00]          	|	AssertOnAndClearRTError()
[04]*         	|	folders = IndexedDir($pathName, -1, 1, FILE_LIST_SEP); err = GetRTError(1)
[00]          	|	folders = folders + foldersFromAlias
[00]*         	|	WAVE/T wFolders = ListToTextWave(folders, FILE_LIST_SEP)
[00]*         	|	for(folder : wFolders)
[00]          	|
[00]          	|		subFolderPathName = GetUniqueSymbolicPath()
[00]          	|
[12]*         	|		NewPath/Q/O $subFolderPathName, folder
[00]*         	|		files = GetAllFilesRecursivelyFromPath(subFolderPathName, extension = extension)
[11]*         	|		KillPath/Z $subFolderPathName
[00]          	|
[00]*         	|		if(!isEmpty(files))
[01]*         	|			allFiles = AddListItem(RemoveEnding(files, FILE_LIST_SEP), allFiles, FILE_LIST_SEP, Inf)
[00]          	|		endif
[00]          	|	endfor
[00]          	|
[00]          	|	return allFiles
[00]          	|End
```

- [x] Review comments
- [x] Check Mac behaviour
- [x] Fix
```
 Test finished with no errors
  ? Free wave leak detected (leaked waves: 6) in "ZeroMQPublishingTests#CheckTPPublishing:period_now"
End of test "MIES with Basic"
```
-> flaky test
- [x] Make that a CI failure, upstream issue: https://github.com/byte-physics/igortest/issues/494

Close #2402
Close https://github.com/AllenInstitute/MIES/issues/1733