### PR TITLE
SF_OperationPowerSpectrum: Fix average option with SweepBrowser data

### DIFF
--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -2075,36 +2075,35 @@ StrConstant CO_AB_LOADHISTORYFROMPXP = "ABLoadHistoryFromPXP"
 /// @name Constants for SweepFormula Meta data in JSON format
 /// @anchor SFMetaDataConstants
 ///@{
-StrConstant SF_META_DATATYPE             = "/DataType"           // string
-StrConstant SF_META_SWEEPNO              = "/SweepNumber"        // number
-StrConstant SF_META_RANGE                = "/Range"              // numeric wave
-StrConstant SF_META_CHANNELTYPE          = "/ChannelType"        // number
-StrConstant SF_META_CHANNELNUMBER        = "/ChannelNumber"      // number
-StrConstant SF_META_DEVICE               = "/Device"             // string
-StrConstant SF_META_EXPERIMENT           = "/Experiment"         // string
-StrConstant SF_META_SWEEPMAPINDEX        = "/SweepMapIndex"      // number
-StrConstant SF_META_ISAVERAGED           = "/IsAveraged"         // number
-StrConstant SF_META_AVERAGED_FIRST_SWEEP = "/AveragedFirstSweep" // number
-StrConstant SF_META_XVALUES              = "/XValues"            // numeric wave
-StrConstant SF_META_XTICKLABELS          = "/XTickLabels"        // text wave
-StrConstant SF_META_XTICKPOSITIONS       = "/XTickPositions"     // numeric wave
-StrConstant SF_META_YTICKLABELS          = "/YTickLabels"        // text wave
-StrConstant SF_META_YTICKPOSITIONS       = "/YTickPositions"     // numeric wave
-StrConstant SF_META_XAXISLABEL           = "/XAxisLabel"         // string
-StrConstant SF_META_YAXISLABEL           = "/YAxisLabel"         // string
-StrConstant SF_META_LEGEND_LINE_PREFIX   = "/LegendLinePrefix"   // string
-StrConstant SF_META_TAG_TEXT             = "/TagText"            // string
-StrConstant SF_META_OPSTACK              = "/OperationStack"     // string
-StrConstant SF_META_MOD_MARKER           = "/Marker"             // numeric wave (per point) or number (all points)
-StrConstant SF_META_SHOW_LEGEND          = "/ShowLegend"         // numeric, boolean, defaults to true (1)
-StrConstant SF_META_CUSTOM_LEGEND        = "/CustomLegend"       // string with custom legend text, honours /ShowLegend
-StrConstant SF_META_ARGSETUPSTACK        = "/ArgSetupStack"      // string
-StrConstant SF_META_TRACECOLOR           = "/TraceColor"         // numeric wave, applies to markers and lines
-StrConstant SF_META_LINESTYLE            = "/LineStyle"          // number
-StrConstant SF_META_TRACE_MODE           = "/TraceMode"          // number, one of @ref TraceDisplayTypes
-StrConstant SF_META_TRACETOFRONT         = "/TraceToFront"       // number, boolean, defaults to false (0)
-StrConstant SF_META_DONOTPLOT            = "/DoNotPlot"          // number, boolean, defaults to false (0)
-StrConstant SF_META_WINDOW_HOOK          = "/WindowHook"         // string
+StrConstant SF_META_DATATYPE           = "/DataType"         // string
+StrConstant SF_META_SWEEPNO            = "/SweepNumber"      // number
+StrConstant SF_META_RANGE              = "/Range"            // numeric wave
+StrConstant SF_META_CHANNELTYPE        = "/ChannelType"      // number
+StrConstant SF_META_CHANNELNUMBER      = "/ChannelNumber"    // number
+StrConstant SF_META_DEVICE             = "/Device"           // string
+StrConstant SF_META_EXPERIMENT         = "/Experiment"       // string
+StrConstant SF_META_SWEEPMAPINDEX      = "/SweepMapIndex"    // number
+StrConstant SF_META_ISAVERAGED         = "/IsAveraged"       // number
+StrConstant SF_META_XVALUES            = "/XValues"          // numeric wave
+StrConstant SF_META_XTICKLABELS        = "/XTickLabels"      // text wave
+StrConstant SF_META_XTICKPOSITIONS     = "/XTickPositions"   // numeric wave
+StrConstant SF_META_YTICKLABELS        = "/YTickLabels"      // text wave
+StrConstant SF_META_YTICKPOSITIONS     = "/YTickPositions"   // numeric wave
+StrConstant SF_META_XAXISLABEL         = "/XAxisLabel"       // string
+StrConstant SF_META_YAXISLABEL         = "/YAxisLabel"       // string
+StrConstant SF_META_LEGEND_LINE_PREFIX = "/LegendLinePrefix" // string
+StrConstant SF_META_TAG_TEXT           = "/TagText"          // string
+StrConstant SF_META_OPSTACK            = "/OperationStack"   // string
+StrConstant SF_META_MOD_MARKER         = "/Marker"           // numeric wave (per point) or number (all points)
+StrConstant SF_META_SHOW_LEGEND        = "/ShowLegend"       // numeric, boolean, defaults to true (1)
+StrConstant SF_META_CUSTOM_LEGEND      = "/CustomLegend"     // string with custom legend text, honours /ShowLegend
+StrConstant SF_META_ARGSETUPSTACK      = "/ArgSetupStack"    // string
+StrConstant SF_META_TRACECOLOR         = "/TraceColor"       // numeric wave, applies to markers and lines
+StrConstant SF_META_LINESTYLE          = "/LineStyle"        // number
+StrConstant SF_META_TRACE_MODE         = "/TraceMode"        // number, one of @ref TraceDisplayTypes
+StrConstant SF_META_TRACETOFRONT       = "/TraceToFront"     // number, boolean, defaults to false (0)
+StrConstant SF_META_DONOTPLOT          = "/DoNotPlot"        // number, boolean, defaults to false (0)
+StrConstant SF_META_WINDOW_HOOK        = "/WindowHook"       // string
 
 /// A color group allows to have matching colors for sweep data with the same channel type/number and sweep.
 /// It is applied before the matching headstage/average colors in #SF_GetTraceColor().

