### PR TITLE
UTF_HistoricAnalysisBrowser.ipf: Add test for settings restore

### DIFF
--- a/Packages/tests/HistoricData/UTF_HistoricAnalysisBrowser.ipf
+++ b/Packages/tests/HistoricData/UTF_HistoricAnalysisBrowser.ipf
@@ -351,3 +351,46 @@ static Function TestCheckIfCollapsed()
 	PGC_SetAndActivateControl(abWin, "button_AB_Remove")
 	CheckIfABCollapsed_IGNORE()
 End
+
+static Function/S AnalysisBrowserShowAllAndRefresh_IGNORE([variable restoreSettings])
+
+	string abWin
+
+	restoreSettings = ParamIsDefault(restoreSettings) ? 0 : !!restoreSettings
+
+	abWin = AB_OpenAnalysisBrowser(restoreSettings = restoreSettings)
+
+	SetCheckBoxState(abWin, "check_load_nwb", CHECKBOX_SELECTED)
+	SetCheckBoxState(abWin, "check_load_pxp", CHECKBOX_SELECTED)
+	PGC_SetAndActivateControl(abWin, "button_AB_refresh")
+
+	return abWin
+End
+
+static Function CheckRestoreSettings()
+
+	string abWin, sweepBrowsers
+
+	Make/FREE/T files = {PXP_FILENAME}
+	DownloadFilesIfRequired(files)
+	[abWin, sweepBrowsers] = OpenAnalysisBrowser(files)
+	CHECK(WindowExists(abWin))
+
+	KillWindow/Z $abWin
+
+	// restore settings works
+
+	abWin = AnalysisBrowserShowAllAndRefresh_IGNORE(restoreSettings = 1)
+
+	WAVE/T list = GetExperimentBrowserGUIList()
+	CHECK_EQUAL_VAR(DimSize(list, ROWS), 1)
+	CHECK_EQUAL_STR(GetFile(files[0]), list[0][%file][0])
+
+	KillWindow/Z $abWin
+
+	// and not restoring as well
+	abWin = AnalysisBrowserShowAllAndRefresh_IGNORE(restoreSettings = 0)
+
+	WAVE/T list = GetExperimentBrowserGUIList()
+	CHECK_EQUAL_VAR(DimSize(list, ROWS), 0)
+End


### PR DESCRIPTION
I could not reproduce the failure. But adding a test sounded like a good idea to start the conversation.

Close #2460