### PR TITLE
GetAllFilesRecursivelyFromPath: Fix compilation on MacOSX

### DIFF
--- a/Packages/MIES/MIES_Utilities_File.ipf
+++ b/Packages/MIES/MIES_Utilities_File.ipf
@@ -327,7 +327,7 @@ static Function [WAVE/Z/T filesResolved, WAVE/Z/T foldersResolved] GetAllFilesAl
 
 	WAVE/Z/T filesWithoutAliases = GrepTextWave(files, "\.lnk$", invert = 1)
 #else
-	WAVE aliasFiles = files
+	WAVE/T aliasFiles = files
 	WAVE/ZZ filesWithoutAliases
 #endif // WINDOWS
 


### PR DESCRIPTION
Broken since 2436f408 (GetAllFilesRecursivelyFromPath: Rework it completely, 2025-04-16).

Thanks for opening a PR in MIES :sparkles:!

- Code can only be merged if the continous integration tests pass
- [ ] Please ensure that the branch is named correctly. See
  [here](https://alleninstitute.github.io/MIES/developers.html#branch-naming-scheme) for the detailed explanation.
