### PR TITLE
CA_GetCacheIndex: Don't use RMD for FindValue

### DIFF
--- a/Packages/MIES/MIES_Cache.ipf
+++ b/Packages/MIES/MIES_Cache.ipf
@@ -591,7 +591,7 @@ threadsafe static Function CA_GetCacheIndex(WAVE keys, string key)
 		return NaN
 	endif
 
-	FindValue/TXOP=(1 + 4)/TEXT=key/RMD=[0, numFilledRows] keys
+	FindValue/TXOP=(1 + 4)/TEXT=key keys
 
 	return (V_Value == -1) ? NaN : V_Value
 End


### PR DESCRIPTION
As verified using testing and contacting WaveMetrics support, the RMD flag of FindValue makes searching a text wave slower by a factor of three to four. The reason is that the implementation does not assume that the search range could be continuous, therefore it isn't optimized as well.

So let's drop the /RMD flag for this particular case.

Will merge once CI passes.