### PR TITLE
.github/workflows/monthly-scheduled.yml: Use bash as default shell

### DIFF
--- a/.github/workflows/monthly-scheduled.yml
+++ b/.github/workflows/monthly-scheduled.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     # on every 1st of each month at 2:30 UTC
     - cron:  '30 2 1 * *'
+defaults:
+  run:
+    shell: bash
 
 jobs:
   GitGarbageCollection:

--- a/.github/workflows/monthly-scheduled.yml
+++ b/.github/workflows/monthly-scheduled.yml
@@ -22,4 +22,4 @@ jobs:
         run: |
             git config gc.auto 1024
             git config gc.packLimit 10
-            git gc --auto
+            git gc --auto --no-detach


### PR DESCRIPTION
With powershell we have CI failures [1]. And for all other workflows we
also default to bash.

[1]: https://github.com/AllenInstitute/MIES/actions/runs/15988849165/job/45098180247Thanks for opening a PR in MIES :sparkles:!

- Code can only be merged if the continous integration tests pass
- [ ] Please ensure that the branch is named correctly. See
  [here](https://alleninstitute.github.io/MIES/developers.html#branch-naming-scheme) for the detailed explanation.