--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -7004,6 +7004,7 @@ static Function/WAVE SF_AverageDataOverSweeps(WAVE/WAVE input)
 	for(i = 0; i < numGroups; i += 1)
 		WAVE wData = output[i]
 		JWN_SetNumberInWaveNote(wData, SF_META_ISAVERAGED, 1)
+		JWN_SetNumberInWaveNote(wData, SF_META_TRACE_MODE, TRACE_DISPLAY_MODE_LINES)
 		if(CmpStr(GetDimLabel(groupWaves, ROWS, i), SF_AVERAGING_NONSWEEPDATA_LBL))
 			WAVE group = groupWaves[i]
 			JWN_SetNumberInWaveNote(wData, SF_META_CHANNELNUMBER, JWN_GetNumberFromWaveNote(group, SF_META_CHANNELNUMBER))

--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -1514,11 +1514,16 @@ Function [STRUCT RGBColor s] SF_GetTraceColor(string graph, string opStack, WAVE
 		return [s]
 	endif
 
+	isAveraged = JWN_GetNumberFromWaveNote(data, SF_META_ISAVERAGED)
+	if(isAveraged)
+		[s] = GetTraceColorForAverage()
+		return [s]
+	endif
+
 	channelNumber = JWN_GetNumberFromWaveNote(data, SF_META_CHANNELNUMBER)
 	channelType   = JWN_GetNumberFromWaveNote(data, SF_META_CHANNELTYPE)
-	isAveraged    = JWN_GetNumberFromWaveNote(data, SF_META_ISAVERAGED)
 	mapIndex      = JWN_GetNumberFromWaveNote(data, SF_META_SWEEPMAPINDEX)
-	sweepNo       = (isAveraged == 1) ? JWN_GetNumberFromWaveNote(data, SF_META_AVERAGED_FIRST_SWEEP) : JWN_GetNumberFromWaveNote(data, SF_META_SWEEPNO)
+	sweepNo       = JWN_GetNumberFromWaveNote(data, SF_META_SWEEPNO)
 	if(!IsValidSweepNumber(sweepNo))
 		return [s]
 	endif
@@ -6976,7 +6981,6 @@ static Function/WAVE SF_AverageDataOverSweeps(WAVE/WAVE input)
 			if(isSweepData)
 				JWN_SetNumberInWaveNote(group, SF_META_CHANNELNUMBER, channelNumber)
 				JWN_SetNumberInWaveNote(group, SF_META_CHANNELTYPE, channelType)
-				JWN_SetNumberInWaveNote(group, SF_META_AVERAGED_FIRST_SWEEP, sweepNo)
 			endif
 			groupWaves[pos] = group
 
@@ -7004,7 +7008,6 @@ static Function/WAVE SF_AverageDataOverSweeps(WAVE/WAVE input)
 			WAVE group = groupWaves[i]
 			JWN_SetNumberInWaveNote(wData, SF_META_CHANNELNUMBER, JWN_GetNumberFromWaveNote(group, SF_META_CHANNELNUMBER))
 			JWN_SetNumberInWaveNote(wData, SF_META_CHANNELTYPE, JWN_GetNumberFromWaveNote(group, SF_META_CHANNELTYPE))
-			JWN_SetNumberInWaveNote(wData, SF_META_AVERAGED_FIRST_SWEEP, JWN_GetNumberFromWaveNote(group, SF_META_AVERAGED_FIRST_SWEEP))
 		endif
 	endfor
 

--- a/Packages/tests/Basic/UTF_SweepFormula.ipf
+++ b/Packages/tests/Basic/UTF_SweepFormula.ipf
@@ -1081,8 +1081,6 @@ static Function/WAVE TestAverageOverSweeps_CheckMeta(WAVE data, variable channel
 	CHECK_EQUAL_VAR(channelNumber, val)
 	val = JWN_GetNumberFromWaveNote(data, SF_META_CHANNELTYPE)
 	CHECK_EQUAL_VAR(channelType, val)
-	val = JWN_GetNumberFromWaveNote(data, SF_META_AVERAGED_FIRST_SWEEP)
-	CHECK_EQUAL_VAR(firstSweep, val)
 	val = JWN_GetNumberFromWaveNote(data, SF_META_ISAVERAGED)
 	CHECK_EQUAL_VAR(1, val)
 

--- a/Packages/tests/HistoricData/UTF_HistoricSweepBrowser.ipf
+++ b/Packages/tests/HistoricData/UTF_HistoricSweepBrowser.ipf
@@ -23,3 +23,27 @@ static Function TestTTLDisplayWithNoEpochInfo([string str])
 
 	CHECK_NO_RTE()
 End
+
+Function TestSweepFormulaPowerSpectrumAverage()
+
+	string abWin, sweepBrowsers, file, sweepBrowser, bsPanel, scPanel, code
+
+	WAVE/T files = GetHistoricDataFiles()
+	file = "input:" + files[0]
+
+	[abWin, sweepBrowsers] = OpenAnalysisBrowser({file}, loadSweeps = 1)
+	sweepBrowser           = StringFromList(0, sweepBrowsers)
+
+	bsPanel = BSP_GetPanel(sweepBrowser)
+	CHECK(WindowExists(bsPanel))
+
+	scPanel = BSP_GetSweepControlsPanel(sweepBrowser)
+	CHECK(WindowExists(scPanel))
+
+	code = "trange = [0, inf]\r"                                            + \
+	       "sel = select(selrange($trange),selchannels(AD), selsweeps())\r" + \
+	       "dat = data($sel)\r"                                             + \
+	       "powerspectrum($dat, default, avg)"
+
+	ExecuteSweepFormulaCode(sweepBrowser, code)
+End


### PR DESCRIPTION
Since fd5ee28 (SF: Use correct LNB getter in SF_GetTraceColor,
2024-10-04) we require mapIndex to be valid when fetching the labnotebook
for sweep data in SF_GetTraceColor.

But average data was always treated sweep-like but that does not have a
map index. This can also be not easily fixed as it is not clear which mapIndex to use
for sweeps from multiple experiments. Instead we now use the default
average color.

This also makes the metadata entry SF_META_AVERAGED_FIRST_SWEEP obsolete.

Close #2390
