### PR TITLE
[Backport] SF_CheckInputCode: Preprocess code

### DIFF
--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -2899,16 +2899,18 @@ End
 static Function SF_CheckInputCode(string code, string graph)
 
 	variable i, numGraphs, jsonIDy, jsonIDx, subFormulaCnt
-	string jsonPath, xFormula, yFormula, formulasRemain, subPath, yAndXFormula
+	string jsonPath, xFormula, yFormula, formulasRemain, subPath, yAndXFormula, codeWithoutVariables, preProcCode
 
 	NVAR jsonID = $GetSweepFormulaJSONid(SF_GetBrowserDF(graph))
 	JSON_Release(jsonID, ignoreErr = 1)
 	jsonID = JSON_New()
 	JSON_AddObjects(jsonID, "")
 
-	code = SF_CheckVariableAssignments(code, jsonID)
+	preProcCode = SF_PreprocessInput(code)
 
-	WAVE/T graphCode = SF_SplitCodeToGraphs(SF_PreprocessInput(code))
+	codeWithoutVariables = SF_CheckVariableAssignments(preProcCode, jsonID)
+
+	WAVE/T graphCode = SF_SplitCodeToGraphs(codeWithoutVariables)
 
 	numGraphs = DimSize(graphCode, ROWS)
 	for(i = 0; i < numGraphs; i += 1)

--- a/Packages/tests/Basic/UTF_SweepFormula.ipf
+++ b/Packages/tests/Basic/UTF_SweepFormula.ipf
@@ -1267,6 +1267,13 @@ static Function TestInputCodeCheck()
 	JSON_Release(jsonId)
 	CHECK_EQUAL_STR(jsonRef, jsonTxt)
 
+	formula = "# comment\r var = 1\r\r $var"
+	jsonRef = "{\n\"graph_0\": {\n\"pair_0\": {\n\"formula_y\": \"$var\"\n}\n},\n\"variable:var\": 1\n}"
+	MIES_SF#SF_CheckInputCode(formula, win)
+	jsonTxt = JSON_Dump(jsonId)
+	JSON_Release(jsonId)
+	CHECK_EQUAL_STR(jsonRef, jsonTxt)
+
 	formula = "[*]"
 	try
 		MIES_SF#SF_CheckInputCode(formula, win)


### PR DESCRIPTION
We need to preprocess the code before we can extract the variables and the formula. Broken since 8ec6945e97 (SF: Add support to check also variables with the check button, 2023-03-29).
