### PR TITLE
AnalysisBrowser: Don't support backslash escape sequences in file/folder listbox

### DIFF
--- a/Packages/MIES/MIES_AnalysisBrowser_Macro.ipf
+++ b/Packages/MIES/MIES_AnalysisBrowser_Macro.ipf
@@ -74,7 +74,7 @@ Window AnalysisBrowser() : Panel
 	ListBox listbox_AB_Folders, userdata(ResizeControlsInfo)=A"!!,FU!!#8L!!#E<huH,7z!!#](Aon\"Qzzzzzzzzzzzzzz!!#o2B4uAezz"
 	ListBox listbox_AB_Folders, userdata(ResizeControlsInfo)+=A"zzzzzzzzzzzz!!#u:Du]k<zzzzzzzzzzz"
 	ListBox listbox_AB_Folders, userdata(ResizeControlsInfo)+=A"zzz!!#u:Du]k<zzzzzzzzzzzzzz!!!"
-	ListBox listbox_AB_Folders, labelBack=(65535, 65535, 65535), mode=9
+	ListBox listbox_AB_Folders, labelBack=(65535, 65535, 65535), mode=9, special={4, 0, 0}
 	Button button_AB_AddFolder, pos={7, 5}, size={100, 25}, proc=AB_ButtonProc_AddFolder
 	Button button_AB_AddFolder, title="Add folder"
 	Button button_AB_AddFolder, help={"Add a new folder to the list"}

--- a/Packages/MIES/MIES_Constants.ipf
+++ b/Packages/MIES/MIES_Constants.ipf
@@ -21,7 +21,7 @@ Constant DAQ_CONFIG_WAVE_VERSION = 3
 Constant DA_EPHYS_PANEL_VERSION           = 66
 Constant DATA_SWEEP_BROWSER_PANEL_VERSION = 52
 Constant WAVEBUILDER_PANEL_VERSION        = 14
-Constant ANALYSISBROWSER_PANEL_VERSION    = 9
+Constant ANALYSISBROWSER_PANEL_VERSION    = 10
 Constant PSX_PLOT_PANEL_VERSION           = 1
 
 /// Version of the stimset wave note


### PR DESCRIPTION

When you add on windows UNC path like

\\server\share\folder

in the analysis browser this get's shown as

<??>rver<??>ared<??>older

as Igor Pro treats two backslashes as starting an escape sequence for annotated text.

So let's remove escape code support for this listbox to fix the display issue.

Close #2400
