### PR TITLE
AFH_CheckAnalysisParameter: Allow superfluous analysis parameters

### DIFF
--- a/Packages/MIES/MIES_AnalysisFunctionHelpers.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctionHelpers.ipf
@@ -893,7 +893,7 @@ Function/S AFH_CheckAnalysisParameter(string genericFunc, STRUCT CheckParameters
 				// non-matching type
 				suppType = AFH_GetAnalysisParamType(name, s.params, typeCheck = 0)
 				if(cmpstr(reqType, suppType))
-					errorMessages[index++] = name + ": has an differing types (" + reqType + " vs " + suppType + ")."
+					errorMessages[index++] = name + ": has differing types (" + reqType + " vs " + suppType + ")."
 					continue
 				endif
 

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -2437,3 +2437,17 @@ StrConstant TP_ANALYSIS_DATA_LABELS = "BASELINE;STEADYSTATERES;INSTANTRES;ELEVAT
 // Object names for thread data transfer out of ITC Fifothread @ref TFH_FifoLoop
 StrConstant ITC_THREAD_FIFOPOS   = "fifopos"
 StrConstant ITC_THREAD_TIMESTAMP = "timestamp"
+
+/// @name Error types for AFH_CheckAnalysisParameter
+///
+/// @anchor CheckAnalysisParameterErrorTypes
+///@{
+Constant CAP_INVALID_NAME       = 1
+Constant CAP_REQ_BUT_MISSING    = 2
+Constant CAP_DIFFERING_TYPES    = 3
+Constant CAP_SUPERFLUOUS        = 4
+Constant CAP_INVALID_TYPE       = 5
+Constant CAP_INVALID_WAVE       = 6
+Constant CAP_FAILED_CHECK_FUNC  = 7
+Constant CAP_ABORTED_CHECK_FUNC = 8
+///@}

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -2862,7 +2862,7 @@ static Function DAP_CheckAnalysisFunctionAndParameter(string device, string setN
 		s.setName = setName
 
 		[errorMessage, WAVE errorTypes] = AFH_CheckAnalysisParameter(func, s)
-		if(!IsEmpty(errorMessage))
+		if(!IsEmpty(errorMessage) && !IsConstant(errorTypes, CAP_SUPERFLUOUS))
 			printf "(%s) The analysis parameter check for function %s in stim set %s did not pass.\r", device, func, setName
 			print errorMessage
 			ControlWindowToFront()

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -2861,7 +2861,7 @@ static Function DAP_CheckAnalysisFunctionAndParameter(string device, string setN
 		s.params  = WB_ExtractAnalysisFunctionParams(stimSet)
 		s.setName = setName
 
-		errorMessage = AFH_CheckAnalysisParameter(func, s)
+		[errorMessage, WAVE errorTypes] = AFH_CheckAnalysisParameter(func, s)
 		if(!IsEmpty(errorMessage))
 			printf "(%s) The analysis parameter check for function %s in stim set %s did not pass.\r", device, func, setName
 			print errorMessage

--- a/Packages/MIES/MIES_WaveBuilder.ipf
+++ b/Packages/MIES/MIES_WaveBuilder.ipf
@@ -2573,7 +2573,7 @@ Function/S WB_SaveStimSet(string baseName, variable stimulusType, WAVE SegWvType
 	s.params  = params
 	s.setName = tempName
 
-	errorMessage = AFH_CheckAnalysisParameter(genericFunc, s)
+	[errorMessage, WAVE errorTypes] = AFH_CheckAnalysisParameter(genericFunc, s)
 
 	if(!IsEmpty(errorMessage))
 		printf "The analysis parameters are not valid and the stimset can therefore not be saved.\r"

--- a/Packages/tests/HardwareBasic/UTF_AnalysisFunctionManagement.ipf
+++ b/Packages/tests/HardwareBasic/UTF_AnalysisFunctionManagement.ipf
@@ -1596,12 +1596,12 @@ static Function AFT14j([string str])
 	InitDAQSettingsFromString(s, "MD1_RA0_I0_L0_BKG1_FAR0"                   + \
 	                             "__HS0_DA0_AD0_CM:IC:_ST:AnaFuncParams1_DA_0:")
 
-	try
-		AcquireData_NG(s, str)
-		FAIL()
-	catch
-		PASS()
-	endtry
+	AcquireData_NG(s, str)
+End
+
+static Function AFT14j_REENTRY([string str])
+
+	CHECK_EQUAL_VAR(GetSetVariable(str, "SetVar_Sweep"), 1)
 End
 
 // MD: mid sweep event is also called for very short stimsets


### PR DESCRIPTION
@timjarsky Found that on my analoge planning tool (aka large papersheet on my desk)