### PR TITLE
Fix release steps

### DIFF
--- a/Packages/doc/developers.rst
+++ b/Packages/doc/developers.rst
@@ -75,10 +75,11 @@ Cutting a new release
    for how the asterisk should look like
 -  Push the tag: ``git push origin $tag``. You can pass ``--dry-run`` for
    testing out what is getting pushed without pushing anything.
--  Create the release branches:
+-  Create the release branch:
 
    -  ``git checkout -b release/X.Y``
    -  ``git push --no-verify -u origin release/X.Y``
+   -  ``git commit --allow-empty -m "Start of the release X.Y"``
 
 -  Create a new release on github and check that the Github Actions job
    correctly uploads the artifacts


### PR DESCRIPTION
The compile check for each commit in c3e7dc3 (.github/workflows: Add
job to compile test each commit, 2023-12-22) suffers from an issue when
the release branch is empty. In this case we then assume that the branch
in question is forked from the release branch instead of main. This
results in checking all commits in main since the release branch forked
off.

By adding an empty commit to the release branch we can circumvent the
problem.

Close #2426