### PR TITLE
Tests/RunWithOpts: Don't require .ipf suffix for test suites

### DIFF
--- a/Packages/tests/UTF_HelperFunctions.ipf
+++ b/Packages/tests/UTF_HelperFunctions.ipf
@@ -2000,7 +2000,11 @@ Function RunWithOpts([string testcase, string testsuite, variable allowdebug, va
 	if(ParamIsDefault(testsuite))
 		testsuite = GetDefaultTestSuitesForExperiment()
 	else
-		// do nothing
+		if(!enableRegExp)
+			WAVE/T testsuiteWave = ListToTextWave(testsuite, ";")
+			testsuiteWave[] = RemoveEnding(testsuiteWave[p], ".ipf") + ".ipf"
+			testsuite       = TextWaveToList(testsuiteWave, ";")
+		endif
 	endif
 
 	if(IsEmpty(testcase))


### PR DESCRIPTION
@MichaelHuth FYI. This was requested by you.

Will merge once CI passed.