### PR TITLE
Add FFI routines for datafolder export

### DIFF
--- a/Packages/MIES/MIES_AnalysisBrowser.ipf
+++ b/Packages/MIES/MIES_AnalysisBrowser.ipf
@@ -3240,7 +3240,7 @@ Function AB_CheckboxProc_PXP(STRUCT WMCheckboxAction &cba) : CheckBoxControl
 	return 0
 End
 
-Function/S AB_GetSweepBrowserListForPopup()
+Function/S AB_GetSweepBrowserTitles()
 
 	string wName
 	string sbList = ""
@@ -3250,6 +3250,15 @@ Function/S AB_GetSweepBrowserListForPopup()
 		GetWindow $wName, title
 		sbList = AddListItem(S_Value, sbList, ";", Inf)
 	endfor
+
+	return sbList
+End
+
+Function/S AB_GetSweepBrowserListForPopup()
+
+	string sbList
+
+	sbList = AB_GetSweepBrowserTitles()
 	sbList = AddListItem("New", sbList)
 
 	return sbList

--- a/Packages/MIES/MIES_AnalysisBrowser.ipf
+++ b/Packages/MIES/MIES_AnalysisBrowser.ipf
@@ -3264,7 +3264,7 @@ Function/S AB_GetSweepBrowserListForPopup()
 	return sbList
 End
 
-static Function/S AB_GetSweepBrowserWindowFromTitle(string winTitle)
+Function/S AB_GetSweepBrowserWindowFromTitle(string winTitle)
 
 	WAVE/T wList = ListToTextWave(WinList(SWEEPBROWSER_WINDOW_NAME + "*", ";", "WIN:1"), ";")
 	for(wName : wList)

--- a/Packages/MIES/MIES_BrowserSettingsPanel.ipf
+++ b/Packages/MIES/MIES_BrowserSettingsPanel.ipf
@@ -1951,6 +1951,7 @@ Function/S BSP_RenameAndSetTitle(string win, string newName)
 
 	for(numOtherBrowser = 0;; numOtherBrowser += 1)
 		sprintf newTitle, "Browser%s%s%s", SelectString(numOtherBrowser, "", " [" + num2str(numOtherBrowser) + "]"), suffix, modeSuffix
+		newTitle = RemoveEndingRegExp(newTitle, " *")
 		if(WhichListItem(newTitle, wTitles) == -1)
 			DoWindow/T $win, newTitle
 			break

