### PR TITLE
TP_RecordTP: Fix resistance plotting in Oscilloscope graph

### DIFF
--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -370,6 +370,7 @@ StrConstant DIMENSION_SCALING_LAST_INVOC = "DimensionScalingLastInvocation"
 StrConstant PRESSURE_CTRL_LAST_INVOC     = "PressureControlLastInvocation"
 StrConstant INDEX_ON_TP_START            = "IndexOnTestPulseStart"
 StrConstant AUTOTP_LAST_INVOCATION_KEY   = "AutoTPLastInvocation"
+StrConstant REFERENCE_START_TIME         = "ReferenceStartTime"
 ///@}
 
 /// @name Modes for SaveExperimentSpecial

--- a/Packages/MIES/MIES_Oscilloscope.ipf
+++ b/Packages/MIES/MIES_Oscilloscope.ipf
@@ -61,7 +61,7 @@ End
 Function SCOPE_GetTPTopAxisStart(string device, variable &axisMin)
 
 	string graph
-	variable count, latest
+	variable count, latest, i
 
 	graph = SCOPE_GetGraph(device)
 	GetAxis/W=$graph/Q $AXIS_SCOPE_TP_TIME
@@ -73,7 +73,16 @@ Function SCOPE_GetTPTopAxisStart(string device, variable &axisMin)
 	count = GetNumberFromWaveNote(TPStorage, NOTE_INDEX)
 
 	if(count > 0)
-		latest = TPStorage[count - 1][0][%DeltaTimeInSeconds]
+		for(i = 0; i < NUM_HEADSTAGES; i += 1)
+			latest = TPStorage[count - 1][i][%DeltaTimeInSeconds]
+
+			if(IsFinite(latest))
+				break
+			endif
+		endfor
+
+		ASSERT(IsFinite(latest), "Could not find a finite DeltaTimeInSeconds")
+
 		if(latest >= V_max)
 			axisMin = latest - 0.5 * SCOPE_TIMEAXIS_RESISTANCE_RANGE
 			return 1

--- a/Packages/MIES/MIES_TestPulse.ipf
+++ b/Packages/MIES/MIES_TestPulse.ipf
@@ -1195,6 +1195,8 @@ End
 static Function TP_RecordTP(string device, WAVE TPResults)
 
 	variable delta, i, ret, lastPressureCtrl, now
+	variable refTime = NaN
+
 	WAVE     TPStorage     = GetTPStorage(device)
 	WAVE     hsProp        = GetHSProperties(device)
 	variable count         = GetNumberFromWaveNote(TPStorage, NOTE_INDEX)
@@ -1210,7 +1212,14 @@ static Function TP_RecordTP(string device, WAVE TPResults)
 			endif
 
 			TP_UpdateHoldCmdInTPStorage(device, i)
+
+			if(IsNaN(refTime))
+				refTime = TPResults[%TIMESTAMP][i]
+				SetNumberInWaveNote(TPStorage, REFERENCE_START_TIME, refTime)
+			endif
 		endfor
+	else
+		refTime = GetNumberFromWaveNote(TPStorage, REFERENCE_START_TIME)
 	endif
 
 	ret = EnsureLargeEnoughWave(TPStorage, indexShouldExist = count, dimension = ROWS, initialValue = NaN, checkFreeMemory = 1)
@@ -1248,7 +1257,7 @@ static Function TP_RecordTP(string device, WAVE TPResults)
 	TPStorage[count][][%Baseline_VC] = (hsProp[q][%ClampMode] == V_CLAMP_MODE) ? TPResults[%BaselineSteadyState][q] : NaN
 	TPStorage[count][][%Baseline_IC] = (hsProp[q][%ClampMode] == I_CLAMP_MODE) ? TPResults[%BaselineSteadyState][q] : NaN
 
-	TPStorage[count][][%DeltaTimeInSeconds] = TPResults[%TIMESTAMP][q] - TPStorage[0][q][%TimeStamp]
+	TPStorage[count][][%DeltaTimeInSeconds] = TPResults[%TIMESTAMP][q] - refTime
 	TPStorage[count][][%TPMarker]           = TPResults[%MARKER][q]
 
 	TPStorage[count][][%TPCycleID] = TPResults[%CYCLEID][q]

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -3059,7 +3059,7 @@ End
 Function/WAVE GetTPStorage(string device)
 
 	DFREF    dfr              = GetDeviceTestPulse(device)
-	variable versionOfNewWave = 17
+	variable versionOfNewWave = 18
 	variable numLayersV16     = 40
 	variable numLayers        = 39
 
@@ -3154,6 +3154,7 @@ Function/WAVE GetTPStorage(string device)
 	SetNumberInWaveNote(wv, DIMENSION_SCALING_LAST_INVOC, 0)
 	SetNumberInWaveNote(wv, PRESSURE_CTRL_LAST_INVOC, 0)
 	SetNumberInWaveNote(wv, INDEX_ON_TP_START, 0)
+	SetNumberInWaveNote(wv, REFERENCE_START_TIME, 0)
 
 	SetWaveVersion(wv, versionOfNewWave)
 


### PR DESCRIPTION
In f1e2802003 (TP: Remove TPStorage field %TimeInSeconds, 2025-04-29) we removed the TimeInSeconds column from the TPStorage wave.

But this column held in the very first row and column the reference time for DeltaTimeInSeconds. This is used as x axis for the resistance plots in the oscilloscope.

The current code does therefore result in DeltaTimeInSeconds valus of NaN if a headstage was turned on later than others. Which in turn breaks the resistance display.

We now fix that by reintroducing the reference time for count zero, but this time as a wave note entry. As we are also not writing the DeltaTimeInSeconds for inactive headstage, we have to search the first active one in SCOPE_GetTPTopAxisStart.

Close #2440