--- a/Packages/MIES/MIES_ForeignFunctionInterface.ipf
+++ b/Packages/MIES/MIES_ForeignFunctionInterface.ipf
@@ -142,3 +142,64 @@ Function/WAVE FFI_QueryLogbookUniqueSetting(string device, variable logbookType,
 
 	return settings
 End
+
+/// @brief Save the given permanent Igor Pro `datafolder` in the HDF5 format into `filepath`
+Function FFI_SaveDataFolderToHDF5(string filepath, string datafolder)
+
+	return FFI_SaveDataFolderToHDF5Impl(filepath, {datafolder})
+End
+
+static Function FFI_SaveDataFolderToHDF5Impl(string filepath, WAVE/T datafolders)
+
+	variable ref = NaN
+	variable groupID
+	string entry, cleanName
+
+	ASSERT(!FileExists(filepath), "filepath points to an existing file")
+
+	try
+		HDF5CreateFile ref as filepath; AbortOnRTE
+		for(entry : datafolders)
+			DFREF dfr = $entry
+			ASSERT(DataFolderExistsDFR(dfr), "datafolder " + entry + " does not point to an existing datafolder")
+			cleanName = ReplaceString(":", RemovePrefix(entry, start = "root:"), "/")
+			H5_CreateGroupsRecursively(ref, cleanName)
+			groupID = H5_OpenGroup(ref, cleanName)
+			HDf5SaveGroup/R/IGOR=(-1)/OPTS=(2^0)/COMP={1000, 3, 0} dfr, groupID, "."; AbortOnRTE
+			HDF5CloseGroup groupId; AbortOnRTE
+		endfor
+	catch
+		HDF5DumpErrors/CLR=1
+		// do nothing
+	endtry
+
+	HDF5CloseFile/Z ref
+End
+
+/// @brief Return the titles of all sweep browser windows
+Function/WAVE FFI_GetSweepBrowserTitles()
+
+	WAVE wv = ListToTextWave(AB_GetSweepBrowserTitles(), ";")
+
+	if(DimSize(wv, ROWS) == 0)
+		return $""
+	endif
+
+	return wv
+End
+
+/// @brief Save the psx data of the sweepbrowser with title `wintTitle` in the HDF5 format into `filepath`
+Function FFI_SavePSXDataFolderToHDF5(string filepath, string winTitle)
+
+	string sbWin, folderList
+
+	sbWin = AB_GetSweepBrowserWindowFromTitle(winTitle)
+
+	DFREF dfr = SFH_GetWorkingDF(sbWin)
+
+	folderList = GetListOfObjects(dfr, "^psx[0-9]*$", typeFlag = COUNTOBJECTS_DATAFOLDER, fullPath = 1)
+	ASSERT(!IsEmpty(folderList), "Could find any psx folders")
+	WAVE/T folders = ListToTextWave(folderList, ";")
+
+	return FFI_SaveDataFolderToHDF5Impl(filepath, folders)
+End

--- a/Packages/tests/Basic/UTF_ForeignFunctionInterface.ipf
+++ b/Packages/tests/Basic/UTF_ForeignFunctionInterface.ipf
@@ -43,3 +43,56 @@ static Function TestLogbookQueryUnique()
 	WAVE/Z settings = FFI_QueryLogbookUniqueSetting(device, LBT_LABNOTEBOOK, keyTxt)
 	CHECK_WAVE(settings, TEXT_WAVE)
 End
+
+static Function TestPsxExport()
+
+	string win, winTitle, filepath, baseFolder, datafolder
+	variable ref
+
+	CHECK_WAVE(FFI_GetSweepBrowserTitles(), NULL_WAVE)
+
+	SB_OpenSweepBrowser()
+
+	winTitle = "Browser"
+	CHECK_EQUAL_TEXTWAVES(FFI_GetSweepBrowserTitles(), {winTitle})
+
+	PathInfo home
+	baseFolder = S_path
+	filepath   = baseFolder + "someFile.h5"
+	DeleteFile/Z filepath
+
+	// no psx folders
+	try
+		FFI_SavePSXDataFolderToHDF5(filepath, winTitle)
+		FAIL()
+	catch
+		CHECK_NO_RTE()
+		CHECK(!FileExists(filepath))
+	endtry
+
+	// create psx folder
+	win        = AB_GetSweepBrowserWindowFromTitle(winTitle)
+	datafolder = GetDataFolder(1, SFH_GetWorkingDF(win)) + "psx"
+	NewDataFolder $datafolder
+
+	// file already exists (taking the experiment here)
+	filepath = baseFolder + IgorInfo(12)
+	try
+		FFI_SavePSXDataFolderToHDF5(filepath, winTitle)
+		FAIL()
+	catch
+		CHECK_NO_RTE()
+	endtry
+
+	// store a wave
+	DFREF dfr = $datafolder
+	Make dfr:data/WAVE=data = p
+
+	filepath = baseFolder + "someFile.h5"
+	FFI_SavePSXDataFolderToHDF5(filepath, winTitle)
+
+	ref = H5_Openfile(filepath)
+	WAVE/Z read_data = H5_LoadDataset(ref, "/sweepBrowser/FormulaData/psx/data")
+	CHECK_EQUAL_WAVES(data, read_data)
+	H5_CloseFile(ref)
+End


### PR DESCRIPTION
FFI_GetSweepBrowserTitles() returns a text wave with all sweep browser titles. 

FFI_SavePSXDataFolderToHDF5 takes a full filepath to a non-existing file and a sweep browser title. It will then save all psx datafolders it can find in it.