### PR TITLE
UTF_DataGenerators.ipf: Make them static

### DIFF
--- a/Packages/tests/Basic/UTF_Amplifier.ipf
+++ b/Packages/tests/Basic/UTF_Amplifier.ipf
@@ -60,7 +60,7 @@ static Function TestFuncMapping()
 	endfor
 End
 
-// UTF_TD_GENERATOR GetClampModesWithoutIZero
+// UTF_TD_GENERATOR DataGenerators#GetClampModesWithoutIZero
 static Function TestAmplifierUnits([variable clampMode])
 
 	string unit, prefix, unitWithPrefix

--- a/Packages/tests/Basic/UTF_AnalysisFunctionParameters.ipf
+++ b/Packages/tests/Basic/UTF_AnalysisFunctionParameters.ipf
@@ -749,31 +749,12 @@ static Function EnsureCorrectUserAnalysis()
 	REQUIRE_EQUAL_VAR(ItemsInList(FunctionList("InvalidSignature", ";", "WIN:UserAnalysisFunctions.ipf")), 1)
 End
 
-static Function/WAVE GetAnalysisFunctions()
-
-	string funcs
-
-	funcs = AFH_GetAnalysisFunctions(ANALYSIS_FUNCTION_VERSION_V3, includeUserFunctions = 0)
-
-	// remove our test help functions which do nasty things
-	funcs = GrepList(funcs, ".*_V3", 1)
-	funcs = GrepList(funcs, ".*_.*")
-
-	WAVE/T wv = ListToTextWave(funcs, ";")
-
-	SetDimensionLabels(wv, funcs, ROWS)
-
-	Sort/DIML wv, wv
-
-	return wv
-End
-
 Function CheckHelpStringsOfAllAnalysisFunctions()
 
 	string genericFunc, params, names, name, help
 	variable j, numParams
 
-	for(genericFunc : GetAnalysisFunctions())
+	for(genericFunc : DataGenerators#GetAnalysisFunctions())
 		params = AFH_GetListOfAnalysisParams(genericFunc, REQUIRED_PARAMS | OPTIONAL_PARAMS)
 
 		names     = AFH_GetListOfAnalysisParamNames(params)
@@ -786,7 +767,7 @@ Function CheckHelpStringsOfAllAnalysisFunctions()
 	endfor
 End
 
-/// UTF_TD_GENERATOR GetAnalysisFunctions
+/// UTF_TD_GENERATOR DataGenerators#GetAnalysisFunctions
 static Function CheckAbbrevName([string func])
 
 	string abbrev
@@ -832,7 +813,7 @@ End
 
 static Function AnalysisParamsMustHaveSameOptionality()
 
-	WAVE/T funcs = GetAnalysisFunctions()
+	WAVE/T funcs = DataGenerators#GetAnalysisFunctions()
 
 	[WAVE/T required, WAVE/T optional, WAVE/T mixed] = GetAllAnalysisParameters_IGNORE(funcs)
 
@@ -896,7 +877,7 @@ static Function GenerateAnalysisFunctionTable()
 	string type, param, help
 	variable idx
 
-	WAVE/T funcs = GetAnalysisFunctions()
+	WAVE/T funcs = DataGenerators#GetAnalysisFunctions()
 
 	[WAVE/T required, WAVE/T optional, WAVE/T mixed] = GetAllAnalysisParameters_IGNORE(funcs)
 
@@ -939,7 +920,7 @@ static Function GenerateAnalysisFunctionLegend()
 
 	string func
 
-	WAVE/T funcs = GetAnalysisFunctions()
+	WAVE/T funcs = DataGenerators#GetAnalysisFunctions()
 
 	Make/FREE/T/N=(DimSize(funcs, ROWS), 2) output
 
@@ -993,29 +974,7 @@ Function GAPasT_AbortsWithIllegalType()
 	endtry
 End
 
-static Function/WAVE GetAnalysisParameterValues()
-
-	Make/FREE/N=(5)/WAVE waves
-
-	Make/FREE/T wv0 = {"var", "123"}
-	waves[0] = wv0
-
-	Make/FREE/T wv1 = {"str", "abcd"}
-	waves[1] = wv1
-
-	Make/FREE/T wv2 = {"wv", "1;2;"}
-	waves[2] = wv2
-
-	Make/FREE/T wv3 = {"txtwv", "a;b;"}
-	waves[3] = wv3
-
-	Make/FREE/T wv4 = {"i_dont_exist", ""}
-	waves[4] = wv4
-
-	return waves
-End
-
-/// UTF_TD_GENERATOR GetAnalysisParameterValues
+/// UTF_TD_GENERATOR DataGenerators#GetAnalysisParameterValues
 Function GAPasT_Works([WAVE/T wv])
 
 	string result

--- a/Packages/tests/Basic/UTF_Configuration.ipf
+++ b/Packages/tests/Basic/UTF_Configuration.ipf
@@ -369,7 +369,7 @@ End
 
 /// @brief Checks if every (qualified) panel has a panel type set
 ///
-/// UTF_TD_GENERATOR GetMiesMacrosWithPanelType
+/// UTF_TD_GENERATOR DataGenerators#GetMiesMacrosWithPanelType
 static Function TCONF_CheckMacrosForPanelType([string str])
 
 	string win, panelType

--- a/Packages/tests/Basic/UTF_DAEphyswoHardware.ipf
+++ b/Packages/tests/Basic/UTF_DAEphyswoHardware.ipf
@@ -142,8 +142,8 @@ static Function/WAVE GetStimsetFromUserData(string device, string ctrl)
 	return ListToTextWave(RemoveFromList(STIMSET_TP_WHILE_DAQ, GetUserData(device, ctrl, USER_DATA_MENU_EXP)), ";")
 End
 
-/// UTF_TD_GENERATOR v1:GetChannelTypes
-/// UTF_TD_GENERATOR v0:GetChannelNumbersForDATTL
+/// UTF_TD_GENERATOR v1:DataGenerators#GetChannelTypes
+/// UTF_TD_GENERATOR v0:DataGenerators#GetChannelNumbersForDATTL
 Function CheckStimsetUpdateAndSearch([STRUCT IUTF_mData &m])
 
 	string device, expected, ctrlWave, ctrlSearch

--- a/Packages/tests/Basic/UTF_EpochswoHardware.ipf
+++ b/Packages/tests/Basic/UTF_EpochswoHardware.ipf
@@ -187,16 +187,7 @@ static Function EP_GetEpochsDoesNotFallbackWithShortNames()
 	CHECK_WAVE(resultEmpty, NULL_WAVE)
 End
 
-static Function/WAVE OldEpochsFormats()
-
-	Make/WAVE/N=2/FREE oldFormats = {root:EpochsWave:EpochsWave_4e534e298, root:EpochsWave:EpochsWave_d150d896e}
-
-	SetDimensionLabels(oldFormats, "EpochsWave_4e534e298;EpochsWave_d150d896e", ROWS)
-
-	return oldFormats
-End
-
-// UTF_TD_GENERATOR OldEpochsFormats
+// UTF_TD_GENERATOR DataGenerators#OldEpochsFormats
 static Function EP_GetEpochsWorksWithoutShortNames([WAVE wv])
 
 	WAVE/Z/T result = EP_GetEpochs($"", $"", NaN, XOP_CHANNEL_TYPE_DAC, 0, "Inserted TP", epochsWave = wv)

--- a/Packages/tests/Basic/UTF_Labnotebook.ipf
+++ b/Packages/tests/Basic/UTF_Labnotebook.ipf
@@ -711,29 +711,7 @@ Function SCid_InvalidWaveRef()
 	CHECK_WAVE(settings, NULL_WAVE)
 End
 
-Function/WAVE LBNInvalidValidPairs()
-
-	Make/WAVE/N=5/FREE waves
-
-	Make/T/FREE wv0 = {"a:b", "a [b]"}
-	waves[0] = wv0
-
-	Make/T/FREE wv1 = {"\"", "_"}
-	waves[1] = wv1
-
-	Make/T/FREE wv2 = {"\'", "_"}
-	waves[2] = wv2
-
-	Make/T/FREE wv3 = {";", "_"}
-	waves[3] = wv3
-
-	Make/T/FREE wv4 = {":", "_"}
-	waves[4] = wv4
-
-	return waves
-End
-
-// UTF_TD_GENERATOR LBNInvalidValidPairs
+// UTF_TD_GENERATOR DataGenerators#LBNInvalidValidPairs
 Function LabnotebookUpgradeForValidDimensionLabelsNum([WAVE/T wv])
 
 	string device, txtSetting, refSetting, invalidName, newName
@@ -775,7 +753,7 @@ Function LabnotebookUpgradeForValidDimensionLabelsNum([WAVE/T wv])
 	CHECK_EQUAL_STR(txtSetting, newName)
 End
 
-// UTF_TD_GENERATOR LBNInvalidValidPairs
+// UTF_TD_GENERATOR DataGenerators#LBNInvalidValidPairs
 Function LabnotebookUpgradeForValidDimensionLabelsText([WAVE/T wv])
 
 	string device, refSetting, invalidName, newName, setting
@@ -1129,19 +1107,6 @@ Function Test_GetLastSettingChannel()
 	CHECK_EQUAL_TEXTWAVES(settings, {"", "", "", "", "", "", "", "", "252627"}, mode = WAVE_DATA)
 End
 
-Function/WAVE AllDescriptionWaves()
-
-	Make/FREE/WAVE/N=1 wvs
-
-	// GetLBNumericalDescription creates a wave within the MIES datafolder, but that is killed at Test Begin
-	// Thus, we use a copy of that wave here
-	WAVE wDesc = GetLBNumericalDescription()
-	Duplicate/FREE wDesc, wT
-	wvs[0] = wT
-
-	return wvs
-End
-
 Function IsValidUnit(string unitWithPrefix)
 
 	string prefix, unit
@@ -1152,7 +1117,7 @@ Function IsValidUnit(string unitWithPrefix)
 	CHECK(IsFinite(numPrefix))
 End
 
-// UTF_TD_GENERATOR AllDescriptionWaves
+// UTF_TD_GENERATOR DataGenerators#AllDescriptionWaves
 Function CheckLBNDescriptions([WAVE/T wv])
 
 	variable i, numEntries, num

--- a/Packages/tests/Basic/UTF_PGCSetAndActivateControl.ipf
+++ b/Packages/tests/Basic/UTF_PGCSetAndActivateControl.ipf
@@ -3,8 +3,6 @@
 #pragma rtFunctionErrors = 1
 #pragma ModuleName       = PGC_Testing
 
-static StrConstant PGCT_POPUPMENU_ENTRIES = "Entry1;Entry2;Entry3"
-
 static Function TEST_CASE_BEGIN_OVERRIDE(string testCase)
 
 	TestCaseBeginCommon(testCase)
@@ -174,29 +172,7 @@ Function PGCT_ListBoxProc(STRUCT WMListboxAction &lba) : ListBoxControl
 	return 0
 End
 
-static Function/WAVE ControlTypesWhichOnlyAcceptVar()
-
-	Make/T/FREE wv = {"checkbox_ctrl_mode_checkbox", "slider_ctrl", "tab_ctrl", "valdisp_ctrl", "button_ctrl", "listbox_ctrl"}
-
-	return wv
-End
-
-static Function/WAVE ControlTypesWhichRequireOneParameter()
-
-	// all except button
-	Make/T/FREE wv = {"checkbox_ctrl_mode_checkbox", "slider_ctrl", "tab_ctrl", "valdisp_ctrl", "popup_ctrl", "setvar_str_ctrl", "setvar_num_ctrl", "listbox_ctrl"}
-
-	return wv
-End
-
-static Function/WAVE ControlTypesWhichOnlyAcceptVarOrStr()
-
-	Make/T/FREE wv = {"popup_ctrl", "setvar_str_ctrl", "setvar_num_ctrl"}
-
-	return wv
-End
-
-// UTF_TD_GENERATOR ControlTypesWhichOnlyAcceptVar
+// UTF_TD_GENERATOR DataGenerators#ControlTypesWhichOnlyAcceptVar
 static Function PGCT_AbortsWithStr([string str])
 
 	SVAR/SDFR=root: panel
@@ -212,7 +188,7 @@ static Function PGCT_AbortsWithStr([string str])
 	CHECK(!NVAR_Exists(called))
 End
 
-// UTF_TD_GENERATOR ControlTypesWhichOnlyAcceptVar
+// UTF_TD_GENERATOR DataGenerators#ControlTypesWhichOnlyAcceptVar
 static Function PGCT_SettingVarWorks([string str])
 
 	SVAR/SDFR=root: panel
@@ -236,7 +212,7 @@ static Function PGCT_SettingVarWorks([string str])
 	endif
 End
 
-// UTF_TD_GENERATOR ControlTypesWhichRequireOneParameter
+// UTF_TD_GENERATOR DataGenerators#ControlTypesWhichRequireOneParameter
 static Function PGCT_AbortsWithoutVarAndStrOrBoth([string str])
 
 	SVAR/SDFR=root: panel
@@ -334,21 +310,7 @@ static Function PGCT_PopupMenuStrWorks1()
 	endfor
 End
 
-Function/WAVE InvalidPopupMenuOtherIndizes()
-
-	Make/FREE wv = {-1, NaN, Inf, -Inf, ItemsInList(PGCT_POPUPMENU_ENTRIES)}
-
-	return wv
-End
-
-Function/WAVE InvalidPopupMenuColorTableIndizes()
-
-	Make/FREE wv = {-1, NaN, Inf, -Inf, ItemsInList(CTabList())}
-
-	return wv
-End
-
-// UTF_TD_GENERATOR InvalidPopupMenuOtherIndizes
+// UTF_TD_GENERATOR DataGenerators#InvalidPopupMenuOtherIndizes
 static Function PGCT_PopupMenuOtherAbortsWithOutOfRangeVar([variable var])
 
 	variable refValue, popNum, i
@@ -379,7 +341,7 @@ static Function PGCT_PopupMenuOtherAbortsWithOutOfRangeVar([variable var])
 	CHECK_EQUAL_STR(refString, popStr)
 End
 
-// UTF_TD_GENERATOR InvalidPopupMenuColorTableIndizes
+// UTF_TD_GENERATOR DataGenerators#InvalidPopupMenuColorTableIndizes
 static Function PGCT_PopupMenuColorAbortsWithOutOfRangeVar([variable var])
 
 	variable refValue, popNum, i
@@ -577,14 +539,7 @@ static Function PGCT_ModeFlagDefault()
 	CHECK_EQUAL_VAR(refState, state)
 End
 
-static Function/WAVE VariousModeFlags()
-
-	Make/FREE/D modes = {-1, PGC_MODE_ASSERT_ON_DISABLED, PGC_MODE_FORCE_ON_DISABLED, PGC_MODE_SKIP_ON_DISABLED}
-
-	return modes
-End
-
-// UTF_TD_GENERATOR VariousModeFlags
+// UTF_TD_GENERATOR DataGenerators#VariousModeFlags
 static Function PGCT_ModeFlag([variable var])
 
 	variable refState, state

--- a/Packages/tests/Basic/UTF_SweepFormula.ipf
+++ b/Packages/tests/Basic/UTF_SweepFormula.ipf
@@ -95,7 +95,7 @@ static Function TestNonFiniteValues()
 End
 
 // Fails with Abort
-// UTF_TD_GENERATOR NonFiniteValues
+// UTF_TD_GENERATOR DataGenerators#NonFiniteValues
 //static Function TestNonFiniteValuesPrimitiveOperations([variable var])
 //
 //	string win, device, str

--- a/Packages/tests/Basic/UTF_SweepFormula_PSX.ipf
+++ b/Packages/tests/Basic/UTF_SweepFormula_PSX.ipf
@@ -739,155 +739,7 @@ static Function FillEventWave_IGNORE(WAVE psxEvent, string id, string comboKey)
 	JWN_SetWaveNoteFromJSON(psxEvent, jsonID)
 End
 
-Function/WAVE StatsTest_GetInput()
-
-	Make/T/FREE/N=(3) template
-	SetDimensionLabels(template, "prop;state;postProc", ROWS)
-
-	// wv0
-	Duplicate/FREE/T template, wv0
-	WAVE/T input = wv0
-
-	input[%prop]     = "estate"
-	input[%state]    = "accept"
-	input[%postProc] = "nothing"
-
-	JWN_SetWaveInWaveNote(input, "/results", {PSX_ACCEPT, PSX_ACCEPT, PSX_ACCEPT, PSX_ACCEPT})
-	JWN_SetWaveInWaveNote(input, "/xValues", {1, 3, 5, 7})
-	JWN_SetWaveInWaveNote(input, "/marker", {PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT})
-
-	// wv1
-	Duplicate/FREE/T template, wv1
-	WAVE/T input = wv1
-
-	input[%prop]     = "estate"
-	input[%state]    = "reject"
-	input[%postProc] = "nothing"
-
-	JWN_SetWaveInWaveNote(input, "/results", {PSX_REJECT, PSX_REJECT, PSX_REJECT})
-	JWN_SetWaveInWaveNote(input, "/xValues", {0, 4, 8})
-	JWN_SetWaveInWaveNote(input, "/marker", {PSX_MARKER_REJECT, PSX_MARKER_REJECT, PSX_MARKER_REJECT})
-
-	// wv2
-	Duplicate/FREE/T template, wv2
-	WAVE/T input = wv2
-
-	input[%prop]     = "estate"
-	input[%state]    = "undetermined"
-	input[%postProc] = "nothing"
-
-	JWN_SetWaveInWaveNote(input, "/results", {PSX_UNDET, PSX_UNDET, PSX_UNDET})
-	JWN_SetWaveInWaveNote(input, "/xValues", {2, 6, 9})
-	JWN_SetWaveInWaveNote(input, "/marker", {PSX_MARKER_UNDET, PSX_MARKER_UNDET, PSX_MARKER_UNDET})
-
-	// wv3
-	Duplicate/FREE/T template, wv3
-	WAVE/T input = wv3
-
-	input[%prop]     = "tau"
-	input[%state]    = "accept"
-	input[%postProc] = "nothing"
-
-	JWN_SetWaveInWaveNote(input, "/results", {0e-6, 4e-6, 8e-6})
-	JWN_SetWaveInWaveNote(input, "/xValues", {0, 4, 8})
-	JWN_SetWaveInWaveNote(input, "/marker", {PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT})
-
-	// wv4
-	Duplicate/FREE/T template, wv4
-	WAVE/T input = wv4
-
-	input[%prop]     = "amp"
-	input[%state]    = "accept"
-	input[%postProc] = "stats"
-
-	JWN_SetWaveInWaveNote(input, "/results", {40, 40, 20, 25.81988897471611, 0, -2.0775})
-	JWN_SetWaveInWaveNote(input, "/xValues", ListToTextWave(PSX_STATS_LABELS, ";"))
-	JWN_SetWaveInWaveNote(input, "/marker", {PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT, \
-	                                         PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT})
-
-	// wv5
-	Duplicate/FREE/T template, wv5
-	WAVE/T input = wv5
-
-	input[%prop]     = "fstate"
-	input[%state]    = "undetermined"
-	input[%postProc] = "count"
-
-	JWN_SetWaveInWaveNote(input, "/results", {5})
-	// no xValues
-	JWN_SetWaveInWaveNote(input, "/marker", {PSX_MARKER_UNDET})
-
-	// wv6
-	Duplicate/FREE/T template, wv6
-	WAVE/T input = wv6
-
-	input[%prop]     = "peaktime"
-	input[%state]    = "undetermined"
-	input[%postProc] = "hist"
-
-	JWN_SetWaveInWaveNote(input, "/results", {1, 2})
-	// no xValues
-	JWN_SetWaveInWaveNote(input, "/marker", {PSX_MARKER_UNDET, PSX_MARKER_UNDET})
-
-	// wv7
-	Duplicate/FREE/T template, wv7
-	WAVE/T input = wv7
-
-	input[%prop]     = "xinterval"
-	input[%state]    = "undetermined"
-	input[%postProc] = "log10"
-
-	Make/FREE/D result = {NaN, log(60 - 20), log(90 - 60)}
-	JWN_SetWaveInWaveNote(input, "/results", result)
-	JWN_SetWaveInWaveNote(input, "/xValues", {2, 6, 9})
-	JWN_SetWaveInWaveNote(input, "/marker", {PSX_MARKER_UNDET, PSX_MARKER_UNDET, PSX_MARKER_UNDET})
-
-	// wv8
-	Duplicate/FREE/T template, wv8
-	WAVE/T input = wv8
-
-	input[%prop]     = "fitresult"
-	input[%state]    = "undetermined"
-	input[%postProc] = "nothing"
-
-	JWN_SetWaveInWaveNote(input, "/results", {1, 1, 1, 1, 1})
-	JWN_SetWaveInWaveNote(input, "/xValues", {1, 3, 5, 7, 9})
-	JWN_SetWaveInWaveNote(input, "/marker", {PSX_MARKER_UNDET, PSX_MARKER_UNDET, PSX_MARKER_UNDET, PSX_MARKER_UNDET, PSX_MARKER_UNDET})
-
-	// wv9
-	Duplicate/FREE/T template, wv9
-	WAVE/T input = wv9
-
-	input[%prop]     = "risetime"
-	input[%state]    = "undetermined"
-	input[%postProc] = "nothing"
-
-	JWN_SetWaveInWaveNote(input, "/results", {0.2, 0.6, 0.9})
-	JWN_SetWaveInWaveNote(input, "/xValues", {2, 6, 9})
-	JWN_SetWaveInWaveNote(input, "/marker", {PSX_MARKER_UNDET, PSX_MARKER_UNDET, PSX_MARKER_UNDET})
-
-	// wv10
-	Duplicate/FREE/T template, wv10
-	WAVE/T input = wv10
-
-	input[%prop]     = "peaktime"
-	input[%state]    = "all"
-	input[%postProc] = "nonfinite"
-
-	JWN_SetWaveInWaveNote(input, "/results", {1, 3, 5, 7, 9})
-	JWN_SetWaveInWaveNote(input, "/xValues", {0, -1, +1, 0, -1})
-	JWN_SetWaveInWaveNote(input, "/marker", {PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT, PSX_MARKER_UNDET})
-	Make/FREE/T lbl = {"-inf", "NaN", "inf"}
-	JWN_SetWaveInWaveNote(input, "/XTickLabels", lbl)
-	JWN_SetWaveInWaveNote(input, "/XTickPositions", {-1, 0, 1})
-
-	// end
-	Make/FREE/WAVE results = {wv0, wv1, wv2, wv3, wv4, wv5, wv6, wv7, wv8, wv9, wv10}
-
-	return results
-End
-
-/// UTF_TD_GENERATOR w0:StatsTest_GetInput
+/// UTF_TD_GENERATOR w0:DataGenerators#StatsTest_GetInput
 static Function StatsWorksWithResults([STRUCT IUTF_mData &m])
 
 	string formulaGraph, browser, device, stateAsStr, postProc, prop
@@ -1001,163 +853,8 @@ static Function StatsWorksWithResults([STRUCT IUTF_mData &m])
 	endif
 End
 
-Function/WAVE StatsTestSpecialCases_GetInput()
-
-	Make/T/FREE/N=(7) template
-	SetDimensionLabels(template, "prop;state;postProc;refNumOutputRows;numEventsCombo0;numEventsCombo1;outOfRange", ROWS)
-
-	// wv0
-	// every
-	Duplicate/FREE/T template, wv0
-	WAVE/T input = wv0
-
-	input[%prop]             = "estate"
-	input[%state]            = "every"
-	input[%postProc]         = "nothing"
-	input[%refNumOutputRows] = "3"
-	input[%numEventsCombo0]  = "5"
-	input[%numEventsCombo1]  = "3"
-	input[%outOfRange]       = "0"
-
-	JWN_CreatePath(input, "/0")
-	JWN_SetWaveInWaveNote(input, "/0/results", {PSX_ACCEPT, PSX_ACCEPT, PSX_ACCEPT})
-	JWN_SetWaveInWaveNote(input, "/0/xValues", {1, 3, 1})
-	JWN_SetWaveInWaveNote(input, "/0/marker", {PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT})
-
-	JWN_CreatePath(input, "/1")
-	JWN_SetWaveInWaveNote(input, "/1/results", {PSX_REJECT, PSX_REJECT, PSX_REJECT})
-	JWN_SetWaveInWaveNote(input, "/1/xValues", {0, 4, 0})
-	JWN_SetWaveInWaveNote(input, "/1/marker", {PSX_MARKER_REJECT, PSX_MARKER_REJECT, PSX_MARKER_REJECT})
-
-	JWN_CreatePath(input, "/2")
-	JWN_SetWaveInWaveNote(input, "/2/results", {PSX_UNDET, PSX_UNDET})
-	JWN_SetWaveInWaveNote(input, "/2/xValues", {2, 2})
-	JWN_SetWaveInWaveNote(input, "/2/marker", {PSX_MARKER_UNDET, PSX_MARKER_UNDET})
-
-	// wv1
-	// no match
-	Duplicate/FREE/T template, wv1
-	WAVE/T input = wv1
-
-	input[%prop]             = "estate"
-	input[%state]            = "accept"
-	input[%postProc]         = "nothing"
-	input[%refNumOutputRows] = "0"
-	input[%numEventsCombo0]  = "1"
-	input[%numEventsCombo1]  = "1"
-	input[%outOfRange]       = "0"
-
-	// wv2
-	// histogram works also with just one point
-	Duplicate/FREE/T template, wv2
-	WAVE/T input = wv2
-
-	input[%prop]             = "estate"
-	input[%state]            = "reject"
-	input[%postProc]         = "hist"
-	input[%refNumOutputRows] = "1"
-	input[%numEventsCombo0]  = "1"
-	input[%numEventsCombo1]  = "0"
-	input[%outOfRange]       = "0"
-
-	JWN_CreatePath(input, "/0")
-	JWN_SetWaveInWaveNote(input, "/0/results", {1})
-	// no x values
-	JWN_SetWaveInWaveNote(input, "/0/marker", {PSX_MARKER_REJECT})
-
-	// wv3
-	// histogram with no match as the tau values are out-of-range
-	Duplicate/FREE/T template, wv3
-	WAVE/T input = wv3
-
-	input[%prop]             = "tau"
-	input[%state]            = "undetermined"
-	input[%postProc]         = "hist"
-	input[%refNumOutputRows] = "0"
-	input[%numEventsCombo0]  = "3"
-	input[%numEventsCombo1]  = "0"
-	input[%outOfRange]       = "1"
-
-	// wv4
-	// histogram with match but cut out data
-	Duplicate/FREE/T template, wv4
-	WAVE/T input = wv4
-
-	input[%prop]             = "amp"
-	input[%state]            = "all"
-	input[%postProc]         = "hist"
-	input[%refNumOutputRows] = "1"
-	input[%numEventsCombo0]  = "3"
-	input[%numEventsCombo1]  = "0"
-	input[%outOfRange]       = "1"
-
-	JWN_CreatePath(input, "/0")
-	JWN_SetWaveInWaveNote(input, "/0/results", {1})
-	// no xValues
-	JWN_SetWaveInWaveNote(input, "/0/marker", {PSX_MARKER_REJECT})
-
-	// wv5
-	// stats ignores NaN
-	Duplicate/FREE/T template, wv5
-	WAVE/T input = wv5
-
-	input[%prop]             = "amp"
-	input[%state]            = "all"
-	input[%postProc]         = "stats"
-	input[%refNumOutputRows] = "1"
-	input[%numEventsCombo0]  = "2"
-	input[%numEventsCombo1]  = "2"
-	input[%outOfRange]       = "0"
-
-	JWN_CreatePath(input, "/0")
-	JWN_SetWaveInWaveNote(input, "/0/results", {10, NaN, 0, 0, NaN, NaN})
-	JWN_SetWaveInWaveNote(input, "/0/xValues", ListToTextWave(PSX_STATS_LABELS, ";"))
-	JWN_SetWaveInWaveNote(input, "/0/marker", {PSX_MARKER_REJECT, PSX_MARKER_REJECT, PSX_MARKER_REJECT, \
-	                                           PSX_MARKER_REJECT, PSX_MARKER_REJECT, PSX_MARKER_REJECT})
-
-	// wv6
-	// stats ignores NaN and with all data NaN we don't get anything
-	Duplicate/FREE/T template, wv6
-	WAVE/T input = wv6
-
-	input[%prop]             = "amp"
-	input[%state]            = "all"
-	input[%postProc]         = "stats"
-	input[%refNumOutputRows] = "0"
-	input[%numEventsCombo0]  = "1"
-	input[%numEventsCombo1]  = "1"
-	input[%outOfRange]       = "0"
-
-	// no results
-	// no xValues
-	// no marker
-
-	// wv7
-	// xinterval with multiple combos
-	Duplicate/FREE/T template, wv7
-	WAVE/T input = wv7
-
-	input[%prop]             = "xinterval"
-	input[%state]            = "accept"
-	input[%postProc]         = "nothing"
-	input[%refNumOutputRows] = "1"
-	input[%numEventsCombo0]  = "5"
-	input[%numEventsCombo1]  = "5"
-	input[%outOfRange]       = "0"
-
-	JWN_CreatePath(input, "/0")
-	JWN_SetWaveInWaveNote(input, "/0/results", {NaN, 20, NaN, 20})
-	JWN_SetWaveInWaveNote(input, "/0/xValues", {1, 3, 1, 3})
-	JWN_SetWaveInWaveNote(input, "/0/marker", {PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT})
-
-	// end
-	Make/FREE/WAVE results = {wv0, wv1, wv2, wv3, wv4, wv5, wv6, wv7}
-
-	return results
-End
-
 // Test events being present locally in a DFREF
-/// UTF_TD_GENERATOR w0:StatsTestSpecialCases_GetInput
+/// UTF_TD_GENERATOR w0:DataGenerators#StatsTestSpecialCases_GetInput
 static Function StatsWorksWithResultsSpecialCases([STRUCT IUTF_mData &m])
 
 	string prop, stateAsStr, postProc, browser, device, formulaGraph, comboKey, pathPrefix, history, id
@@ -1298,17 +995,7 @@ static Function StatsComplainsAboutIntersectingRanges()
 	endtry
 End
 
-static Function/WAVE GetAllStatsProperties()
-
-	WAVE wv = MIES_PSX#PSX_GetAllStatsProperties()
-	CHECK_WAVE(wv, TEXT_WAVE)
-
-	SetDimensionLabelsFromWaveContents(wv)
-
-	return wv
-End
-
-/// IUTF_TD_GENERATOR s0:GetAllStatsProperties
+/// IUTF_TD_GENERATOR s0:DataGenerators#GetAllStatsProperties
 static Function StatsAllProperties([STRUCT IUTF_mData &m])
 
 	string browser, device, formulaGraph, comboKey, id, error, prop
@@ -1483,14 +1170,7 @@ Function/WAVE FakeSweepDataGeneratorPSX(WAVE sweep, variable numChannels)
 	return sweep
 End
 
-static Function/WAVE GetKernelAmplitude()
-
-	Make/D/FREE wv = {5, -5}
-
-	return wv
-End
-
-/// IUTF_TD_GENERATOR v0:GetKernelAmplitude
+/// IUTF_TD_GENERATOR v0:DataGenerators#GetKernelAmplitude
 static Function TestOperationPSX([STRUCT IUTF_mData &m])
 
 	string win, device, str, comboKey
@@ -1821,23 +1501,6 @@ static Function MouseSelectionPSX()
 	CheckPSXEventField({psxEvent_1}, {"Fit manual QC call", "Event manual QC call"}, {0, 1}, PSX_UNDET)
 End
 
-static Function/WAVE SupportedPostProcForEventSelection()
-
-	// nonfinite is tested elsewhere
-	Make/FREE/T wv = {"nothing", "log10"}
-	SetDimensionLabels(wv, AddPrefixToEachListItem("PostProc=", TextWavetoList(wv, ";")), ROWS)
-
-	return wv
-End
-
-static Function/WAVE SupportedAxisModesForEventSelection()
-
-	Make/FREE wv = {MODIFY_GRAPH_LOG_MODE_NORMAL, MODIFY_GRAPH_LOG_MODE_LOG10, MODIFY_GRAPH_LOG_MODE_LOG2}
-	SetDimensionLabels(wv, "LeftAxis=linear;LeftAxis=log10;LeftAxis=log2", ROWS)
-
-	return wv
-End
-
 static Function/S SetupDatabrowserWithSomeData()
 
 	string browser, device
@@ -1872,8 +1535,8 @@ static Function AdaptForPostProc(string postProc, variable val)
 	endswitch
 End
 
-/// UTF_TD_GENERATOR v0:SupportedAxisModesForEventSelection
-/// UTF_TD_GENERATOR s0:SupportedPostProcForEventSelection
+/// UTF_TD_GENERATOR v0:DataGenerators#SupportedAxisModesForEventSelection
+/// UTF_TD_GENERATOR s0:DataGenerators#SupportedPostProcForEventSelection
 static Function MouseSelectionPSXStats([STRUCT IUTF_mData &m])
 
 	string win, browser, code, psxGraph, psxStatsGraph, postProc, comboKey
@@ -2080,59 +1743,7 @@ static Function CheckTraceColors(string win, WAVE/T traces, variable state)
 	endfor
 End
 
-// two sweeps in one operation
-static Function/S GetTestCode(string postProc, [string eventState, string prop])
-
-	string code
-
-	if(ParamIsDefault(eventState))
-		eventState = "all"
-	endif
-
-	if(ParamIsDefault(prop))
-		prop = "peaktime"
-	endif
-
-	code = "psx(myId, psxKernel(select(selrange([50, 150]), selchannels(AD6), selsweeps([0, 2]), selvis(all))), 5, 100, 0)"
-
-	code  = "psx(myId, psxKernel(select(selrange([50, 150]), selchannels(AD6), selsweeps([0, 2]), selvis(all))), 1.5, 100, 0)"
-	code += "\r and \r"
-	code += "psxStats(myId, select(selrange([50, 150]), selchannels(AD6), selsweeps([0, 2]), selvis(all)), " + prop + ", " + eventState + ", " + postProc + ")"
-
-	return code
-End
-
-static Function/WAVE GetCodeVariations()
-
-	string code
-
-	Make/T/N=(3)/FREE wv
-
-	wv[0] = GetTestCode("nothing")
-	code  = ""
-
-	// one sweep per operation separated with `with`
-	code  = "psx(myId, psxKernel(select(selrange([50, 150]), selchannels(AD6), selsweeps([0]), selvis(all))), 2, 100, 0)"
-	code += "\r with \r"
-	code += "psx(myId, psxKernel(select(selrange([50, 150]), selchannels(AD6), selsweeps([2]), selvis(all))), 1.5, 100, 0)"
-	code += "\r and \r"
-	code += "psxStats(myId, select(selrange([50, 150]), selchannels(AD6), selsweeps([0, 2]), selvis(all)), peak, all, nothing)"
-	wv[1] = code
-	code  = ""
-
-	// same as code[1] but with a select array for stats
-	code  = "psx(myId, psxKernel(select(selrange([50, 150]), selchannels(AD6), selsweeps([0]), selvis(all))), 2, 100, 0)"
-	code += "\r with \r"
-	code += "psx(myId, psxKernel(select(selrange([50, 150]), selchannels(AD6), selsweeps([2]), selvis(all))), 1.5, 100, 0)"
-	code += "\r and \r"
-	code += "psxStats(myId, [select(selrange([50, 150]), selchannels(AD6), selsweeps([0]), selvis(all)), select(selrange([50, 150]), selchannels(AD6), selsweeps([2]), selvis(all))], peak, all, nothing)"
-	wv[2] = code
-	code  = ""
-
-	return wv
-End
-
-/// IUTF_TD_GENERATOR s0:GetCodeVariations
+/// IUTF_TD_GENERATOR s0:DataGenerators#GetCodeVariations
 static Function AllEventGraph([STRUCT IUTF_mData &m])
 
 	string browser, code, extAllGraph, win, trace, info, rgbValue, mainWindow, specialEventPanel, comboKey
@@ -2391,8 +2002,8 @@ static Function JumpToUndet()
 	CHECK_EQUAL_VAR(MIES_PSX#PSX_GetCurrentComboIndex(win), 0)
 End
 
-/// UTF_TD_GENERATOR v0:SupportedAxisModesForEventSelection
-/// UTF_TD_GENERATOR s0:SupportedPostProcForEventSelection
+/// UTF_TD_GENERATOR v0:DataGenerators#SupportedAxisModesForEventSelection
+/// UTF_TD_GENERATOR s0:DataGenerators#SupportedPostProcForEventSelection
 static Function JumpToSelectedEvents([STRUCT IUTF_mData &m])
 
 	string browser, code, psxGraph, win, mainWindow, postProc, psxStatsGraph, comboKey

--- a/Packages/tests/Basic/UTF_UtilsChecks.ipf
+++ b/Packages/tests/Basic/UTF_UtilsChecks.ipf
@@ -62,7 +62,7 @@ static Function TestIsStrictlyPositiveAndFinite()
 	CHECK(!IsStrictlyPositiveAndFinite(-1))
 End
 
-// UTF_TD_GENERATOR InfiniteValues
+// UTF_TD_GENERATOR DataGenerators#InfiniteValues
 static Function TestIsStrictlyPositiveAndFiniteInfinite([variable var])
 
 	CHECK(!IsStrictlyPositiveAndFinite(var))
@@ -75,7 +75,7 @@ static Function TestIsNullOrPositiveAndFinite()
 	CHECK(!IsNullOrPositiveAndFinite(-1))
 End
 
-// UTF_TD_GENERATOR InfiniteValues
+// UTF_TD_GENERATOR DataGenerators#InfiniteValues
 static Function TestIsNullOrPositiveAndFiniteInfinite([variable var])
 
 	CHECK(!IsNullOrPositiveAndFinite(var))

--- a/Packages/tests/Basic/UTF_Utils_Algorithm.ipf
+++ b/Packages/tests/Basic/UTF_Utils_Algorithm.ipf
@@ -839,7 +839,7 @@ Function FLW_RequiresNumericWave()
 	endtry
 End
 
-// UTF_TD_GENERATOR InfiniteValues
+// UTF_TD_GENERATOR DataGenerators#InfiniteValues
 Function FLW_RequiresFiniteLevel([variable var])
 
 	try

--- a/Packages/tests/Basic/UTF_Utils_Checks.ipf
+++ b/Packages/tests/Basic/UTF_Utils_Checks.ipf
@@ -281,7 +281,7 @@ Function IC_Works()
 	CHECK_EQUAL_VAR(IsConstant({-1, 2, 3}, 0), 0)
 End
 
-// UTF_TD_GENERATOR InfiniteValues
+// UTF_TD_GENERATOR DataGenerators#InfiniteValues
 Function IC_WorksSpecialValues([variable val])
 
 	Make/FREE/N=0 empty

--- a/Packages/tests/Basic/UTF_Utils_Conversions.ipf
+++ b/Packages/tests/Basic/UTF_Utils_Conversions.ipf
@@ -109,7 +109,7 @@ Function TWTLChecksParams()
 	endtry
 End
 
-// UTF_TD_GENERATOR TrailSepOptions
+// UTF_TD_GENERATOR DataGenerators#TrailSepOptions
 Function TWTLOddCases([variable var])
 
 	Make/FREE/T/N=0 w
@@ -128,7 +128,7 @@ Function TWTLOddCases([variable var])
 	CHECK_EQUAL_STR(result, expected)
 End
 
-// UTF_TD_GENERATOR TrailSepOptions
+// UTF_TD_GENERATOR DataGenerators#TrailSepOptions
 Function TWTL1D([variable var])
 
 	Make/FREE/T/N=3 w = {"1", "2", "3"}
@@ -142,7 +142,7 @@ Function TWTL1D([variable var])
 	CHECK_EQUAL_STR(list, refList)
 End
 
-// UTF_TD_GENERATOR TrailSepOptions
+// UTF_TD_GENERATOR DataGenerators#TrailSepOptions
 Function TWTL2D([variable var])
 
 	Make/FREE/T/N=(3, 3) w = {{"1", "2", "3"}, {"4", "5", "6"}, {"7", "8", "9"}}
@@ -156,7 +156,7 @@ Function TWTL2D([variable var])
 	CHECK_EQUAL_STR(list, refList)
 End
 
-// UTF_TD_GENERATOR TrailSepOptions
+// UTF_TD_GENERATOR DataGenerators#TrailSepOptions
 Function TWTL3D([variable var])
 
 	Make/FREE/T/N=(2, 2, 2) w = {{{"1", "2"}, {"3", "4"}}, {{"5", "6"}, {"7", "8"}}}
@@ -170,7 +170,7 @@ Function TWTL3D([variable var])
 	CHECK_EQUAL_STR(list, refList)
 End
 
-// UTF_TD_GENERATOR TrailSepOptions
+// UTF_TD_GENERATOR DataGenerators#TrailSepOptions
 Function TWTL4D([variable var])
 
 	Make/FREE/T/N=(2, 2, 2, 2) w = {{{{"1", "2"}, {"3", "4"}}, {{"5", "6"}, {"7", "8"}}}, {{{"9", "10"}, {"11", "12"}}, {{"13", "14"}, {"15", "16"}}}}
@@ -184,7 +184,7 @@ Function TWTL4D([variable var])
 	CHECK_EQUAL_STR(list, refList)
 End
 
-// UTF_TD_GENERATOR TrailSepOptions
+// UTF_TD_GENERATOR DataGenerators#TrailSepOptions
 Function TWTLCustomSepators([variable var])
 
 	Make/FREE/T/N=(2, 2, 2, 2) w = {{{{"1", "2"}, {"3", "4"}}, {{"5", "6"}, {"7", "8"}}}, {{{"9", "10"}, {"11", "12"}}, {{"13", "14"}, {"15", "16"}}}}
@@ -198,7 +198,7 @@ Function TWTLCustomSepators([variable var])
 	CHECK_EQUAL_STR(list, refList)
 End
 
-// UTF_TD_GENERATOR TrailSepOptions
+// UTF_TD_GENERATOR DataGenerators#TrailSepOptions
 Function TWTLStopOnEmpty([variable var])
 
 	Make/FREE/T/N=(3, 3) w = {{"", "2", "3"}, {"4", "5", "6"}, {"7", "8", "9"}}
@@ -233,7 +233,7 @@ Function TWTLStopOnEmpty([variable var])
 	CHECK_EQUAL_STR(list, refList)
 End
 
-// UTF_TD_GENERATOR TrailSepOptions
+// UTF_TD_GENERATOR DataGenerators#TrailSepOptions
 Function TWTLMaxElements([variable var])
 
 	Make/FREE/T/N=(3, 3) w = {{"1", "2", "3"}, {"4", "5", "6"}, {"7", "8", "9"}}
@@ -264,7 +264,7 @@ Function TWTLMaxElements([variable var])
 	CHECK_EQUAL_STR(list, refList)
 End
 
-// UTF_TD_GENERATOR TrailSepOptions
+// UTF_TD_GENERATOR DataGenerators#TrailSepOptions
 static Function TWTLSingleElementNDSeparators([variable var])
 
 	string list
@@ -295,30 +295,8 @@ static Function TWTLSingleElementNDSeparators([variable var])
 	CHECK_EQUAL_STR(list, refList)
 End
 
-Function/WAVE SomeTextWaves()
-
-	Make/WAVE/FREE/N=5 all
-
-	Make/FREE/T/N=0 wv1
-
-	// both empty and null roundtrip to an empty wave
-	all[0] = wv1
-	all[1] = $""
-
-	Make/FREE/T/N=(3, 3) wv2 = {{"1", "2", "3"}, {"4", "5", "6"}, {"7", "8", "9"}}
-	all[2] = wv2
-
-	Make/FREE/T/N=(2, 2, 2) wv3 = {{{"1", "2"}, {"3", "4"}}, {{"5", "6"}, {"7", "8"}}}
-	all[3] = wv3
-
-	Make/FREE/T/N=(2, 2, 2, 2) wv4 = {{{{"1", "2"}, {"3", "4"}}, {{"5", "6"}, {"7", "8"}}}, {{{"9", "10"}, {"11", "12"}}, {{"13", "14"}, {"15", "16"}}}}
-	all[4] = wv4
-
-	return all
-End
-
-// UTF_TD_GENERATOR w0:SomeTextWaves
-// UTF_TD_GENERATOR v0:TrailSepOptions
+// UTF_TD_GENERATOR w0:DataGenerators#SomeTextWaves
+// UTF_TD_GENERATOR v0:DataGenerators#TrailSepOptions
 Function TWTLRoundTrips([STRUCT IUTF_MDATA &md])
 
 	string list
@@ -467,7 +445,7 @@ End
 /// NumericWaveToList
 /// @{
 
-// UTF_TD_GENERATOR TrailSepOptions
+// UTF_TD_GENERATOR DataGenerators#TrailSepOptions
 Function NWLWorks([variable var])
 
 	string expected, result
@@ -800,13 +778,7 @@ Function STIW_TestDimensions()
 	REQUIRE_EQUAL_VAR(ScaleToIndexWrapper(testWave, Inf, ROWS), 0)
 End
 
-Function/WAVE STIW_TestAbortGetter()
-
-	Make/D/FREE data = {4, -1, 0.1, NaN, Inf, -Inf}
-	return data
-End
-
-// UTF_TD_GENERATOR STIW_TestAbortGetter
+// UTF_TD_GENERATOR DataGenerators#STIW_TestAbortGetter
 Function STIW_TestAbort([variable var])
 
 	Make/FREE testwave

--- a/Packages/tests/Basic/UTF_Utils_DataFolder.ipf
+++ b/Packages/tests/Basic/UTF_Utils_DataFolder.ipf
@@ -155,7 +155,7 @@ Function GetListOfObjectsWorks2()
 	KillDataFolder/Z test
 End
 
-// IUTF_TD_GENERATOR w0:CountObjectTypeFlags
+// IUTF_TD_GENERATOR w0:DataGenerators#CountObjectTypeFlags
 Function GetListOfObjectsWorksTypeFlag([STRUCT IUTF_mData &md])
 
 	string result, expected, expectedRec

--- a/Packages/tests/Basic/UTF_Utils_Mies_Sweep.ipf
+++ b/Packages/tests/Basic/UTF_Utils_Mies_Sweep.ipf
@@ -23,7 +23,7 @@
 /// IsValidSweepNumber
 /// @{
 
-// UTF_TD_GENERATOR InfiniteValues
+// UTF_TD_GENERATOR DataGenerators#InfiniteValues
 static Function IVSN_WorksSpecialValues([variable val])
 
 	CHECK(!IsValidSweepNumber(val))
@@ -41,27 +41,13 @@ End
 /// ExtractSweepNumber
 /// @{
 
-Function/WAVE GetValidStringsWithSweepNumber()
-
-	Make/FREE/T wv = {"Sweep_100", "Sweep_100_bak", "Config_Sweep_100", "Config_Sweep_100_bak", "X_100"}
-
-	return wv
-End
-
-// UTF_TD_GENERATOR GetValidStringsWithSweepNumber
+// UTF_TD_GENERATOR DataGenerators#GetValidStringsWithSweepNumber
 Function ESN_Works([string str])
 
 	CHECK_EQUAL_VAR(ExtractSweepNumber(str), 100)
 End
 
-Function/WAVE GetInvalidStringsWithSweepNumber()
-
-	Make/FREE/T wv = {"", "A", "A__", "Sweep_-100"}
-
-	return wv
-End
-
-// UTF_TD_GENERATOR GetInvalidStringsWithSweepNumber
+// UTF_TD_GENERATOR DataGenerators#GetInvalidStringsWithSweepNumber
 Function ESN_Complains([string str])
 
 	try

--- a/Packages/tests/Basic/UTF_Utils_Numeric.ipf
+++ b/Packages/tests/Basic/UTF_Utils_Numeric.ipf
@@ -128,8 +128,8 @@ End
 /// IndexAfterDecimation
 /// @{
 
-// IUTF_TD_GENERATOR v0:IndexAfterDecimation_Positions
-// IUTF_TD_GENERATOR v1:IndexAfterDecimation_Sizes
+// IUTF_TD_GENERATOR v0:DataGenerators#IndexAfterDecimation_Positions
+// IUTF_TD_GENERATOR v1:DataGenerators#IndexAfterDecimation_Sizes
 static Function TestIndexAfterDecimation([STRUCT IUTF_mData &md])
 
 	variable decimationFactor, srcPulseLength, srcOffset

--- a/Packages/tests/Basic/UTF_WaveAveraging.ipf
+++ b/Packages/tests/Basic/UTF_WaveAveraging.ipf
@@ -3,16 +3,6 @@
 #pragma rtFunctionErrors = 1
 #pragma ModuleName       = UTF_WaveAveraging
 
-static Function/WAVE SupportedTypeGetter()
-
-	Make/FREE result = {IGOR_TYPE_32BIT_FLOAT, IGOR_TYPE_64BIT_FLOAT}
-
-	SetDimLabel 0, 0, $"float", result
-	SetDimLabel 0, 1, $"double", result
-
-	return result
-End
-
 static Function IgorTypeToUTFType_IGNORE(variable igor_type)
 
 	switch(igor_type)
@@ -56,7 +46,7 @@ Function DoesNothingWithInvalidWave()
 	CHECK_WAVE(result[0], NULL_WAVE)
 End
 
-/// UTF_TD_GENERATOR SupportedTypeGetter
+/// UTF_TD_GENERATOR DataGenerators#SupportedTypeGetter
 Function ReturnsCorrectResultWithOneWave([variable var])
 
 	Make/D/FREE data = {1, 2, 3, 4}
@@ -74,7 +64,7 @@ Function ReturnsCorrectResultWithOneWave([variable var])
 	CheckWaveScaling_IGNORE(result[0])
 End
 
-/// UTF_TD_GENERATOR SupportedTypeGetter
+/// UTF_TD_GENERATOR DataGenerators#SupportedTypeGetter
 Function PointForPointNoNans([variable var])
 
 	Make/D/FREE data1 = {1, 2, 3, 4}
@@ -94,7 +84,7 @@ Function PointForPointNoNans([variable var])
 	CheckWaveScaling_IGNORE(result[0])
 End
 
-/// UTF_TD_GENERATOR SupportedTypeGetter
+/// UTF_TD_GENERATOR DataGenerators#SupportedTypeGetter
 Function PointForPointWithNaNs([variable var])
 
 	Make/D/FREE data1 = {1, 2, NaN, 4}
@@ -114,7 +104,7 @@ Function PointForPointWithNaNs([variable var])
 	CheckWaveScaling_IGNORE(result[0])
 End
 
-/// UTF_TD_GENERATOR SupportedTypeGetter
+/// UTF_TD_GENERATOR DataGenerators#SupportedTypeGetter
 Function NonPointForPointNoNans([variable var])
 
 	Make/D/FREE data1 = {1, 2, 3, 4}
@@ -134,7 +124,7 @@ Function NonPointForPointNoNans([variable var])
 	CheckWaveScaling_IGNORE(result[0])
 End
 
-/// UTF_TD_GENERATOR SupportedTypeGetter
+/// UTF_TD_GENERATOR DataGenerators#SupportedTypeGetter
 Function NonPointForPointWithNans([variable var])
 
 	Make/D/FREE data1 = {1, 2, NaN, 4}

--- a/Packages/tests/Basic/UTF_WaveBuilder.ipf
+++ b/Packages/tests/Basic/UTF_WaveBuilder.ipf
@@ -264,7 +264,7 @@ Function WB_SaveErrorsDontDeleteExistingStimSets()
 	CHECK_EQUAL_VAR(modCount, WaveMOdCount(stimset))
 End
 
-/// UTF_TD_GENERATOR GetChannelTypes
+/// UTF_TD_GENERATOR DataGenerators#GetChannelTypes
 Function ExportAndLoadOfCustomWaves([variable var])
 
 	string setName, path, filename, history

--- a/Packages/tests/Basic/UTF_WaveBuilderRegression.ipf
+++ b/Packages/tests/Basic/UTF_WaveBuilderRegression.ipf
@@ -61,21 +61,7 @@ Function/WAVE WB_FetchRefWave_IGNORE(string name)
 	return wv
 End
 
-Function/WAVE WB_GatherStimsets()
-
-	string list
-
-	DFREF dfr = root:wavebuilder_misc:DAParameterWaves
-	list = GetListOfObjects(dfr, "WP_.*")
-	list = RemovePrefixFromListItem("WP_", list)
-	WAVE/T wv = ListToTextWave(list, ";")
-
-	SetDimensionLabels(wv, list, ROWS)
-
-	return wv
-End
-
-// UTF_TD_GENERATOR WB_GatherStimsets
+// UTF_TD_GENERATOR DataGenerators#WB_GatherStimsets
 Function WB_RegressionTest([string stimset])
 
 	variable i, j, sweepCount, duration, epochCount, minimum, maximum

--- a/Packages/tests/Compilation/CompilationTester.ipf
+++ b/Packages/tests/Compilation/CompilationTester.ipf
@@ -1,6 +1,7 @@
 #pragma rtGlobals         = 3
 #pragma rtFunctionErrors  = 1
 #pragma TextEncoding      = "UTF-8"
+#pragma ModuleName        = CompilationTester
 #pragma IndependentModule = MIES_CompilationTester
 
 #include "igortest"
@@ -37,7 +38,7 @@ static Function GetEnvironmentVariableAsBoolean(string key)
 	return NaN
 End
 
-Function/WAVE GetIncludes()
+static Function/WAVE GetIncludes()
 
 	// keep sorted
 	Make/FREE/T includes = {"UTF_All_Includes"}
@@ -47,7 +48,7 @@ Function/WAVE GetIncludes()
 	return includes
 End
 
-Function/WAVE GetDefines()
+static Function/WAVE GetDefines()
 
 	if(GetEnvironmentVariableAsBoolean("CI_SKIP_COMPILATION_TEST_DEFINES"))
 		Make/FREE/T/N=1 defines
@@ -75,8 +76,8 @@ Function/WAVE GetDefines()
 	return defines
 End
 
-/// UTF_TD_GENERATOR s0:GetIncludes
-/// UTF_TD_GENERATOR s1:GetDefines
+/// UTF_TD_GENERATOR s0:CompilationTester#GetIncludes
+/// UTF_TD_GENERATOR s1:CompilationTester#GetDefines
 Function TestCompilation([STRUCT IUTF_mData &md])
 
 	if(strlen(md.s1) > 0)

--- a/Packages/tests/HardwareAnalysisFunctions/UTF_MultiPatchSeqDaScale.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_MultiPatchSeqDaScale.ipf
@@ -58,7 +58,7 @@ static Function/WAVE GetLBNSingleEntry_IGNORE(variable sweepNo, string device, s
 	endswitch
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function MSQ_DS1([string str])
 
 	[STRUCT DAQSettings s] = MSQ_GetDAQSettings(str)
@@ -92,7 +92,7 @@ static Function MSQ_DS1_REENTRY([string str])
 	CommonAnalysisFunctionChecks(str, sweepNo, setPass)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function MSQ_DS2([string str])
 
 	AFH_AddAnalysisParameter("MSQ_DAScale_DA_0", "DAScales", wv = {1000, 1500, 2000, 3000, 5000})

--- a/Packages/tests/HardwareAnalysisFunctions/UTF_MultiPatchSeqFastRheoEstimate.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_MultiPatchSeqFastRheoEstimate.ipf
@@ -54,7 +54,7 @@ static Function/WAVE GetLBNSingleEntry_IGNORE(string device, variable sweepNo, s
 	endswitch
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function MSQ_FRE1([string str])
 
 	[STRUCT DAQSettings s] = MSQ_GetDAQSettings(str)
@@ -146,7 +146,7 @@ static Function MSQ_FRE1_REENTRY([string str])
 	CommonAnalysisFunctionChecks(str, sweepNo, {0, 0})
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function MSQ_FRE2([string str])
 
 	[STRUCT DAQSettings s] = MSQ_GetDAQSettings(str)
@@ -241,7 +241,7 @@ static Function MSQ_FRE2_REENTRY([string str])
 	CommonAnalysisFunctionChecks(str, sweepNo, {0, 0})
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function MSQ_FRE3([string str])
 
 	[STRUCT DAQSettings s] = MSQ_GetDAQSettings(str)
@@ -334,7 +334,7 @@ static Function MSQ_FRE3_REENTRY([string str])
 	CommonAnalysisFunctionChecks(str, sweepNo, {0, 0})
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function MSQ_FRE4([string str])
 
 	[STRUCT DAQSettings s] = MSQ_GetDAQSettings(str)
@@ -432,7 +432,7 @@ static Function MSQ_FRE4_REENTRY([string str])
 	CommonAnalysisFunctionChecks(str, sweepNo, {0, 0})
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function MSQ_FRE5([string str])
 
 	[STRUCT DAQSettings s] = MSQ_GetDAQSettings(str)
@@ -543,7 +543,7 @@ End
 
 // only one IC and one VC headstage
 // check that VC is on again in the end
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function MSQ_FRE6([string str])
 
 	[STRUCT DAQSettings s] = MSQ_GetDAQSettings(str)
@@ -647,7 +647,7 @@ End
 
 // one test with PostDAQDAScale and PostDAQDAScaleFactor analysis parameters
 // check dascale after DAQ
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function MSQ_FRE7([string str])
 
 	[STRUCT DAQSettings s] = MSQ_GetDAQSettings(str)
@@ -758,7 +758,7 @@ End
 
 // one test with PostDAQDAScale and PostDAQDAScaleFactor analysis parameters
 // check dascale after DAQ and one headstage failed
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function MSQ_FRE8([string str])
 
 	[STRUCT DAQSettings s] = MSQ_GetDAQSettings(str)
@@ -865,7 +865,7 @@ static Function MSQ_FRE9_PreInit(string device)
 End
 
 // one test with range exceeded and MaximumDAScale analysis parameter
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function MSQ_FRE9([string str])
 
 	[STRUCT DAQSettings s] = MSQ_GetDAQSettings(str)
@@ -969,7 +969,7 @@ static Function MSQ_FRE10_PreInit(string device)
 End
 
 // Using MinOffset and a scale factor
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function MSQ_FRE10([string str])
 
 	[STRUCT DAQSettings s] = MSQ_GetDAQSettings(str)
@@ -1073,7 +1073,7 @@ static Function MSQ_FRE10_REENTRY([string str])
 	CommonAnalysisFunctionChecks(str, sweepNo, {1, 1})
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function MSQ_FRE11([string str])
 
 	ST_SetStimsetParameter("MSQ_FastRheoEst_DA_0", "Total number of steps", var = 50)

--- a/Packages/tests/HardwareAnalysisFunctions/UTF_MultiPatchSeqSpikeControl.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_MultiPatchSeqSpikeControl.ipf
@@ -144,7 +144,7 @@ static Function/WAVE GetLBNEntries_IGNORE(string device, variable sweepNo)
 	return wv
 End
 
-// UTF_TD_GENERATOR SpikeCountsStateValues
+// UTF_TD_GENERATOR DataGenerators#SpikeCountsStateValues
 static Function TestSpikeCounts([WAVE vals])
 
 	CHECK_EQUAL_VAR(MIES_SC#SC_SpikeCountsCalcDetail(vals[%minimum], vals[%maximum], vals[%idealNumber]), vals[%expectedState])
@@ -163,7 +163,7 @@ static Function SC_Test1_preInit(string device)
 	AFH_AddAnalysisParameter("SC_SpikeControl_DA_0", "IdealNumberOfSpikesPerPulse", var = 1)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SC_Test1([string str])
 
 	[STRUCT DAQSettings s] = MSQ_GetDAQSettings(str)
@@ -248,7 +248,7 @@ static Function SC_Test2_preInit(string device)
 	AFH_AddAnalysisParameter("SC_SpikeControl_DA_0", "IdealNumberOfSpikesPerPulse", var = 1)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SC_Test2([string str])
 
 	[STRUCT DAQSettings s] = MSQ_GetDAQSettings(str)
@@ -337,7 +337,7 @@ static Function SC_Test3_preInit(string device)
 	AFH_AddAnalysisParameter("SC_SpikeControl_DA_0", "IdealNumberOfSpikesPerPulse", var = 1)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SC_Test3([string str])
 
 	[STRUCT DAQSettings s] = MSQ_GetDAQSettings(str)
@@ -435,7 +435,7 @@ static Function SC_Test4_preInit(string device)
 	AFH_AddAnalysisParameter("SC_SpikeControl_DA_0", "IdealNumberOfSpikesPerPulse", var = 2)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SC_Test4([string str])
 
 	[STRUCT DAQSettings s] = MSQ_GetDAQSettings(str)
@@ -533,7 +533,7 @@ static Function SC_Test5_preInit(string device)
 	AFH_AddAnalysisParameter("SC_SpikeControl_DA_0", "IdealNumberOfSpikesPerPulse", var = 2)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SC_Test5([string str])
 
 	[STRUCT DAQSettings s] = MSQ_GetDAQSettings(str)
@@ -632,7 +632,7 @@ static Function SC_Test6_preInit(string device)
 	AFH_AddAnalysisParameter("SC_SpikeControl_DA_0", "IdealNumberOfSpikesPerPulse", var = 1)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SC_Test6([string str])
 
 	[STRUCT DAQSettings s] = MSQ_GetDAQSettings(str)
@@ -721,7 +721,7 @@ static Function SC_Test7_preInit(string device)
 	AFH_AddAnalysisParameter("SC_SpikeControl_DA_0", "IdealNumberOfSpikesPerPulse", var = 2)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SC_Test7([string str])
 
 	[STRUCT DAQSettings s] = MSQ_GetDAQSettings(str)
@@ -843,7 +843,7 @@ static Function SC_Test8_preInit(string device)
 	AFH_AddAnalysisParameter("SC_SpikeControl_DA_0", "IdealNumberOfSpikesPerPulse", var = 1)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SC_Test8([string str])
 
 	[STRUCT DAQSettings s] = MSQ_GetDAQSettings(str)
@@ -989,7 +989,7 @@ static Function SC_Test9_preAcq(string device)
 	PGC_SetAndActivateControl(device, DAP_GetClampModeControl(V_CLAMP_MODE, 1), val = 1)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SC_Test9([string str])
 
 	[STRUCT DAQSettings s] = MSQ_GetDAQSettings(str)
@@ -1081,7 +1081,7 @@ static Function SC_Test10_preAcq(string device)
 	PGC_SetAndActivateControl(device, DAP_GetClampModeControl(V_CLAMP_MODE, 1), val = 1)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SC_Test10([string str])
 
 	[STRUCT DAQSettings s] = MSQ_GetDAQSettings(str)

--- a/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqAccessResistanceSmoke.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqAccessResistanceSmoke.ipf
@@ -225,7 +225,7 @@ static Function PS_AR1_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_AR1([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -298,7 +298,7 @@ static Function PS_AR2_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_AR2([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -374,7 +374,7 @@ static Function PS_AR3_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_AR3([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -450,7 +450,7 @@ static Function PS_AR4_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_AR4([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -526,7 +526,7 @@ static Function PS_AR5_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_AR5([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -601,7 +601,7 @@ static Function PS_AR6_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_AR6([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -703,7 +703,7 @@ static Function PS_AR6a_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_AR6a([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -779,7 +779,7 @@ static Function PS_AR7_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_AR7([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -815,7 +815,7 @@ static Function PS_AR8_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_AR8([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)

--- a/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqChirp.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqChirp.ipf
@@ -168,7 +168,7 @@ End
 
 // BBAA but with zero value which results in PSQ_CR_RERUN
 //
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_CR1([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -247,7 +247,7 @@ static Function PS_CR2_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_CR2([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -326,7 +326,7 @@ static Function PS_CR2a_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_CR2a([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -404,7 +404,7 @@ static Function PS_CR2b_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_CR2b([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -484,7 +484,7 @@ static Function PS_CR3_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_CR3([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -566,7 +566,7 @@ static Function PS_CR4_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_CR4([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -678,7 +678,7 @@ static Function PS_CR4a_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_CR4a([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -789,7 +789,7 @@ static Function PS_CR4b_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_CR4b([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -900,7 +900,7 @@ static Function PS_CR5_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_CR5([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -1012,7 +1012,7 @@ static Function PS_CR6_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_CR6([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -1125,7 +1125,7 @@ static Function PS_CR7_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_CR7([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -1233,7 +1233,7 @@ static Function PS_CR8_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_CR8([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -1342,7 +1342,7 @@ End
 
 // Enough passing sweeps but not enough with the same DAScale
 //
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_CR9([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -1455,7 +1455,7 @@ End
 
 // Enough passing sweeps but not enough with the same DAScale
 //
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_CR9a([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -1568,7 +1568,7 @@ End
 
 // Enough passing sweeps but not enough with the same DAScale
 //
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_CR9b([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -1681,7 +1681,7 @@ End
 
 // Early abort as not enough sweeps with the same DASCale value pass
 //
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_CR10([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -1792,7 +1792,7 @@ static Function PS_CR11_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_CR11([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -1878,7 +1878,7 @@ static Function PS_CR12_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_CR12([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -1964,7 +1964,7 @@ End
 
 // Early abort as not enough sweeps with the same DASCale value pass
 //
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_CR13([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -2066,7 +2066,7 @@ End
 // Early abort as not enough sweeps with the same DASCale value pass
 // and user onset delay
 //
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_CR13a([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -2161,7 +2161,7 @@ static Function PS_CR13b_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_CR13b([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -2246,7 +2246,7 @@ End
 
 // Same as PS_CR1 but with failing sampling interval check
 //
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_CR14([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -2326,7 +2326,7 @@ static Function PS_CR15_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_CR15([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -2412,7 +2412,7 @@ static Function PS_CR16_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_CR16([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -2494,7 +2494,7 @@ static Function PS_CR17_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_CR17([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -2580,7 +2580,7 @@ static Function PS_CR18_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_CR18([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)

--- a/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqDAScale_Adapt.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqDAScale_Adapt.ipf
@@ -389,108 +389,7 @@ static Function PrintSomeValues(WAVE/WAVE entries)
 	print/D wv
 End
 
-static Function/WAVE VariousInputForHasRequiredQCOrder()
-
-	// IPT_FORMAT_OFF
-
-	// all zero
-	Make/FREE firstQC      = {0, 0, 0, 0}
-	Make/FREE checkQCFirst = {0, 0, 0}
-	Make/FREE lastQC       = {0, 0, 0, 0}
-	Make/FREE checkQCLast  = {0, 0, 0}
-	Make/FREE result       = {0}
-
-	Make/FREE/WAVE wv0 = {firstQC, checkQCFirst, lastQC, checkQCLast, result}
-
-	// only first
-	Make/FREE firstQC      = {0, 0, 0, 0}
-	Make/FREE checkQCFirst = {1, 1, 1}
-	Make/FREE lastQC       = {0, 0, 0, 0}
-	Make/FREE checkQCLast  = {0, 0, 0}
-	Make/FREE result       = {0}
-
-	Make/FREE/WAVE wv1 = {firstQC, checkQCFirst, lastQC, checkQCLast, result}
-
-	// only last
-	Make/FREE firstQC      = {0, 0, 0, 0}
-	Make/FREE checkQCFirst = {0, 0, 0}
-	Make/FREE lastQC       = {0, 0, 0, 0}
-	Make/FREE checkQCLast  = {1, 1, 1}
-	Make/FREE result       = {0}
-
-	Make/FREE/WAVE wv2 = {firstQC, checkQCFirst, lastQC, checkQCLast, result}
-
-	// wrong order
-	Make/FREE firstQC      = {0, 1, 1, 0}
-	Make/FREE checkQCFirst = {0, 1, 0}
-	Make/FREE lastQC       = {0, 1, 1, 0}
-	Make/FREE checkQCLast  = {1, 0, 0}
-	Make/FREE result       = {0}
-
-	Make/FREE/WAVE wv3 = {firstQC, checkQCFirst, lastQC, checkQCLast, result}
-
-	// correct order
-	Make/FREE firstQC      = {0, 1, 1, 0}
-	Make/FREE checkQCFirst = {1, 0, 0}
-	Make/FREE lastQC       = {0, 1, 1, 0}
-	Make/FREE checkQCLast  = {0, 1, 0}
-	Make/FREE result       = {1}
-
-	Make/FREE/WAVE wv4 = {firstQC, checkQCFirst, lastQC, checkQCLast, result}
-
-	// correct order but last sweep failed
-	Make/FREE firstQC      = {0, 1, 0, 0}
-	Make/FREE checkQCFirst = {1, 0, 0}
-	Make/FREE lastQC       = {0, 1, 0, 0}
-	Make/FREE checkQCLast  = {0, 1, 0}
-	Make/FREE result       = {0}
-
-	Make/FREE/WAVE wv5 = {firstQC, checkQCFirst, lastQC, checkQCLast, result}
-
-	// correct order but first sweep failed
-	Make/FREE firstQC      = {0, 0, 0, 0}
-	Make/FREE checkQCFirst = {1, 0, 0}
-	Make/FREE lastQC       = {0, 0, 1, 0}
-	Make/FREE checkQCLast  = {0, 1, 0}
-	Make/FREE result       = {0}
-
-	Make/FREE/WAVE wv6 = {firstQC, checkQCFirst, lastQC, checkQCLast, result}
-
-	// passes with fail gap
-	Make/FREE firstQC      = {0, 0, 1, 0, 0}
-	Make/FREE checkQCFirst = {0, 1, 0, 0}
-	Make/FREE lastQC       = {0, 0, 0, 0, 1}
-	Make/FREE checkQCLast  = {0, 0, 0, 1}
-	Make/FREE result       = {1}
-
-	Make/FREE/WAVE wv7 = {firstQC, checkQCFirst, lastQC, checkQCLast, result}
-
-	// fails due to gap with firstQC passing
-	Make/FREE firstQC      = {0, 0, 1, 1, 0}
-	Make/FREE checkQCFirst = {0, 1, 0, 0}
-	Make/FREE lastQC       = {0, 0, 0, 0, 1}
-	Make/FREE checkQCLast  = {0, 0, 0, 1}
-	Make/FREE result       = {0}
-
-	Make/FREE/WAVE wv8 = {firstQC, checkQCFirst, lastQC, checkQCLast, result}
-
-	// fails due to gap with lastQC passing
-	Make/FREE firstQC      = {0, 1, 0, 0, 0}
-	Make/FREE checkQCFirst = {1, 0, 0, 0}
-	Make/FREE lastQC       = {0, 0, 1, 1, 0}
-	Make/FREE checkQCLast  = {0, 0, 1, 0}
-	Make/FREE result       = {0}
-
-	// IPT_FORMAT_ON
-
-	Make/FREE/WAVE wv9 = {firstQC, checkQCFirst, lastQC, checkQCLast, result}
-
-	Make/FREE/WAVE wv = {wv0, wv1, wv2, wv3, wv4, wv5, wv6, wv7, wv8, wv9}
-
-	return wv
-End
-
-/// UTF_TD_GENERATOR w0:VariousInputForHasRequiredQCOrder
+/// UTF_TD_GENERATOR w0:DataGenerators#VariousInputForHasRequiredQCOrder
 static Function HasRequiredQCOrderWorks([STRUCT IUTF_mData &m])
 
 	variable ret
@@ -510,50 +409,7 @@ static Function HasRequiredQCOrderWorks([STRUCT IUTF_mData &m])
 	CHECK_EQUAL_VAR(MIES_PSQ#PSQ_DS_HasRequiredQCOrder(firstQC, checkQCFirst, lastQC, checkQCLast), ret)
 End
 
-static Function/WAVE VariousInputForCalculateFillinQC()
-
-	// all constant
-	Make/FREE DAScales = {1, 1, 1, 1}
-	Make/FREE ref = {0, 0, 0, 0}
-
-	Make/FREE/WAVE wv0 = {DAScales, ref}
-
-	// sorted
-	Make/FREE DAScales = {1, 2, 3, 4}
-	Make/FREE ref = {0, 0, 0, 0}
-
-	Make/FREE/WAVE wv1 = {DAScales, ref}
-
-	// reverse sorted
-	Make/FREE DAScales = {4, 3, 2, 1}
-	Make/FREE ref = {0, 1, 1, 1}
-
-	Make/FREE/WAVE wv2 = {DAScales, ref}
-
-	// first is largest
-	Make/FREE DAScales = {8, 4, 7, 6, 5}
-	Make/FREE ref = {0, 1, 1, 1, 1}
-
-	Make/FREE/WAVE wv3 = {DAScales, ref}
-
-	// complicated, smallest first
-	Make/FREE DAScales = {1, 4, 3, 6, 5}
-	Make/FREE ref = {0, 0, 1, 0, 1}
-
-	Make/FREE/WAVE wv4 = {DAScales, ref}
-
-	// complicated, middle one first
-	Make/FREE DAScales = {3, 4, 1, 6, 5}
-	Make/FREE ref = {0, 0, 1, 0, 1}
-
-	Make/FREE/WAVE wv5 = {DAScales, ref}
-
-	Make/FREE/WAVE wv = {wv0, wv1, wv2, wv3, wv4, wv5}
-
-	return wv
-End
-
-/// UTF_TD_GENERATOR w0:VariousInputForCalculateFillinQC
+/// UTF_TD_GENERATOR w0:DataGenerators#VariousInputForCalculateFillinQC
 static Function CalculateFillinQCWorks([STRUCT IUTF_mData &m])
 
 	WAVE/WAVE entries = m.w0
@@ -602,7 +458,7 @@ static Function PS_DS_AD1_preAcq(string device)
 	JWN_SetWaveInWaveNote(overrideResults, "APFrequenciesRhSuAd", apFrequenciesFromRhSuAd)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_AD1([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -750,7 +606,7 @@ static Function PS_DS_AD1a_preAcq(string device)
 	JWN_SetWaveInWaveNote(overrideResults, "APFrequenciesRhSuAd", apFrequenciesFromRhSuAd)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_AD1a([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -948,7 +804,7 @@ static Function PS_DS_AD2_preAcq(string device)
 	JWN_SetWaveInWaveNote(overrideResults, "APFrequenciesRhSuAd", apFrequenciesFromRhSuAd)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_AD2([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -1066,7 +922,7 @@ static Function PS_DS_AD2a_preAcq(string device)
 	JWN_SetWaveInWaveNote(overrideResults, "APFrequenciesRhSuAd", apFrequenciesFromRhSuAd)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_AD2a([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -1188,7 +1044,7 @@ static Function PS_DS_AD2b_preAcq(string device)
 	JWN_SetWaveInWaveNote(overrideResults, "APFrequenciesRhSuAd", apFrequenciesFromRhSuAd)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_AD2b([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -1309,7 +1165,7 @@ static Function PS_DS_AD3_preAcq(string device)
 	JWN_SetWaveInWaveNote(overrideResults, "APFrequenciesRhSuAd", apFrequenciesFromRhSuAd)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_AD3([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -1426,7 +1282,7 @@ static Function PS_DS_AD4_preAcq(string device)
 	JWN_SetWaveInWaveNote(overrideResults, "APFrequenciesRhSuAd", apFrequenciesFromRhSuAd)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_AD4([string str])
 
 	variable ref, sweepNo
@@ -1479,7 +1335,7 @@ static Function PS_DS_AD4a_preAcq(string device)
 	JWN_SetWaveInWaveNote(overrideResults, "APFrequenciesRhSuAd", apFrequenciesFromRhSuAd)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_AD4a([string str])
 
 	variable ref, sweepNo
@@ -1531,7 +1387,7 @@ static Function PS_DS_AD5_preAcq(string device)
 	JWN_SetWaveInWaveNote(overrideResults, "APFrequenciesRhSuAd", apFrequenciesFromRhSuAd)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_AD5([string str])
 
 	variable ref, sweepNo
@@ -1584,7 +1440,7 @@ static Function PS_DS_AD6_preAcq(string device)
 	JWN_SetWaveInWaveNote(overrideResults, "APFrequenciesRhSuAd", apFrequenciesFromRhSuAd)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_AD6([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -1698,7 +1554,7 @@ static Function PS_DS_AD7_preAcq(string device)
 	JWN_SetWaveInWaveNote(overrideResults, "APFrequenciesRhSuAd", apFrequenciesFromRhSuAd)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_AD7([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -1814,7 +1670,7 @@ static Function PS_DS_AD8_preAcq(string device)
 	JWN_SetWaveInWaveNote(overrideResults, "APFrequenciesRhSuAd", apFrequenciesFromRhSuAd)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_AD8([string str])
 
 	variable ref, sweepNo
@@ -1864,7 +1720,7 @@ static Function PS_DS_AD10_preAcq(string device)
 	JWN_SetWaveInWaveNote(overrideResults, "APFrequenciesRhSuAd", apFrequenciesFromRhSuAd)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_AD10([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -1979,7 +1835,7 @@ static Function PS_DS_AD12_preAcq(string device)
 	JWN_SetWaveInWaveNote(overrideResults, "APFrequenciesRhSuAd", apFrequenciesFromRhSuAd)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_AD12([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -2104,7 +1960,7 @@ static Function PS_DS_AD13_preAcq(string device)
 	JWN_SetWaveInWaveNote(overrideResults, "APFrequenciesRhSuAd", apFrequenciesFromRhSuAd)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_AD13([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -2219,7 +2075,7 @@ static Function PS_DS_AD14_preAcq(string device)
 	JWN_SetWaveInWaveNote(overrideResults, "APFrequenciesRhSuAd", apFrequenciesFromRhSuAd)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_AD14([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -2336,7 +2192,7 @@ static Function PS_DS_AD15_preAcq(string device)
 	JWN_SetWaveInWaveNote(overrideResults, "APFrequenciesRhSuAd", apFrequenciesFromRhSuAd)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_AD15([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -2452,7 +2308,7 @@ static Function PS_DS_AD16_preAcq(string device)
 	JWN_SetWaveInWaveNote(overrideResults, "APFrequenciesRhSuAd", apFrequenciesFromRhSuAd)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_AD16([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -2573,7 +2429,7 @@ static Function PS_DS_AD17_preAcq(string device)
 	JWN_SetWaveInWaveNote(overrideResults, "APFrequenciesRhSuAd", apFrequenciesFromRhSuAd)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_AD17([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -2685,7 +2541,7 @@ static Function PS_DS_AD18_preAcq(string device)
 	JWN_SetWaveInWaveNote(overrideResults, "APFrequenciesRhSuAd", apFrequenciesFromRhSuAd)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_AD18([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -2785,7 +2641,7 @@ static Function PS_DS_AD19_preAcq(string device)
 	JWN_SetWaveInWaveNote(overrideResults, "APFrequenciesRhSuAd", apFrequenciesFromRhSuAd)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_AD19([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -2897,7 +2753,7 @@ static Function PS_DS_AD20_preAcq(string device)
 	JWN_SetWaveInWaveNote(overrideResults, "APFrequenciesRhSuAd", apFrequenciesFromRhSuAd)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_AD20([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -3011,7 +2867,7 @@ static Function PS_DS_AD21_preAcq(string device)
 	JWN_SetWaveInWaveNote(overrideResults, "APFrequenciesRhSuAd", apFrequenciesFromRhSuAd)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_AD21([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -3131,7 +2987,7 @@ static Function PS_DS_AD22_preAcq(string device)
 	JWN_SetWaveInWaveNote(overrideResults, "APFrequenciesRhSuAd", apFrequenciesFromRhSuAd)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_AD22([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)

--- a/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqDAScale_Sub.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqDAScale_Sub.ipf
@@ -110,7 +110,7 @@ static Function PS_DS_Sub1_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_Sub1([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -268,7 +268,7 @@ static Function PS_DS_Sub2_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_Sub2([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -494,7 +494,7 @@ static Function PS_DS_Sub3_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_Sub3([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -684,7 +684,7 @@ static Function PS_DS_Sub4_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_Sub4([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -931,7 +931,7 @@ static Function PS_DS_Sub5_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_Sub5([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -1093,7 +1093,7 @@ static Function PS_DS_Sub5a_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_Sub5a([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -1255,7 +1255,7 @@ static Function PS_DS_Sub6_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_Sub6([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -1503,7 +1503,7 @@ static Function PS_DS_Sub7_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_Sub7([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -1701,7 +1701,7 @@ static Function PS_DS_Sub8_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_Sub8([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -1913,7 +1913,7 @@ static Function PS_DS_Sub9_preAcq(string device)
 End
 
 // Same as PS_DS_Sub1 but with custom RMS short/long and target V thresholds
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_Sub9([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -2073,7 +2073,7 @@ static Function PS_DS_Sub10_preAcq(string device)
 End
 
 // Same as PS_DS_Sub3, but with non-matching sampling interval
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_Sub10([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -2265,7 +2265,7 @@ static Function PS_DS_Sub11_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_Sub11([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)

--- a/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqDAScale_Supra.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqDAScale_Supra.ipf
@@ -101,7 +101,7 @@ static Function PS_DS_Supra1_preAcq(string device)
 End
 
 // The decision logic *without* FinalSlopePercent is the same as for Sub, only the plotting is different
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_Supra1([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str, "PSQ_DaScale_Supr_DA_0")
@@ -191,7 +191,7 @@ static Function PS_DS_Supra2_preAcq(string device)
 End
 
 // Different to PS_DS_Supra1 is that the second does not spike and a different offset operator
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_Supra2([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str, "PSQ_DaScale_Supr_DA_0")
@@ -281,7 +281,7 @@ static Function PS_DS_Supra3_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_Supra3([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str, "PSQ_DS_SupraLong_DA_0")
@@ -371,7 +371,7 @@ static Function PS_DS_Supra4_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_Supra4([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str, "PSQ_DS_SupraLong_DA_0")
@@ -465,7 +465,7 @@ static Function PS_DS_Supra5_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_Supra5([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str, "PSQ_DS_SupraLong_DA_0")
@@ -570,7 +570,7 @@ static Function PS_DS_Supra6_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_Supra6([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str, "PSQ_DS_SupraLong_DA_0")
@@ -656,7 +656,7 @@ static Function PS_DS_Supra7_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_DS_Supra7([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str, "PSQ_DaScale_Supr_DA_0")

--- a/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqPipetteInBath.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqPipetteInBath.ipf
@@ -185,7 +185,7 @@ static Function PS_PB1_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_PB1([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -252,7 +252,7 @@ static Function PS_PB2_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_PB2([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -320,7 +320,7 @@ static Function PS_PB3_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_PB3([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -408,7 +408,7 @@ static Function PS_PB4_preAcq(string device)
 End
 
 // Same as PS_PB1 but has NumberOfFailedSweeps set to 2
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_PB4([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -475,7 +475,7 @@ static Function PS_PB5_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_PB5([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -546,7 +546,7 @@ static Function PS_PB6_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_PB6([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -625,7 +625,7 @@ End
 
 // Same as PS_PB2 but with failing sampling interval check
 //
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_PB7([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)

--- a/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqRamp.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqRamp.ipf
@@ -187,7 +187,7 @@ static Function PS_RA1_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_RA1([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -268,7 +268,7 @@ static Function PS_RA2_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_RA2([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -332,7 +332,7 @@ static Function PS_RA2a_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_RA2a([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -423,7 +423,7 @@ static Function PS_RA2b_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_RA2b([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -487,7 +487,7 @@ static Function PS_RA3_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_RA3([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -567,7 +567,7 @@ static Function PS_RA4_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_RA4([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -643,7 +643,7 @@ static Function PS_RA5_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_RA5([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -720,7 +720,7 @@ static Function PS_RA6_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_RA6([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -819,7 +819,7 @@ End
 
 // Same as PS_RA2 but with failing sampling interval check
 //
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_RA7([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)

--- a/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqRheobase.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqRheobase.ipf
@@ -136,7 +136,7 @@ static Function PS_RB1_preAcq(string device)
 	SetFinalDAScale(PSQ_RB_FINALSCALE_FAKE_HIGH)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_RB1([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -230,7 +230,7 @@ static Function PS_RB2_preAcq(string device)
 	SetFinalDAScale(PSQ_RB_FINALSCALE_FAKE_HIGH)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_RB2([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -310,7 +310,7 @@ static Function PS_RB3_preAcq(string device)
 	SetFinalDAScale(PSQ_RB_FINALSCALE_FAKE_HIGH)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_RB3([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -390,7 +390,7 @@ static Function PS_RB4_preAcq(string device)
 	SetFinalDAScale(PSQ_RB_FINALSCALE_FAKE_HIGH)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_RB4([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -483,7 +483,7 @@ static Function PS_RB5_preAcq(string device)
 	SetFinalDAScale(PSQ_RB_FINALSCALE_FAKE_HIGH)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_RB5([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -563,7 +563,7 @@ static Function PS_RB6_preAcq(string device)
 	SetFinalDAScale(PSQ_RB_FINALSCALE_FAKE_HIGH)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_RB6([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -645,7 +645,7 @@ static Function PS_RB7_preAcq(string device)
 	SetFinalDAScale(PSQ_RB_FINALSCALE_FAKE_HIGH)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_RB7([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -732,7 +732,7 @@ static Function PS_RB8_preAcq(string device)
 	SetFinalDAScale(PSQ_RB_FINALSCALE_FAKE_LOW)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_RB8([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -823,7 +823,7 @@ static Function PS_RB9_preAcq(string device)
 End
 
 // check behaviour of DAScale 0 with PSQ_RB_DASCALE_STEP_LARGE stepsize
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_RB9([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -910,7 +910,7 @@ static Function PS_RB10_preAcq(string device)
 End
 
 // check behaviour of DAScale 0 with PSQ_RB_DASCALE_STEP_SMALL stepsize
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_RB10([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -998,7 +998,7 @@ End
 
 // Same as PS_RB1 but with failing sampling frequency check
 //
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_RB11([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -1093,7 +1093,7 @@ static Function PS_RB12_preAcq(string device)
 #endif // TESTS_WITH_NI_HARDWARE
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_RB12([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)

--- a/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqSealEvaluation.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqSealEvaluation.ipf
@@ -230,7 +230,7 @@ static Function PS_SE1_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_SE1([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -307,7 +307,7 @@ static Function PS_SE2_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_SE2([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -384,7 +384,7 @@ static Function PS_SE3_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_SE3([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -460,7 +460,7 @@ static Function PS_SE4_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_SE4([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -536,7 +536,7 @@ static Function PS_SE5_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_SE5([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -614,7 +614,7 @@ static Function PS_SE6_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_SE6([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -692,7 +692,7 @@ static Function PS_SE7_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_SE7([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -768,7 +768,7 @@ static Function PS_SE7a_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_SE7a([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -845,7 +845,7 @@ static Function PS_SE8_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_SE8([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -879,7 +879,7 @@ static Function PS_SE9_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_SE9([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)

--- a/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqSquarePulse.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqSquarePulse.ipf
@@ -86,7 +86,7 @@ static Function PS_SP1_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_SP1([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -152,7 +152,7 @@ static Function PS_SP2_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_SP2([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -219,7 +219,7 @@ static Function PS_SP3_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_SP3([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -287,7 +287,7 @@ static Function PS_SP4_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_SP4([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -355,7 +355,7 @@ static Function PS_SP5_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_SP5([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -424,7 +424,7 @@ static Function PS_SP6_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_SP6([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -494,7 +494,7 @@ static Function PS_SP7_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_SP7([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -566,7 +566,7 @@ End
 
 // Same as PS_SP1 but with failing sampling interval check
 //
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_SP8([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -635,7 +635,7 @@ End
 
 // Same as PS_SP1 but with failing async QC
 //
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_SP9([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -704,7 +704,7 @@ static Function PS_SP10_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_SP10([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)

--- a/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqTrueRestingMembranePotential.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_PatchSeqTrueRestingMembranePotential.ipf
@@ -195,7 +195,7 @@ static Function PS_VM1_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_VM1([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -297,7 +297,7 @@ static Function PS_VM2_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_VM2([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -407,7 +407,7 @@ static Function PS_VM3_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_VM3([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -513,7 +513,7 @@ static Function PS_VM4_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_VM4([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -623,7 +623,7 @@ static Function PS_VM5_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_VM5([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -732,7 +732,7 @@ static Function PS_VM5a_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_VM5a([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -849,7 +849,7 @@ static Function PS_VM5b_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_VM5b([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -959,7 +959,7 @@ static Function PS_VM6_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_VM6([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -1016,7 +1016,7 @@ static Function PS_VM7_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_VM7([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -1126,7 +1126,7 @@ static Function PS_VM7a_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_VM7a([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -1236,7 +1236,7 @@ static Function PS_VM7b_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_VM7b([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -1348,7 +1348,7 @@ static Function PS_VM8_preAcq(string device)
 	SetAsyncChannelProperties(device, asyncChannels, -1e6, +1e6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function PS_VM8([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)

--- a/Packages/tests/HardwareAnalysisFunctions/UTF_ReachTargetVoltage.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_ReachTargetVoltage.ipf
@@ -41,7 +41,7 @@ static Function RTV_Works_preAcq(string device)
 	AFH_AddAnalysisParameter("ReachTargetVoltage_DA_0", "EnableIndexing", var = 0)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function RTV_Works([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -73,7 +73,7 @@ static Function RTV_WorksWithIndexing_preAcq(string device)
 	AFH_AddAnalysisParameter("ReachTargetVoltage_DA_0", "IndexingEndStimsetAllIC", str = "ReachTargetVoltageIndexEnd_DA_0")
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function RTV_WorksWithIndexing([string str])
 
 	[STRUCT DAQSettings s] = PS_GetDAQSettings(str)
@@ -117,7 +117,7 @@ static Function RTV_WorksWithMultipleHeadstages_preAcq(string device)
 	PGC_SetAndActivateControl(device, "setvar_DataAcq_AutoBiasV", val = -70)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function RTV_WorksWithMultipleHeadstages([string str])
 
 	STRUCT DAQSettings s
@@ -160,7 +160,7 @@ static Function RTV_ReportsDAScaleOutOfRange_preAcq(string device)
 	AFH_AddAnalysisParameter("ReachTargetVoltage_DA_0", "EnableIndexing", var = 0)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function RTV_ReportsDAScaleOutOfRange([string str])
 
 	WAVE overrideResults = MIES_AF#CreateOverrideResults()

--- a/Packages/tests/HardwareAnalysisFunctions/UTF_SetControls.ipf
+++ b/Packages/tests/HardwareAnalysisFunctions/UTF_SetControls.ipf
@@ -37,7 +37,7 @@ static Function SC_SetControls1_preAcq(string device)
 End
 
 // ignores invalid control
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SC_SetControls1([string str])
 
 	[STRUCT DAQSettings s] = SC_GetDAQSettings(str)
@@ -66,7 +66,7 @@ static Function SC_SetControls2_preAcq(string device)
 End
 
 // complains on wrong parameter type (string)
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SC_SetControls2([string str])
 
 	[STRUCT DAQSettings s] = SC_GetDAQSettings(str, far = 0)
@@ -95,7 +95,7 @@ static Function SC_SetControls2a_preAcq(string device)
 End
 
 // complains on wrong parameter type (numeric)
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SC_SetControls2a([string str])
 
 	[STRUCT DAQSettings s] = SC_GetDAQSettings(str, far = 0)
@@ -125,7 +125,7 @@ static Function SC_SetControls2b_preAcq(string device)
 End
 
 // complains on wrong parameter type (numeric wave)
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SC_SetControls2b([string str])
 
 	[STRUCT DAQSettings s] = SC_GetDAQSettings(str, far = 0)
@@ -155,7 +155,7 @@ static Function SC_SetControls3_preAcq(string device)
 End
 
 // invalid parameter wave size
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SC_SetControls3([string str])
 
 	[STRUCT DAQSettings s] = SC_GetDAQSettings(str, far = 0)
@@ -185,7 +185,7 @@ static Function SC_SetControls3a_preAcq(string device)
 End
 
 // invalid event type (unknown)
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SC_SetControls3a([string str])
 
 	[STRUCT DAQSettings s] = SC_GetDAQSettings(str, far = 0)
@@ -215,7 +215,7 @@ static Function SC_SetControls3b_preAcq(string device)
 End
 
 // invalid event type (mid sweep)
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SC_SetControls3b([string str])
 
 	[STRUCT DAQSettings s] = SC_GetDAQSettings(str, far = 0)
@@ -245,7 +245,7 @@ static Function SC_SetControls3c_PreAcq(string device)
 End
 
 // invalid event type (generic)
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SC_SetControls3c([string str])
 
 	[STRUCT DAQSettings s] = SC_GetDAQSettings(str, far = 0)
@@ -275,7 +275,7 @@ static Function SC_SetControls4_preAcq(string device)
 End
 
 // unchangeable control in other event than pre DAQ
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SC_SetControls4([string str])
 
 	[STRUCT DAQSettings s] = SC_GetDAQSettings(str, far = 0)
@@ -305,7 +305,7 @@ static Function SC_SetControls5_preAcq(string device)
 End
 
 // hidden control is ignored
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SC_SetControls5([string str])
 
 	[STRUCT DAQSettings s] = SC_GetDAQSettings(str)
@@ -352,7 +352,7 @@ static Function SC_SetControls6_preAcq(string device)
 End
 
 // works with different controls
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SC_SetControls6([string str])
 
 	[STRUCT DAQSettings s] = SC_GetDAQSettings(str)
@@ -394,7 +394,7 @@ static Function SC_SetControls7_preAcq(string device)
 End
 
 // works with event/data tuples and also accepts incorrect casing for the event names
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SC_SetControls7([string str])
 
 	[STRUCT DAQSettings s] = SC_GetDAQSettings(str)
@@ -433,7 +433,7 @@ static Function SC_SetControls8_preAcq(string device)
 End
 
 // works with event/data tuples setting notebook text
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SC_SetControls8([string str])
 
 	[STRUCT DAQSettings s] = SC_GetDAQSettings(str)
@@ -479,7 +479,7 @@ static Function SC_SetControls9_preAcq(string device)
 End
 
 // supports "Pre Sweep" (old) and "Pre Sweep Config" (new)
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SC_SetControls9([string str])
 
 	[STRUCT DAQSettings s] = SC_GetDAQSettings(str)

--- a/Packages/tests/HardwareBasic/UTF_AnalysisFunctionManagement.ipf
+++ b/Packages/tests/HardwareBasic/UTF_AnalysisFunctionManagement.ipf
@@ -127,7 +127,7 @@ Function RewriteAnalysisFunctions_IGNORE()
 End
 
 // invalid analysis functions
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT1([string str])
 
 	STRUCT DAQSettings s
@@ -187,7 +187,7 @@ static Function AFT1_REENTRY([string str])
 End
 
 // can not call prototype analysis functions as they reside in the wrong file
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT2([string str])
 
 	variable sweepNo
@@ -249,7 +249,7 @@ static Function AFT2_REENTRY([string str])
 End
 
 // uses a valid V1 function and got calls for all events except post set
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT3([string str])
 
 	STRUCT DAQSettings s
@@ -320,7 +320,7 @@ static Function AFT3_REENTRY([string str])
 End
 
 // uses a valid V1 function and got calls for all events including post set
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT4([string str])
 
 	STRUCT DAQSettings s
@@ -391,7 +391,7 @@ static Function AFT4_REENTRY([string str])
 End
 
 // uses a valid V2 function and got calls for all events except post set
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT5([string str])
 
 	STRUCT DAQSettings s
@@ -453,7 +453,7 @@ static Function AFT5_REENTRY([string str])
 End
 
 // uses a valid V2 function and got calls for all events including post set
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT6([string str])
 
 	STRUCT DAQSettings s
@@ -524,7 +524,7 @@ static Function AFT6_REENTRY([string str])
 End
 
 // uses a valid V3 function and got calls for all events including post set
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT6a([string str])
 
 	STRUCT DAQSettings s
@@ -591,7 +591,7 @@ End
 // uses a valid V3 generic function and then ignores other set analysis functions
 // The wavebuilder does not store other analysis functions if the generic name is set.
 // That is the reason why they are in the labnotebook but not called.
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT6b([string str])
 
 	STRUCT DAQSettings s
@@ -663,7 +663,7 @@ static Function AFT6b_REENTRY([string str])
 End
 
 // ana func called for each headstage
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT7([string str])
 
 	STRUCT DAQSettings s
@@ -745,7 +745,7 @@ static Function AFT7_REENTRY([string str])
 End
 
 // not called if attached to TTL stimsets
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT8([string str])
 
 	STRUCT DAQSettings s
@@ -800,7 +800,7 @@ static Function AFT8_REENTRY([string str])
 End
 
 // does not call some ana funcs if aborted
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT9([string str])
 
 	STRUCT DAQSettings s
@@ -839,7 +839,7 @@ static Function AFT9_REENTRY([string str])
 End
 
 // DAQ works if the analysis function can not be found
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT10([string str])
 
 	STRUCT DAQSettings s
@@ -893,7 +893,7 @@ static Function AFT10_REENTRY([string str])
 End
 
 // calls correct analysis functions
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT11([string str])
 
 	STRUCT DAQSettings s
@@ -966,7 +966,7 @@ End
 
 // abort early results in other analysis functions not being called
 // preDAQ
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT12([string str])
 
 	STRUCT DAQSettings s
@@ -1040,7 +1040,7 @@ End
 
 // abort early results in other analysis functions not being called
 // midSweep
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT13([string str])
 
 	STRUCT DAQSettings s
@@ -1056,7 +1056,7 @@ static Function AFT13_REENTRY([string str])
 End
 
 // Delay acquisition background task call until sweep already finished and ITC fifopos returned == NaN
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT13a([string str])
 
 	STRUCT DAQSettings s
@@ -1142,7 +1142,7 @@ End
 // test parameter handling
 // tests also that no type parameters
 // in Params1_V3_GetParams() are okay
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT14([string str])
 
 	STRUCT DAQSettings s
@@ -1220,7 +1220,7 @@ static Function AFT14a_PreInit(string device)
 End
 
 // test parameter handling with valid type string and optional parameter
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT14a([string str])
 
 	STRUCT DAQSettings s
@@ -1258,7 +1258,7 @@ static Function AFT14b_PreInit(string device)
 End
 
 // test parameter handling with non-matching type string
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT14b([string str])
 
 	STRUCT DAQSettings s
@@ -1302,7 +1302,7 @@ static Function AFT14c_PreInit(string device)
 End
 
 // test parameter handling with invalid type string
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT14c([string str])
 
 	STRUCT DAQSettings s
@@ -1348,7 +1348,7 @@ End
 
 // test parameter handling with analysis parameter check and help function and
 // non-passing check
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT14d([string str])
 
 	STRUCT DAQSettings s
@@ -1396,7 +1396,7 @@ End
 // - Check asserts out on MyNum == NaN
 // - Help also asserts out but that is silently ignored
 // - Asserting out is equal to not passing the check function
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT14e([string str])
 
 	STRUCT DAQSettings s
@@ -1442,7 +1442,7 @@ End
 
 // test parameter handling with analysis parameter check and help function
 // - Checks pass
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT14f([string str])
 
 	STRUCT DAQSettings s
@@ -1483,7 +1483,7 @@ End
 // test parameter handling with analysis parameter check and help function
 // - Checks pass, MyNum is not present and optional and is therefore not checked
 //   (the check would assert out)
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT14g([string str])
 
 	STRUCT DAQSettings s
@@ -1522,7 +1522,7 @@ static Function AFT14h_PreInit(string device)
 End
 
 // test parameter handling with new analysis parameter check signature
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT14h([string str])
 
 	STRUCT DAQSettings s
@@ -1561,7 +1561,7 @@ static Function AFT14i_PreInit(string device)
 End
 
 // parameter MyVar is neither required nor optional as no _GetParams is present but still checked
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT14i([string str])
 
 	STRUCT DAQSettings s
@@ -1589,7 +1589,7 @@ static Function AFT14j_PreInit(string device)
 End
 
 // parameter MyVar is present but neither required nor optional and we have a _GetParams function
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT14j([string str])
 
 	STRUCT DAQSettings s
@@ -1605,7 +1605,7 @@ static Function AFT14j([string str])
 End
 
 // MD: mid sweep event is also called for very short stimsets
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT15([string str])
 
 	STRUCT DAQSettings s
@@ -1638,7 +1638,7 @@ static Function AFT15_REENTRY([string str])
 End
 
 // SD: mid sweep event is also called for very short stimsets
-// UTF_TD_GENERATOR DeviceNameGeneratorMD0
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD0
 static Function AFT16([string str])
 
 	STRUCT DAQSettings s
@@ -1671,7 +1671,7 @@ static Function AFT16_REENTRY([string str])
 End
 
 // Calling Abort during pre DAQ event will prevent DAQ
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT17([string str])
 
 	STRUCT DAQSettings s
@@ -1714,7 +1714,7 @@ End
 // Analysis functions work properly with indexing
 // We index from AnaFuncIdx1_DA_0 to AnaFuncIdx2_DA_0
 // but only the second one has a analysis function set
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT18([string str])
 
 	STRUCT DAQSettings s
@@ -1757,7 +1757,7 @@ static Function AFT18_REENTRY([string str])
 End
 
 // check that pre-set-event can abort
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT19([string str])
 
 	STRUCT DAQSettings s
@@ -1790,7 +1790,7 @@ static Function AFT19_REENTRY([string str])
 End
 
 // check that pre sweep config can abort
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT19a([string str])
 
 	STRUCT DAQSettings s
@@ -1823,7 +1823,7 @@ static Function AFT19a_REENTRY([string str])
 End
 
 // check total ordering of events via timestamps
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT20([string str])
 
 	STRUCT DAQSettings s
@@ -1854,7 +1854,7 @@ static Function AFT20_REENTRY([string str])
 End
 
 // it possible to change the stimset in POST DAQ event
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT21([string str])
 
 	STRUCT DAQSettings s
@@ -1886,7 +1886,7 @@ static Function AFT21_REENTRY([string str])
 End
 
 // POST_SET_EVENT works with only HS1 active
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AFT22([string str])
 
 	STRUCT DAQSettings s
@@ -1958,7 +1958,7 @@ static Function AFT22_REENTRY([string str])
 	CHECK_WAVE(anaFuncs, NULL_WAVE)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function CanModifyStimsetInPreSweepConfig([string str])
 
 	STRUCT DAQSettings s
@@ -2017,7 +2017,7 @@ static Function [WAVE entryHS1, WAVE entryHS2] GetLastSweepLBNEntries(WAVE numer
 	return [entriesHS1, entriesHS2]
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function CheckLastSweepInSetWithoutSkipping([string str])
 
 	STRUCT DAQSettings s

--- a/Packages/tests/HardwareBasic/UTF_AutoTestpulse.ipf
+++ b/Packages/tests/HardwareBasic/UTF_AutoTestpulse.ipf
@@ -84,7 +84,7 @@ static Function AutoTP_OptimumValues_preAcq(string device)
 	CtrlNamedBackGround StopTP, start, period=1, proc=StopTPWhenFinished
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AutoTP_OptimumValues([string str])
 
 	[STRUCT DAQSettings s] = AutoTP_GetDAQSettings(str)
@@ -138,7 +138,7 @@ static Function AutoTP_BadValues_preAcq(string device)
 	CtrlNamedBackGround StopTP, start, period=30, proc=StopTPWhenFinished
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AutoTP_BadValues([string str])
 
 	[STRUCT DAQSettings s] = AutoTP_GetDAQSettings(str)
@@ -194,7 +194,7 @@ static Function AutoTP_MixedOptimumBadValues_preAcq(string device)
 	CtrlNamedBackGround StopTP, start, period=1, proc=StopTPWhenFinished
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AutoTP_MixedOptimumBadValues([string str])
 
 	[STRUCT DAQSettings s] = AutoTP_GetDAQSettings(str)
@@ -251,7 +251,7 @@ static Function AutoTP_SpecialCases_preAcq(string device)
 	CtrlNamedBackGround StopTP, start, period=1, proc=StopTPWhenFinished
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AutoTP_SpecialCases([string str])
 
 	[STRUCT DAQSettings s] = AutoTP_GetDAQSettings(str)

--- a/Packages/tests/HardwareBasic/UTF_BasicHardwareTests.ipf
+++ b/Packages/tests/HardwareBasic/UTF_BasicHardwareTests.ipf
@@ -45,8 +45,8 @@ static Function GlobalPreAcq(string device)
 	PASS()
 End
 
-// UTF_TD_GENERATOR v0:IndexingPossibilities
-// UTF_TD_GENERATOR s0:DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR v0:DataGenerators#IndexingPossibilities
+// UTF_TD_GENERATOR s0:DataGenerators#DeviceNameGeneratorMD1
 static Function CheckActiveSetCount([STRUCT IUTF_MDATA &md])
 
 	STRUCT DAQSettings s
@@ -85,8 +85,8 @@ static Function CheckThatTestpulseRan_IGNORE(string device)
 	CHECK_WAVE(settings, NUMERIC_WAVE)
 End
 
-// UTF_TD_GENERATOR v0:SingleMultiDeviceDAQ
-// UTF_TD_GENERATOR s0:DeviceNameGenerator
+// UTF_TD_GENERATOR v0:DataGenerators#SingleMultiDeviceDAQ
+// UTF_TD_GENERATOR s0:DataGenerators#DeviceNameGenerator
 static Function Abort_ITI_TP([STRUCT IUTF_MDATA &md])
 
 	STRUCT DAQSettings s
@@ -112,8 +112,8 @@ static Function Abort_ITI_TP_REENTRY([STRUCT IUTF_MDATA &md])
 	CheckDAQStopReason(md.s0, DQ_STOP_REASON_TP_STARTED)
 End
 
-// UTF_TD_GENERATOR v0:SingleMultiDeviceDAQ
-// UTF_TD_GENERATOR s0:DeviceNameGenerator
+// UTF_TD_GENERATOR v0:DataGenerators#SingleMultiDeviceDAQ
+// UTF_TD_GENERATOR s0:DataGenerators#DeviceNameGenerator
 static Function Abort_ITI_TP_A_TP([STRUCT IUTF_MDATA &md])
 
 	STRUCT DAQSettings s
@@ -141,8 +141,8 @@ static Function Abort_ITI_TP_A_TP_REENTRY([STRUCT IUTF_MDATA &md])
 	CheckDAQStopReason(md.s0, DQ_STOP_REASON_TP_STARTED)
 End
 
-// UTF_TD_GENERATOR v0:SingleMultiDeviceDAQ
-// UTF_TD_GENERATOR s0:DeviceNameGenerator
+// UTF_TD_GENERATOR v0:DataGenerators#SingleMultiDeviceDAQ
+// UTF_TD_GENERATOR s0:DataGenerators#DeviceNameGenerator
 static Function AbortTP([STRUCT IUTF_MDATA &md])
 
 	STRUCT DAQSettings s
@@ -178,8 +178,8 @@ static Function AbortTP_REENTRY([STRUCT IUTF_MDATA &md])
 	PASS()
 End
 
-// UTF_TD_GENERATOR v0:SingleMultiDeviceDAQ
-// UTF_TD_GENERATOR s0:DeviceNameGenerator
+// UTF_TD_GENERATOR v0:DataGenerators#SingleMultiDeviceDAQ
+// UTF_TD_GENERATOR s0:DataGenerators#DeviceNameGenerator
 static Function StartDAQDuringTP([STRUCT IUTF_MDATA &md])
 
 	STRUCT DAQSettings s
@@ -215,8 +215,8 @@ static Function StartDAQDuringTP_REENTRY([STRUCT IUTF_MDATA &md])
 	// ascending sweep numbers are checked in TEST_CASE_BEGIN_OVERRIDE()
 End
 
-// UTF_TD_GENERATOR v0:SingleMultiDeviceDAQ
-// UTF_TD_GENERATOR s0:DeviceNameGenerator
+// UTF_TD_GENERATOR v0:DataGenerators#SingleMultiDeviceDAQ
+// UTF_TD_GENERATOR s0:DataGenerators#DeviceNameGenerator
 static Function Abort_ITI_PressAcq([STRUCT IUTF_MDATA &md])
 
 	STRUCT DAQSettings s
@@ -243,8 +243,8 @@ static Function Abort_ITI_PressAcq_REENTRY([STRUCT IUTF_MDATA &md])
 	CheckDAQStopReason(device, DQ_STOP_REASON_DAQ_BUTTON)
 End
 
-// UTF_TD_GENERATOR v0:SingleMultiDeviceDAQ
-// UTF_TD_GENERATOR s0:DeviceNameGenerator
+// UTF_TD_GENERATOR v0:DataGenerators#SingleMultiDeviceDAQ
+// UTF_TD_GENERATOR s0:DataGenerators#DeviceNameGenerator
 static Function Abort_ITI_TP_A_PressAcq([STRUCT IUTF_MDATA &md])
 
 	STRUCT DAQSettings s
@@ -279,8 +279,8 @@ static Function ChangeToOtherDeviceDAQ_PreAcq(string device)
 	wv[%$"Analysis pre DAQ function"][%Set] = "ChangeToOtherDeviceDAQAF"
 End
 
-// UTF_TD_GENERATOR v0:SingleMultiDeviceDAQ
-// UTF_TD_GENERATOR s0:DeviceNameGeneratorMD0
+// UTF_TD_GENERATOR v0:DataGenerators#SingleMultiDeviceDAQ
+// UTF_TD_GENERATOR s0:DataGenerators#DeviceNameGeneratorMD0
 static Function ChangeToOtherDeviceDAQ([STRUCT IUTF_MDATA &md])
 
 	STRUCT DAQSettings s
@@ -314,7 +314,7 @@ static Function ChangeStimSetDuringDAQ_PreAcq(string device)
 	CtrlNamedBackGround ChangeStimsetDuringDAQ, start, period=30, proc=ChangeStimSet_IGNORE
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function ChangeStimSetDuringDAQ([string str])
 
 	STRUCT DAQSettings s
@@ -346,8 +346,8 @@ static Function ChangeStimSetDuringDAQ_REENTRY([string str])
 	CheckDAQStopReason(str, DQ_STOP_REASON_FINISHED, sweepNo = 2)
 End
 
-// UTF_TD_GENERATOR v0:SingleMultiDeviceDAQ
-// UTF_TD_GENERATOR s0:DeviceNameGenerator
+// UTF_TD_GENERATOR v0:DataGenerators#SingleMultiDeviceDAQ
+// UTF_TD_GENERATOR s0:DataGenerators#DeviceNameGenerator
 static Function DAQZerosDAC([STRUCT IUTF_MDATA &md])
 
 	STRUCT DAQSettings s
@@ -395,7 +395,7 @@ static Function DAQZerosDAC_REENTRY([STRUCT IUTF_MDATA &md])
 End
 
 // Using unassociated channels works
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function UnassociatedChannelsAndTTLs([string str])
 
 	STRUCT DAQSettings s
@@ -770,7 +770,7 @@ static Function UnassociatedChannelsAndTTLs_REENTRY([string str])
 	endif
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function CheckSamplingInterval1([string str])
 
 	STRUCT DAQSettings s
@@ -815,7 +815,7 @@ static Function CheckSamplingInterval1_REENTRY([string str])
 	CHECK_CLOSE_VAR(DimDelta(channelAD, ROWS), expectedSampInt, tol = 1e-6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function CheckSamplingInterval2([string str])
 
 	STRUCT DAQSettings s
@@ -860,7 +860,7 @@ static Function CheckSamplingInterval2_REENTRY([string str])
 	CHECK_CLOSE_VAR(DimDelta(channelAD, ROWS), expectedSampInt, tol = 1e-6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function CheckSamplingInterval3([string str])
 
 	STRUCT DAQSettings s
@@ -906,7 +906,7 @@ static Function CheckSamplingInterval3_REENTRY([string str])
 	CHECK_CLOSE_VAR(DimDelta(channelAD, ROWS), expectedSampInt, tol = 1e-6)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function ChangeCMDuringSweep([string str])
 
 	STRUCT DAQSettings s
@@ -969,7 +969,7 @@ static Function ChangeCMDuringSweepWMS_PreAcq(string device)
 	CtrlNamedBackGround ChangeClampModeDuringSweep, start, period=30, proc=ClampModeDuringSweep_IGNORE
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function ChangeCMDuringSweepWMS([string str])
 
 	STRUCT DAQSettings s
@@ -1020,7 +1020,7 @@ static Function ChangeCMDuringSweepWMS_REENTRY([string str])
 	CHECK_EQUAL_TEXTWAVES(foundStimSets, {"StimulusSetC_DA_0", "StimulusSetC_DA_0", "StimulusSetC_DA_0"})
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function ChangeCMDuringSweepNoRA([string str])
 
 	STRUCT DAQSettings s
@@ -1060,7 +1060,7 @@ static Function ChangeCMDuringITI_PreAcq(string device)
 	CtrlNamedBackGround ChangeClampModeDuringSweep, start, period=30, proc=ClampModeDuringITI_IGNORE
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function ChangeCMDuringITI([string str])
 
 	STRUCT DAQSettings s
@@ -1099,7 +1099,7 @@ static Function ChangeCMDuringITI_REENTRY([string str])
 	CHECK_EQUAL_WAVES(clampMode, {V_CLAMP_MODE, I_CLAMP_MODE, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, mode = WAVE_DATA)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function ChangeCMDuringITIWithTP([string str])
 
 	STRUCT DAQSettings s
@@ -1163,7 +1163,7 @@ static Function AutoPipetteOffsetIgnoresApplyOnModeSwitch_PreAcq(string device)
 	PGC_SetAndActivateControl(device, "check_DA_applyOnModeSwitch", val = 1)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AutoPipetteOffsetIgnoresApplyOnModeSwitch([string str])
 
 	STRUCT DAQSettings s
@@ -1206,7 +1206,7 @@ static Function HasNaNAsDefaultWhenAborted_PreAcq(string device)
 End
 
 // check default values for data when aborting DAQ
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function HasNaNAsDefaultWhenAborted([string str])
 
 	STRUCT DAQSettings s
@@ -1286,7 +1286,7 @@ End
 //
 // Now we should not find any unassoc labnotebook keys which only differ in the channel number.
 //
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function UnassocChannelsDuplicatedEntry([string str])
 
 	STRUCT DAQSettings s
@@ -1353,7 +1353,7 @@ static Function LabnotebookEntriesCanBeQueried_PreAcq(string device)
 	PGC_SetAndActivateControl(device, DAP_GetClampModeControl(I_CLAMP_MODE, 1), val = 1)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function LabnotebookEntriesCanBeQueried([string str])
 
 	STRUCT DAQSettings s
@@ -1384,7 +1384,7 @@ static Function LabnotebookEntriesCanBeQueried_REENTRY([string str])
 	CheckLabnotebookKeys_IGNORE(textualKeys, textualValues)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function DataBrowserCreatesBackupsByDefault([string str])
 
 	STRUCT DAQSettings s
@@ -1429,7 +1429,7 @@ End
 /// the LBN cache waves. After the second sweep these LBN entries can now be queried thus "proving"
 /// that the LBN caches were successfully updated.
 ///
-/// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+/// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function IncrementalLabnotebookCacheUpdate([string str])
 
 	STRUCT DAQSettings s
@@ -1453,7 +1453,7 @@ static Function IncrementalLabnotebookCacheUpdate_REENTRY([string str])
 	CHECK_EQUAL_VAR(anaFuncTracker[POST_SWEEP_EVENT], 2)
 End
 
-/// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+/// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function TestAcquiringNewDataOnOldData([string str])
 
 	STRUCT DAQSettings s
@@ -1522,7 +1522,7 @@ static Function AsyncAcquisitionLBN_PreAcq(string device)
 	PGC_SetAndActivateControl(device, ctrl, str = "myUnit")
 End
 
-/// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+/// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AsyncAcquisitionLBN([string str])
 
 	STRUCT DAQSettings s
@@ -1582,7 +1582,7 @@ static Function AsyncAcquisitionLBN_REENTRY([string str])
 	CHECK_EQUAL_STR(refStr, readStr)
 End
 
-/// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+/// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function CheckSettingsFails([string str])
 
 	STRUCT DAQSettings s
@@ -1606,8 +1606,8 @@ static Function CheckSettingsFails_REENTRY([string str])
 	CHECK_EQUAL_VAR(sweepNo, NaN)
 End
 
-// // UTF_TD_GENERATOR v0:SingleMultiDeviceDAQ
-// // UTF_TD_GENERATOR s0:DeviceNameGeneratorMD1
+// // UTF_TD_GENERATOR v0:DataGenerators#SingleMultiDeviceDAQ
+// // UTF_TD_GENERATOR s0:DataGenerators#DeviceNameGeneratorMD1
 static Function CheckAcquisitionStates([STRUCT IUTF_MDATA &md])
 
 	STRUCT DAQSettings s
@@ -1749,7 +1749,7 @@ static Function ConfigureFails_PreAcq(string device)
 	PGC_SetAndActivateControl(device, ctrl, val = 10000)
 End
 
-/// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+/// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function ConfigureFails([string str])
 
 	STRUCT DAQSettings s
@@ -1772,7 +1772,7 @@ static Function ConfigureFails_REENTRY([string str])
 	CheckDAQStopReason(str, DQ_STOP_REASON_CONFIG_FAILED)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function StopDAQDueToUnlocking([string str])
 
 	STRUCT DAQSettings s
@@ -1798,7 +1798,7 @@ static Function StopDAQDueToUnlocking_REENTRY([string str])
 	CheckDAQStopReason(str, DQ_STOP_REASON_UNLOCKED_DEVICE)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function StopDAQDueToUncompiled([string str])
 
 	STRUCT DAQSettings s
@@ -1827,7 +1827,7 @@ End
 // Roundtrip stimsets, this also leaves the NWBv2 file lying around
 // for later validation.
 //
-// UTF_TD_GENERATOR MajorNWBVersions
+// UTF_TD_GENERATOR DataGenerators#MajorNWBVersions
 static Function ExportStimsetsAndRoundtripThem([variable var])
 
 	string baseFolder, nwbFile, discLocation
@@ -1879,7 +1879,7 @@ static Function ExportIntoNWBSweepBySweep_PreAcq(string device)
 	PGC_SetAndActivateControl(device, "Check_Settings_NwbExport", val = CHECKBOX_SELECTED)
 End
 
-/// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+/// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function ExportIntoNWBSweepBySweep([string str])
 
 	variable ref
@@ -1925,7 +1925,7 @@ static Function ExportOnlyCommentsIntoNWB_PreAcq(string device)
 	PGC_SetAndActivateControl(device, "SetVar_DataAcq_Comment", str = "abcdefgh ijjkl")
 End
 
-/// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+/// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function ExportOnlyCommentsIntoNWB([string str])
 
 	string discLocation, userComment, userCommentRef
@@ -1949,7 +1949,7 @@ static Function ExportOnlyCommentsIntoNWB([string str])
 	H5_CloseFile(fileID)
 End
 
-/// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+/// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function CheckPulseInfoGathering([string str])
 
 	STRUCT DAQSettings s
@@ -2000,8 +2000,8 @@ static Function CheckPulseInfoGathering_REENTRY([string str])
 	CHECK_EQUAL_VAR(DimSize(pulseInfos, ROWS), 60)
 End
 
-// // UTF_TD_GENERATOR v0:SingleMultiDeviceDAQ
-// // UTF_TD_GENERATOR s0:DeviceNameGenerator
+// // UTF_TD_GENERATOR v0:DataGenerators#SingleMultiDeviceDAQ
+// // UTF_TD_GENERATOR s0:DataGenerators#DeviceNameGenerator
 static Function RepeatedAcquisitionWithOneSweep([STRUCT IUTF_MDATA &md])
 
 	STRUCT DAQSettings s
@@ -2018,7 +2018,7 @@ static Function RepeatedAcquisitionWithOneSweep_REENTRY([STRUCT IUTF_MDATA &md])
 	CHECK_EQUAL_VAR(GetSetVariable(md.s0, "SetVar_Sweep"), 1)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function EnableIndexingInPostDAQ([string str])
 
 	STRUCT DAQSettings s
@@ -2046,7 +2046,7 @@ static Function ScaleZeroWithCycling_PreAcq(string device)
 	PGC_SetAndActivateControl(device, "check_Settings_ScalingZero", val = CHECKBOX_SELECTED)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function ScaleZeroWithCycling([string str])
 
 	STRUCT DAQSettings s
@@ -2096,7 +2096,7 @@ static Function AcquireWithoutAmplifier_PreAcq(string device)
 	PGC_SetAndActivateControl(device, GetPanelControl(1, CHANNEL_TYPE_HEADSTAGE, CHANNEL_CONTROL_CHECK), val = 1)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function AcquireWithoutAmplifier([string str])
 
 	STRUCT DAQSettings s
@@ -2132,7 +2132,7 @@ static Function AcquireWithoutAmplifier_REENTRY([string str])
 	CHECK_EQUAL_WAVES(saveAmpSettings, {NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, CHECKBOX_SELECTED}, mode = WAVE_DATA)
 End
 
-// UTF_TD_GENERATOR GetITCDevices
+// UTF_TD_GENERATOR DataGenerators#GetITCDevices
 Function HandlesFIFOTimeoutProperly([string str])
 
 	STRUCT DAQSettings s
@@ -2158,7 +2158,7 @@ Function HandlesFIFOTimeoutProperly_REENTRY([string str])
 	CHECK_EQUAL_VAR(stopReason, DQ_STOP_REASON_FINISHED)
 End
 
-// UTF_TD_GENERATOR GetITCDevices
+// UTF_TD_GENERATOR DataGenerators#GetITCDevices
 Function HandlesStuckFIFOProperly([string str])
 
 	STRUCT DAQSettings s
@@ -2184,8 +2184,8 @@ Function HandlesStuckFIFOProperly_REENTRY([string str])
 	CHECK_EQUAL_VAR(stopReason, DQ_STOP_REASON_FINISHED)
 End
 
-// UTF_TD_GENERATOR v0:InsertedTPPossibilities
-// UTF_TD_GENERATOR s0:DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR v0:DataGenerators#InsertedTPPossibilities
+// UTF_TD_GENERATOR s0:DataGenerators#DeviceNameGeneratorMD1
 static Function CheckDelays([STRUCT IUTF_MDATA &md])
 
 	STRUCT DAQSettings s
@@ -2225,7 +2225,7 @@ static Function CheckDelays_REENTRY([STRUCT IUTF_MDATA &md])
 	CHECK_EQUAL_VAR(val, 10)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function CheckSweepOrdering([string str])
 
 	STRUCT DAQSettings s
@@ -2261,7 +2261,7 @@ static Function CheckSweepOrdering_REENTRY([string str])
 	endtry
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function DoNotAllowTestPulseOnUnassocDA([string str])
 
 	STRUCT DAQSettings s
@@ -2283,7 +2283,7 @@ static Function RandomAcq_preAcq(string device)
 	PGC_SetAndActivateControl(device, "check_DataAcq_RepAcqRandom", val = 1)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function RandomAcq([string str])
 
 	STRUCT DAQSettings s
@@ -2319,7 +2319,7 @@ static Function CheckIfNoTTLonTP_preAcq(string device)
 	PGC_SetAndActivateControl(device, GetPanelControl(0, CHANNEL_TYPE_TTL, CHANNEL_CONTROL_CHECK), val = 1)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function CheckIfNoTTLonTP([string str])
 
 	STRUCT DAQSettings s
@@ -2335,7 +2335,7 @@ static Function CheckIfNoTTLonTP_REENTRY([string str])
 End
 
 #ifdef TESTS_WITH_NI_HARDWARE
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function TestNIAcquisitionReliability([string str])
 
 	STRUCT DAQSettings s
@@ -2351,7 +2351,7 @@ static Function TestNIAcquisitionReliability_REENTRY([string str])
 End
 #endif // TESTS_WITH_NI_HARDWARE
 
-// IUTF_TD_GENERATOR s0:DeviceNameGeneratorMD1
+// IUTF_TD_GENERATOR s0:DataGenerators#DeviceNameGeneratorMD1
 // IUTF_TD_GENERATOR s1:DataGenerators#RoundTripStimsetFileType
 static Function RoundTripDepStimsetsRecursionThroughSweeps([STRUCT IUTF_mData &mData])
 
@@ -2433,7 +2433,7 @@ static Function TestCustomElectrodeNamesInNWB_preAcq(string device)
 	FFI_SetCellElectrodeName(device, 1, "Electric Dreams of Current")
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function TestCustomElectrodeNamesInNWB([string str])
 
 	STRUCT DAQSettings s
@@ -2450,7 +2450,7 @@ static Function TestCustomElectrodeNamesInNWB_REENTRY([string str])
 	TestNwbExportV2()
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function GetDataLimitsCheckWorks([string str])
 
 	variable DAScaleLimit

--- a/Packages/tests/HardwareBasic/UTF_ConfigurationHardware.ipf
+++ b/Packages/tests/HardwareBasic/UTF_ConfigurationHardware.ipf
@@ -5,7 +5,7 @@
 
 static StrConstant REF_DAEPHYS_CONFIG_FILE = "DA_Ephys.json"
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function RestoreDAEphysPanel([string str])
 
 	string fName, rewrittenConfigPath
@@ -22,7 +22,7 @@ static Function RestoreDAEphysPanel([string str])
 	MIES_CONF#CONF_SaveDAEphys(fname)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function RestoreAndSaveConfiguration([string str])
 
 	string settingsIPath, settingsFolder, templateFolder, workingFolder
@@ -97,7 +97,7 @@ static Function RestoreAndSaveConfiguration([string str])
 	DeleteFile fName
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function CheckIfConfigurationRestoresMCCFilterGain([string str])
 
 	string rewrittenConfig, fName, path
@@ -160,8 +160,8 @@ End
 
 /// @brief Checks if every typed panel restores with auto opening
 ///
-/// IUTF_TD_GENERATOR s0:GetMiesMacrosWithPanelType
-/// IUTF_TD_GENERATOR s1:DeviceNameGenerator
+/// IUTF_TD_GENERATOR s0:DataGenerators#GetMiesMacrosWithPanelType
+/// IUTF_TD_GENERATOR s1:DataGenerators#DeviceNameGenerator
 static Function TCONF_CheckTypedPanelRestore([STRUCT IUTF_mData &md])
 
 	string win, winRestored, rewrittenConfig, device
@@ -199,7 +199,7 @@ static Function TCONF_CheckTypedPanelRestore([STRUCT IUTF_mData &md])
 	CHECK_EQUAL_STR(win, winRestored)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function CheckIfConfigurationRestoresDAEphysWithUnassocDA([string str])
 
 	string rewrittenConfig, fName
@@ -293,7 +293,7 @@ static Function CheckIfConfigurationRestoresDAEphysWithoutAmp_PreAcq(string devi
 	PGC_SetAndActivateControl(device, "SetVar_DataAcq_TPAmplitude", val = 9.5)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function CheckIfConfigurationRestoresDAEphysWithoutAmp([string str])
 
 	string rewrittenConfig, fName
@@ -391,7 +391,7 @@ static Function CheckIfConfigurationRestoresDAEphysWithoutAmp2_REENTRY([string s
 	CHECK_EQUAL_STR(hwTypeString[1], "")
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function CheckIfConfigurationSavesAndRestores([string str])
 
 	string rewrittenConfig, fName

--- a/Packages/tests/HardwareBasic/UTF_DAEphys.ipf
+++ b/Packages/tests/HardwareBasic/UTF_DAEphys.ipf
@@ -13,7 +13,7 @@ static Function GlobalPreAcq(string device)
 	PASS()
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 Function CheckIfAllControlsReferStateWv([string str])
 
 	string list, ctrl, stri, expected, lbl, uniqueControls
@@ -170,7 +170,7 @@ Function CheckIfAllControlsReferStateWv([string str])
 	endfor
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 Function CheckStartupSettings([string str])
 
 	string unlockedDevice, list, ctrl, expected, lbl
@@ -246,7 +246,7 @@ Function CheckStartupSettings([string str])
 	CHECK_EQUAL_WAVES(guiStateTxTRef, guiStateTxTNew, mode = WAVE_DATA | DIMENSION_LABELS)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 Function CheckStimsetPopupMetadata([string str])
 
 	string controls, stimsetlist, ctrl, menuExp
@@ -278,7 +278,7 @@ Function CheckStimsetPopupMetadata([string str])
 	endfor
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 Function AllChannelControlsWork([string str])
 
 	string   ctrl
@@ -295,7 +295,7 @@ Function AllChannelControlsWork([string str])
 	endfor
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 Function CheckIfConfigurationRestoresMCCFilterGain([string str])
 
 	string rewrittenConfig, fName
@@ -366,7 +366,7 @@ static Function ComplainsAboutVanishingEpoch_preAcq(string device)
 	ST_SetStimsetParameter(setname, "Amplitude", epochIndex = 1, var = 0)
 End
 
-// UTF_TD_GENERATOR s0:DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR s0:DataGenerators#DeviceNameGeneratorMD1
 static Function ComplainsAboutVanishingEpoch([STRUCT IUTF_MDATA &md])
 
 	variable refNum
@@ -417,7 +417,7 @@ static Function SyncMIESMccWorksOutoftheBox_preAcq(string device)
 	PGC_SetAndActivateControl(device, "check_Settings_SyncMiesToMCC", val = 1)
 End
 
-// UTF_TD_GENERATOR s0:DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR s0:DataGenerators#DeviceNameGeneratorMD1
 static Function SyncMIESMccWorksOutoftheBox([STRUCT IUTF_MDATA &md])
 
 	variable headstage, func, clampMode, val, expected, actual
@@ -451,8 +451,8 @@ static Function CheckAmplifierReadAndWrite_preAcq(string device)
 	PGC_SetAndActivateControl(device, "check_Settings_SyncMiesToMCC", val = 1)
 End
 
-// UTF_TD_GENERATOR s0:DeviceNameGeneratorMD1
-// UTF_TD_GENERATOR v0:GetClampModesWithoutIZero
+// UTF_TD_GENERATOR s0:DataGenerators#DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR v0:DataGenerators#GetClampModesWithoutIZero
 Function CheckAmplifierReadAndWrite([STRUCT IUTF_MDATA &md])
 
 	variable refNum, headstage, func, clampMode, val, expected, actual, newValue
@@ -480,7 +480,7 @@ Function CheckAmplifierReadAndWrite([STRUCT IUTF_MDATA &md])
 
 	WAVE ampStorageWave = GetAmplifierParamStorageWave(device)
 
-	WAVE funcs = GetAmplifierFuncs()
+	WAVE funcs = DataGenerators#GetAmplifierFuncs()
 
 	for(func : funcs)
 		switch(func)
@@ -613,7 +613,7 @@ Function CheckAmplifierReadAndWrite([STRUCT IUTF_MDATA &md])
 	endfor
 
 	// handle funcs which don't interact with the MCC
-	WAVE funcs = GetNoAmplifierFuncs()
+	WAVE funcs = DataGenerators#GetNoAmplifierFuncs()
 
 	newValue = 0
 	for(func : funcs)
@@ -629,13 +629,13 @@ Function CheckAmplifierReadAndWrite([STRUCT IUTF_MDATA &md])
 	endfor
 End
 
-// UTF_TD_GENERATOR v0:GetClampModes
+// UTF_TD_GENERATOR v0:DataGenerators#GetClampModes
 static Function CheckAmplifierScaling([STRUCT IUTF_MDATA &md])
 
 	variable forward, backward, clampMode
 
 	clampMode = md.v0
-	WAVE funcs = GetAmplifierFuncs()
+	WAVE funcs = DataGenerators#GetAmplifierFuncs()
 
 	for(func : funcs)
 		forward  = AI_GetMCCScale(clampMode, func, MCC_READ)

--- a/Packages/tests/HardwareBasic/UTF_Dashboard.ipf
+++ b/Packages/tests/HardwareBasic/UTF_Dashboard.ipf
@@ -9,7 +9,7 @@ static Function DAB_Indexing_preAcq(string device)
 	ST_SetStimsetParameter("StimulusSetB_DA_0", "Total number of steps", var = 2)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function DAB_Indexing([string str])
 
 	STRUCT DAQSettings s
@@ -84,7 +84,7 @@ static Function DAB_Skipping_preAcq(string device)
 	PGC_SetAndActivateControl(device, "Check_Settings_SkipAnalysFuncs", val = CHECKBOX_SELECTED)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function DAB_Skipping([string str])
 
 	STRUCT DAQSettings s

--- a/Packages/tests/HardwareBasic/UTF_Databrowser.ipf
+++ b/Packages/tests/HardwareBasic/UTF_Databrowser.ipf
@@ -3,7 +3,7 @@
 #pragma rtFunctionErrors = 1
 #pragma ModuleName       = DataBrowserTests
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 Function CanFindAllDataBrowsers([string str])
 
 	string win, bsPanel
@@ -39,7 +39,7 @@ Function CanFindAllDataBrowsers([string str])
 	CHECK_EQUAL_VAR(DimSize(matchesAuto, ROWS), 1)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 Function CheckWindowTitles([string str])
 
 	string win
@@ -57,30 +57,7 @@ Function CheckWindowTitles([string str])
 	CHECK_EQUAL_STR(S_Value, "Browser with \"" + str + "\" (A*U*T*O*M*A*T*I*O*N)")
 End
 
-static Function/WAVE AllDatabrowserSubWindows()
-
-	string win
-
-	win = DB_OpenDatabrowser()
-
-	WAVE/Z/T allWindows = ListToTextWave(GetAllWindows(win), ";")
-	CHECK_WAVE(allWindows, TEXT_WAVE)
-
-	allWindows[] = StringFromList(1, allWindows[p], "#")
-
-	RemoveTextWaveEntry1D(allWindows, "", all = 1)
-
-	WAVE/Z/T allWindowsUnique = GetUniqueEntries(allWindows)
-	CHECK_WAVE(allWindowsUnique, TEXT_WAVE)
-
-	SetDimensionLabels(allWindowsUnique, TextWaveToList(allWindowsUnique, ";"), ROWS)
-
-	KillWindow $win
-
-	return allWindowsUnique
-End
-
-// UTF_TD_GENERATOR AllDatabrowserSubWindows
+// UTF_TD_GENERATOR DataGenerators#AllDatabrowserSubWindows
 Function RestoreButtonWorks([string str])
 
 	string win, subWindow

--- a/Packages/tests/HardwareBasic/UTF_Epochs.ipf
+++ b/Packages/tests/HardwareBasic/UTF_Epochs.ipf
@@ -584,7 +584,7 @@ End
 
 /// <------------- TESTS FOLLOW HERE ---------------------->
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function EP_EpochTest1([string str])
 
 	STRUCT DAQSettings s
@@ -600,7 +600,7 @@ static Function EP_EpochTest1_REENTRY([string str])
 	TestEpochsGeneric(str)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function EP_EpochTest2([string str])
 
 	STRUCT DAQSettings s
@@ -616,7 +616,7 @@ static Function EP_EpochTest2_REENTRY([string str])
 	TestEpochsGeneric(str)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function EP_EpochTest3([string str])
 
 	STRUCT DAQSettings s
@@ -632,7 +632,7 @@ static Function EP_EpochTest3_REENTRY([string str])
 	TestEpochsGeneric(str)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function EP_EpochTest4([string str])
 
 	STRUCT DAQSettings s
@@ -648,7 +648,7 @@ static Function EP_EpochTest4_REENTRY([string str])
 	TestEpochsGeneric(str)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function EP_EpochTest4a([string str])
 
 	STRUCT DAQSettings s
@@ -664,7 +664,7 @@ static Function EP_EpochTest4a_REENTRY([string str])
 	TestEpochsGeneric(str)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function EP_EpochTest5([string str])
 
 	STRUCT DAQSettings s
@@ -680,7 +680,7 @@ static Function EP_EpochTest5_REENTRY([string str])
 	TestEpochsGeneric(str)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function EP_EpochTest6([string str])
 
 	STRUCT DAQSettings s
@@ -696,7 +696,7 @@ static Function EP_EpochTest6_REENTRY([string str])
 	TestEpochsGeneric(str)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function EP_EpochTest7([string str])
 
 	STRUCT DAQSettings s
@@ -712,7 +712,7 @@ static Function EP_EpochTest7_REENTRY([string str])
 	TestEpochsGeneric(str)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function EP_EpochTest8([string str])
 
 	STRUCT DAQSettings s
@@ -728,7 +728,7 @@ static Function EP_EpochTest8_REENTRY([string str])
 	TestEpochsGeneric(str)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function EP_EpochTest9([string str])
 
 	STRUCT DAQSettings s
@@ -744,7 +744,7 @@ static Function EP_EpochTest9_REENTRY([string str])
 	TestEpochsGeneric(str)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function EP_EpochTest10([string str])
 
 	STRUCT DAQSettings s
@@ -765,7 +765,7 @@ static Function EP_EpochTest11_preInit(string device)
 	WB_MakeStimsetThirdParty("StimulusSetB_DA_0")
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function EP_EpochTest11([string str])
 
 	STRUCT DAQSettings s
@@ -781,7 +781,7 @@ static Function EP_EpochTest11_REENTRY([string str])
 	TestEpochsGeneric(str)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function EP_EpochTest12([string str])
 
 	STRUCT DAQSettings s
@@ -797,7 +797,7 @@ static Function EP_EpochTest12_REENTRY([string str])
 	TestEpochsGeneric(str)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function EP_EpochTest13([string str])
 
 	STRUCT DAQSettings s
@@ -813,7 +813,7 @@ static Function EP_EpochTest13_REENTRY([string str])
 	TestEpochsGeneric(str)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function EP_TestUserEpochs([string str])
 
 	STRUCT DAQSettings s
@@ -875,7 +875,7 @@ static Function EP_TestUserEpochs_REENTRY([string str])
 	endfor
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function EP_EpochTest14([string str])
 
 	STRUCT DAQSettings s
@@ -891,7 +891,7 @@ static Function EP_EpochTest14_REENTRY([string str])
 	TestEpochsGeneric(str)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function EP_EpochTest15([string str])
 
 	STRUCT DAQSettings s
@@ -919,7 +919,7 @@ End
 // Note: PreAcq sets the ADC sample rate to 10 kHz and relies on the feature that DA sample rate for ITC and NI
 //       equals the AD sample rate. For Sutter 10 kHz is the default maximum frequency for DA independent of the
 //       change in PreAcq.
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function EP_EpochTest16([string str])
 
 	STRUCT DAQSettings s
@@ -944,7 +944,7 @@ End
 // The stimset is also flipped, such that this zeroed interval is at the front in the data wave.
 // This interval should appear as ST_B (stimser baseline trail)
 //
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function EP_EpochTest17([string str])
 
 	STRUCT DAQSettings s
@@ -959,7 +959,7 @@ static Function EP_EpochTest17_REENTRY([string str])
 	TestEpochsGeneric(str)
 End
 
-// IUTF_TD_GENERATOR s0:DeviceNameGeneratorMD1
+// IUTF_TD_GENERATOR s0:DataGenerators#DeviceNameGeneratorMD1
 // IUTF_TD_GENERATOR v0:DataGenerators#EpochTestSamplingFrequency_Gen
 // IUTF_TD_GENERATOR s1:DataGenerators#EpochTest_Stimsets_Gen
 static Function EP_EpochTestSamplingFrequency([STRUCT IUTF_mData &mData])
@@ -981,7 +981,7 @@ static Function EP_EpochTestSamplingFrequency_REENTRY([STRUCT IUTF_mData &mData]
 	TestEpochsGeneric(mData.s0)
 End
 
-// IUTF_TD_GENERATOR s0:DeviceNameGeneratorMD1
+// IUTF_TD_GENERATOR s0:DataGenerators#DeviceNameGeneratorMD1
 // IUTF_TD_GENERATOR v0:DataGenerators#EpochTestSamplingMultiplier_Gen
 // IUTF_TD_GENERATOR s1:DataGenerators#EpochTest_Stimsets_Gen
 static Function EP_EpochTestSamplingMultiplier([STRUCT IUTF_mData &mData])
@@ -1003,7 +1003,7 @@ static Function EP_EpochTestSamplingMultiplier_REENTRY([STRUCT IUTF_mData &mData
 	TestEpochsGeneric(mData.s0)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function EP_EpochTestUnassocDA([string str])
 
 	STRUCT DAQSettings s
@@ -1047,7 +1047,7 @@ static Function EP_EpochTestUnassocDA_REENTRY([string str])
 	TestEpochsGeneric(str)
 End
 
-// IUTF_TD_GENERATOR s0:DeviceNameGeneratorMD1
+// IUTF_TD_GENERATOR s0:DataGenerators#DeviceNameGeneratorMD1
 // IUTF_TD_GENERATOR v0:DataGenerators#EpochTestTTL_TP_Gen
 // IUTF_TD_GENERATOR v1:DataGenerators#EpochTestTTL_TD_Gen
 // IUTF_TD_GENERATOR v2:DataGenerators#EpochTestTTL_OD_Gen
@@ -1113,7 +1113,7 @@ static Function EP_EpochTestTTL_REENTRY([STRUCT IUTF_mData &mData])
 	CHECK_EQUAL_WAVES(epochShortNames, nameRef, mode = WAVE_DATA)
 End
 
-// IUTF_TD_GENERATOR s0:DeviceNameGeneratorMD1
+// IUTF_TD_GENERATOR s0:DataGenerators#DeviceNameGeneratorMD1
 // IUTF_TD_GENERATOR v0:DataGenerators#EpochTestSamplingFrequencyTTL_Gen
 // IUTF_TD_GENERATOR s1:DataGenerators#EpochTest_StimsetsTTL_Gen
 static Function EP_EpochTestTTLSamplingFrequency([STRUCT IUTF_mData &mData])
@@ -1137,7 +1137,7 @@ static Function EP_EpochTestTTLSamplingFrequency_REENTRY([STRUCT IUTF_mData &mDa
 	TestEpochsGeneric(mData.s0)
 End
 
-// IUTF_TD_GENERATOR s0:DeviceNameGeneratorMD1
+// IUTF_TD_GENERATOR s0:DataGenerators#DeviceNameGeneratorMD1
 // IUTF_TD_GENERATOR v0:DataGenerators#EpochTestSamplingMultiplier_Gen
 // IUTF_TD_GENERATOR s1:DataGenerators#EpochTest_StimsetsTTL_Gen
 static Function EP_EpochTestTTLSamplingMultiplier([STRUCT IUTF_mData &mData])
@@ -1161,7 +1161,7 @@ static Function EP_EpochTestTTLSamplingMultiplier_REENTRY([STRUCT IUTF_mData &mD
 	TestEpochsGeneric(mData.s0)
 End
 
-// IUTF_TD_GENERATOR s0:DeviceNameGeneratorMD1
+// IUTF_TD_GENERATOR s0:DataGenerators#DeviceNameGeneratorMD1
 // IUTF_TD_GENERATOR v0:DataGenerators#EpochTestSamplingFrequencyTTL_Gen
 static Function EP_EpochTest18([STRUCT IUTF_mData &mData])
 
@@ -1183,7 +1183,7 @@ static Function EP_EpochTest18_REENTRY([STRUCT IUTF_mData &mData])
 	TestEpochsGeneric(mData.s0)
 End
 
-// IUTF_TD_GENERATOR s0:DeviceNameGeneratorMD1
+// IUTF_TD_GENERATOR s0:DataGenerators#DeviceNameGeneratorMD1
 static Function EP_EpochTest19([STRUCT IUTF_mData &mData])
 
 	STRUCT DAQSettings s

--- a/Packages/tests/HardwareBasic/UTF_HardwareTestsWithBUG.ipf
+++ b/Packages/tests/HardwareBasic/UTF_HardwareTestsWithBUG.ipf
@@ -18,7 +18,7 @@ Function CheckSweepSavingCompatible_PreAcq(string device)
 	ST_SetStimsetParameter("StimulusSetA_DA_0", "Analysis function (generic)", str = "BreakConfigWave")
 End
 
-/// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+/// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 Function CheckSweepSavingCompatible([string str])
 
 	STRUCT DAQSettings s
@@ -37,7 +37,7 @@ Function CheckSweepSavingCompatible_REENTRY([string str])
 	CHECK_EQUAL_VAR(sweepNo, NaN)
 End
 
-/// UTF_TD_GENERATOR DeviceNameGeneratorMD0
+/// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD0
 Function ExtendedDebugLoggingOnErrorWithITC([string str])
 
 	STRUCT DAQSettings s

--- a/Packages/tests/HardwareBasic/UTF_SweepFormulaHardware.ipf
+++ b/Packages/tests/HardwareBasic/UTF_SweepFormulaHardware.ipf
@@ -454,7 +454,7 @@ static Function DirectToFormulaParser(string code)
 	return MIES_SF#SF_ParseFormulaToJSON(code)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SF_TPTest2([string str])
 
 	STRUCT DAQSettings s
@@ -559,7 +559,7 @@ static Function SF_TPTest2_REENTRY([string str])
 	CHECK_EQUAL_VAR(DimSize(data, ROWS), 1)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SF_TPTest([string str])
 
 	STRUCT DAQSettings s
@@ -580,7 +580,7 @@ static Function SF_TPTest_REENTRY([string str])
 	TestSweepFormulaSelectClampMode(str)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SF_ButtonTest([string str])
 
 	STRUCT DAQSettings s
@@ -595,7 +595,7 @@ static Function SF_ButtonTest_REENTRY([string str])
 	TestSweepFormulaButtons(str)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function TestSweepFormulaCodeResults([string str])
 
 	STRUCT DAQSettings s
@@ -687,7 +687,7 @@ Function SF_InsertedTPVersusTP_preAcq(string device)
 	AI_WriteToAmplifier(device, 1, V_CLAMP_MODE, MCC_PRIMARYSIGNALGAIN_FUNC, 1)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SF_InsertedTPVersusTP([string str])
 
 	STRUCT DAQSettings s
@@ -777,7 +777,7 @@ static Function SF_InsertedTPVersusTP_REENTRY([string str])
 	CHECK_EQUAL_WAVES(instInsertedHS1, instTPStorage_HS1, mode = WAVE_DATA, tol = 0.1)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SF_UnassociatedDATTL_Epochs([string str])
 
 	STRUCT DAQSettings s

--- a/Packages/tests/HardwareBasic/UTF_SweepSkipping.ipf
+++ b/Packages/tests/HardwareBasic/UTF_SweepSkipping.ipf
@@ -29,7 +29,7 @@ static Function SkipAhead_PreAcq(string device)
 	PGC_SetAndActivateControl(device, "SetVar_DataAcq_skipAhead", val = 2)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SkipAhead([string str])
 
 	[STRUCT DAQSettings s] = GetDAQSettings("MD1_RA1_I0_L0_BKG1")
@@ -66,7 +66,7 @@ static Function SweepSkipping_PreAcq(string device)
 	PGC_SetAndActivateControl(device, GetPanelControl(0, CHANNEL_TYPE_DAC, CHANNEL_CONTROL_INDEX_END), str = "StimulusSetD_*")
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SweepSkipping([string str])
 
 	[STRUCT DAQSettings s] = GetDAQSettings("MD1_RA1_I1_L0_BKG1")
@@ -111,7 +111,7 @@ static Function SweepSkippingAdvanced_PreAcq(string device)
 	PGC_SetAndActivateControl(device, GetPanelControl(0, CHANNEL_TYPE_DAC, CHANNEL_CONTROL_WAVE), str = "StimulusSetA_*")
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SweepSkippingAdvanced([string str])
 
 	[STRUCT DAQSettings s] = GetDAQSettings("MD1_RA1_I0_L0_BKG1")
@@ -157,8 +157,8 @@ static Function SweepSkippingAdvanced_REENTRY([string str])
 	CHECK_EQUAL_WAVES(skipSweepsSource, {SWEEP_SKIP_AUTO, SWEEP_SKIP_AUTO, SWEEP_SKIP_AUTO, NaN}, mode = WAVE_DATA)
 End
 
-// UTF_TD_GENERATOR v0:SingleMultiDeviceDAQ
-// UTF_TD_GENERATOR s0:DeviceNameGenerator
+// UTF_TD_GENERATOR v0:DataGenerators#SingleMultiDeviceDAQ
+// UTF_TD_GENERATOR s0:DataGenerators#DeviceNameGenerator
 static Function SkipSweepsDuringITI([STRUCT IUTF_MDATA &md])
 
 	[STRUCT DAQSettings s] = GetDAQSettings("MD" + num2str(md.v0) + "_RA1_I0_L0_BKG1_RES5_GSI0_ITI5")
@@ -193,7 +193,7 @@ static Function SkipSweepsBackDuringITI_PreAcq(string device)
 	PGC_SetAndActivateControl(device, GetPanelControl(0, CHANNEL_TYPE_DAC, CHANNEL_CONTROL_INDEX_END), str = "StimulusSetD_*")
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function SkipSweepsBackDuringITI([string str])
 
 	[STRUCT DAQSettings s] = GetDAQSettings("MD1_RA1_I0_L0_BKG1_RES0_GSI0_ITI5")

--- a/Packages/tests/HardwareBasic/UTF_TestPulseAndTPDuringDAQ.ipf
+++ b/Packages/tests/HardwareBasic/UTF_TestPulseAndTPDuringDAQ.ipf
@@ -13,7 +13,7 @@ static Function GlobalPreAcq(string device)
 	PASS()
 End
 
-/// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+/// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function CheckCalculatedTPEntries([string str])
 
 	STRUCT DAQSettings s
@@ -73,8 +73,8 @@ Function CheckTPBaseline_PreAcq(string device)
 	CtrlNamedBackGround StopTP, start=(ticks + 100), period=1, proc=StopTPWhenWeHaveOne
 End
 
-/// UTF_TD_GENERATOR v0:GenerateBaselineValues
-/// UTF_TD_GENERATOR s0:DeviceNameGeneratorMD1
+/// UTF_TD_GENERATOR v0:DataGenerators#GenerateBaselineValues
+/// UTF_TD_GENERATOR s0:DataGenerators#DeviceNameGeneratorMD1
 static Function CheckTPBaseline([STRUCT IUTF_MDATA &md])
 
 	string   device
@@ -174,7 +174,7 @@ End
 /// The analysis function ChangeTPSettings changes some settings in POST_SWEEP of sweep 1 and PRE_SWEEP_CONFIG of sweep 2. We check
 /// that these settings are correctly refelected in the LBN as now TP and DAQ settings for sweep 1 differ.
 ///
-/// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+/// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function CheckTPEntriesFromLBN([string str])
 
 	STRUCT DAQSettings s
@@ -339,7 +339,7 @@ static Function CheckTPEntriesFromLBN_REENTRY([string str])
 	CHECK_EQUAL_VAR(Sum(validWaves), 0)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function TPCachingWorks([string str])
 
 	STRUCT DAQSettings s
@@ -513,7 +513,7 @@ static Function CheckTPStorage1_PreAcq(string device)
 	CtrlNamedBackGround StopTPAfterSomeTime, start=(ticks + 420), period=60, proc=StopTP_IGNORE
 End
 
-/// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+/// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function CheckTPStorage1([string str])
 
 	STRUCT DAQSettings s
@@ -542,7 +542,7 @@ static Function CheckTPStorage2_PreAcq(string device)
 	CtrlNamedBackGround StopTPAfterSomeTime, start=(ticks + 420), period=60, proc=StopTP_IGNORE
 End
 
-/// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+/// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function CheckTPStorage2([string str])
 
 	STRUCT DAQSettings s
@@ -571,7 +571,7 @@ static Function CheckTPStorage3_PreAcq(string device)
 	CtrlNamedBackGround StopTPAfterSomeTime, start=(ticks + 420), period=60, proc=StopTP_IGNORE
 End
 
-/// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+/// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function CheckTPStorage3([string str])
 
 	STRUCT DAQSettings s
@@ -587,7 +587,7 @@ static Function CheckTPStorage3_REENTRY([string str])
 	CheckTPStorage(str)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function TPDuringDAQOnlyTP([string str])
 
 	STRUCT DAQSettings s
@@ -645,8 +645,8 @@ static Function TPDuringDAQOnlyTP_REENTRY([string str])
 	CHECK_EQUAL_TEXTWAVES(stimsets, {"TestPulse", "", "", "", "", "", "", "", ""}, mode = WAVE_DATA)
 End
 
-// UTF_TD_GENERATOR v0:IndexingPossibilities
-// UTF_TD_GENERATOR s0:DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR v0:DataGenerators#IndexingPossibilities
+// UTF_TD_GENERATOR s0:DataGenerators#DeviceNameGeneratorMD1
 static Function TPDuringDAQOnlyTPAndIndexing([STRUCT IUTF_MDATA &md])
 
 	STRUCT DAQSettings s
@@ -668,7 +668,7 @@ static Function TPDuringDAQOnlyTPAndIndexing_REENTRY([STRUCT IUTF_MDATA &md])
 	// generic properties are checked in TPDuringDAQOnlyTP
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function TPDuringDAQTPAndUnAssoc([string str])
 
 	STRUCT DAQSettings s
@@ -750,7 +750,7 @@ static Function TPDuringDAQTPAndUnAssoc_REENTRY([string str])
 	CHECK_EQUAL_STR(stimsetUnassoc, stimsetUnassocRef)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function TPDuringDAQ([string str])
 
 	STRUCT DAQSettings s
@@ -823,7 +823,7 @@ static Function TPDuringDAQWithoodDAQ_PreAcq(string device)
 	PGC_SetAndActivateControl(device, "Gain_DA_02", val = 2)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function TPDuringDAQWithoodDAQ([string str])
 
 	STRUCT DAQSettings s
@@ -889,7 +889,7 @@ static Function TPDuringDAQWithoodDAQ_REENTRY([string str])
 	CHECK_EQUAL_TEXTWAVES(stimsets, {"TestPulse", "StimulusSetC_DA_0", "StimulusSetC_DA_0", "", "", "", "", "", ""}, mode = WAVE_DATA)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function TPDuringDAQOnlyWithoodDAQ([string str])
 
 	STRUCT DAQSettings s
@@ -953,7 +953,7 @@ End
 
 static Constant TP_WAIT_TIMEOUT = 5
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function TPDuringDAQTPStoreCheck([string str])
 
 	STRUCT DAQSettings s
@@ -1017,7 +1017,7 @@ static Function CheckThatTPsCanBeFound_PreAcq(string device)
 	PrepareForPublishTest()
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function CheckThatTPsCanBeFound([string str])
 
 	STRUCT DAQSettings s
@@ -1082,7 +1082,7 @@ static Function CheckThatTPsCanBeFound_REENTRY([string str])
 	CheckStartStopMessages("tp", "stopping")
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function TPDuringDAQWithTTL([string str])
 
 	STRUCT DAQSettings s
@@ -1150,7 +1150,7 @@ static Function RunPowerSpectrum_PreAcq(string device)
 	PGC_SetAndActivateControl(device, "check_settings_show_power", val = 1)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function RunPowerSpectrum([string str])
 
 	STRUCT DAQSettings s
@@ -1186,7 +1186,7 @@ static Function RunPowerSpectrum_REENTRY([string str])
 	CHECK_EQUAL_WAVES(powerSpectrum, {NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, 1}, mode = WAVE_DATA)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function TestPulseCachingWorks([string str])
 
 	STRUCT DAQSettings s
@@ -1215,7 +1215,7 @@ static Function TestPulseCachingWorks_REENTRY([string str])
 	CHECK_GE_VAR(stats[V_Value][%Hits], 1)
 End
 
-/// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+/// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function ExportIntoNWB([string str])
 
 	STRUCT DAQSettings s
@@ -1260,7 +1260,7 @@ static Function TPDuringDAQwithPS_PreAcq(string device)
 	PGC_SetAndActivateControl(device, "check_settings_show_power", val = 1)
 End
 
-/// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+/// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function GetStoredTPTest([string str])
 
 	STRUCT DAQSettings s
@@ -1368,7 +1368,7 @@ static Function GetStoredTPTest_REENTRY([string str])
 	endfor
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function TPDuringDAQwithPS([string str])
 
 	STRUCT DAQSettings s
@@ -1399,8 +1399,8 @@ static Function TPDuringDAQwithPS_REENTRY([string str])
 	CHECK_EQUAL_WAVES(powerSpectrum, {NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, 1}, mode = WAVE_DATA)
 End
 
-// UTF_TD_GENERATOR v0:SingleMultiDeviceDAQ
-// UTF_TD_GENERATOR s0:DeviceNameGenerator
+// UTF_TD_GENERATOR v0:DataGenerators#SingleMultiDeviceDAQ
+// UTF_TD_GENERATOR s0:DataGenerators#DeviceNameGenerator
 static Function TPZerosDAC([STRUCT IUTF_MDATA &md])
 
 	STRUCT DAQSettings s
@@ -1448,7 +1448,7 @@ static Function TestTPPublishing_preAcq(string device)
 	PGC_SetAndActivateControl(device, "setvar_DataAcq_Hold_VC", val = 4.56)
 End
 
-/// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+/// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function TestTPPublishing([string str])
 
 	TUFXOP_Clear/Z/N=(ZMQ_FILTER_TPRESULT_1S)

--- a/Packages/tests/HardwareBasic/UTF_TrackSweepCounts.ipf
+++ b/Packages/tests/HardwareBasic/UTF_TrackSweepCounts.ipf
@@ -232,7 +232,7 @@ static Function Events_MD0_RA0_I0_L0_BKG0(STRUCT TestSettings &t)
 	t.events_HS1[sweepNo][POST_SET_EVENT] = NaN
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD0
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD0
 static Function MD0_RA0_I0_L0_BKG0([string str])
 
 	PrepareForPublishTest()
@@ -273,7 +273,7 @@ static Function Events_MD1_RA0_I0_L0_BKG1(STRUCT TestSettings &t)
 	Events_MD0_RA0_I0_L0_BKG0(t)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function MD1_RA0_I0_L0_BKG1([string str])
 
 	[STRUCT DAQSettings s] = GetDAQSettings()
@@ -331,7 +331,7 @@ static Function Events_MD0_RA1_I0_L0_BKG1(STRUCT TestSettings &t)
 	t.events_HS1[sweepNo][POST_SET_EVENT] = NaN
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD0
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD0
 static Function MD0_RA1_I0_L0_BKG0([string str])
 
 	[STRUCT DAQSettings s] = GetDAQSettings()
@@ -366,7 +366,7 @@ static Function Events_MD1_RA1_I0_L0_BKG1(STRUCT TestSettings &t)
 	Events_MD0_RA1_I0_L0_BKG1(t)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function MD1_RA1_I0_L0_BKG1([string str])
 
 	[STRUCT DAQSettings s] = GetDAQSettings()
@@ -438,7 +438,7 @@ static Function Events_MD1_RA1_I1_L0_BKG1(STRUCT TestSettings &t)
 	t.events_HS1[sweepNo][POST_SET_EVENT] = sweepNo
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function MD1_RA1_I1_L0_BKG1([string str])
 
 	[STRUCT DAQSettings s] = GetDAQSettings()
@@ -476,7 +476,7 @@ static Function Events_MD0_RA1_I1_L0_BKG0(STRUCT TestSettings &t)
 	Events_MD1_RA1_I1_L0_BKG1(t)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD0
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD0
 static Function MD0_RA1_I1_L0_BKG0([string str])
 
 	[STRUCT DAQSettings s] = GetDAQSettings()
@@ -558,7 +558,7 @@ static Function Events_MD1_RA1_I1_L1_BKG1(STRUCT TestSettings &t)
 	t.events_HS1[sweepNo][POST_SET_EVENT] = sweepNo
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function MD1_RA1_I1_L1_BKG1([string str])
 
 	[STRUCT DAQSettings s] = GetDAQSettings()
@@ -595,7 +595,7 @@ static Function Events_MD0_RA1_I1_L1_BKG0(STRUCT TestSettings &t)
 	Events_MD1_RA1_I1_L1_BKG1(t)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD0
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD0
 static Function MD0_RA1_I1_L1_BKG0([string str])
 
 	[STRUCT DAQSettings s] = GetDAQSettings()
@@ -676,7 +676,7 @@ static Function Events_RepeatSets_1(STRUCT TestSettings &t)
 	t.events_HS1[sweepNo][POST_SET_EVENT] = sweepNo
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function RepeatSets_1([string str])
 
 	[STRUCT DAQSettings s] = GetDAQSettings(overrideConfig = "MD1_RA1_I0_L0_BKG1_RES2")
@@ -783,7 +783,7 @@ static Function Events_RepeatSets_2(STRUCT TestSettings &t)
 	t.events_HS1[sweepNo][POST_SET_EVENT] = sweepNo
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function RepeatSets_2([string str])
 
 	[STRUCT DAQSettings s] = GetDAQSettings(overrideConfig = "MD1_RA1_I1_L0_BKG1_RES2")
@@ -911,7 +911,7 @@ static Function Events_RepeatSets_3(STRUCT TestSettings &t)
 	t.events_HS1[sweepNo][POST_SET_EVENT] = sweepNo
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function RepeatSets_3([string str])
 
 	[STRUCT DAQSettings s] = GetDAQSettings(overrideConfig = "MD1_RA1_I1_L1_BKG1_RES2")
@@ -1047,7 +1047,7 @@ static Function RepeatSets_4_PreAcq(string device)
 	SwitchIndexingOrder_IGNORE(device)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function RepeatSets_4([string str])
 
 	[STRUCT DAQSettings s] = GetDAQSettings(overrideConfig = "MD1_RA1_I1_L1_BKG1_RES2")
@@ -1161,7 +1161,7 @@ static Function RepeatSets_5_PreAcq(string device)
 	SwitchIndexingOrder_IGNORE(device)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function RepeatSets_5([string str])
 
 	[STRUCT DAQSettings s] = GetDAQSettings(overrideConfig = "MD1_RA1_I1_L0_BKG1_RES2")
@@ -1214,7 +1214,7 @@ End
 
 // test that locked indexing works when the maximum number of sweeps is
 // not in the first stimset
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function RepeatSets_6([string str])
 
 	[STRUCT DAQSettings s] = GetDAQSettings(overrideConfig = "MD1_RA1_I1_L1_BKG1_RES1")
@@ -1250,7 +1250,7 @@ static Function CheckIZeroClampMode_PreAcq(string device)
 	PGC_SetAndActivateControl(device, "Radio_ClampMode_1IZ", val = 1)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function CheckIZeroClampMode([string str])
 
 	[STRUCT DAQSettings s] = GetDAQSettings(overrideConfig = "MD1_RA0_I0_L0_BKG1_RES1")
@@ -1314,7 +1314,7 @@ static Function Events_RepeatSets_7(STRUCT TestSettings &t)
 End
 
 // test that all events are fired, even with TP during ITI
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function RepeatSets_7([string str])
 
 	[STRUCT DAQSettings s] = GetDAQSettings(overrideConfig = "MD1_RA1_I0_L0_BKG1_RES1_ITI3_TPI1")
@@ -1355,7 +1355,7 @@ End
 
 // Locked Indexing with TP during DAQ
 //
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function RepeatSets_8([string str])
 
 	[STRUCT DAQSettings s] = GetDAQSettings(overrideConfig = "MD1_RA1_I1_L1_BKG1_RES1")
@@ -1399,7 +1399,7 @@ End
 
 // Unlocked Indexing with TP during DAQ
 //
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function RepeatSets_9([string str])
 
 	[STRUCT DAQSettings s] = GetDAQSettings(overrideConfig = "MD1_RA1_I1_L0_BKG1_RES1")

--- a/Packages/tests/HardwareBasic/UTF_VeryBasicHardwareTests.ipf
+++ b/Packages/tests/HardwareBasic/UTF_VeryBasicHardwareTests.ipf
@@ -17,7 +17,7 @@ static Function CheckTestingInstallation()
 	REQUIRE_PROPER_STR(str)
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function TestLocking([string str])
 
 	// check that we can gather the device config wave
@@ -44,7 +44,7 @@ static Function CheckThatZeroMQMessagingWorks()
 	PrepareForPublishTest()
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function CheckNumberOfRacksAndTTLs([string str])
 
 	variable numRacksRef, numTTLsRef
@@ -107,7 +107,7 @@ static Function CheckDeviceLists()
 
 End
 
-// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 static Function CheckGetDeviceInfoValid([string str])
 
 	WAVE/Z wv = GetDeviceInfoWave(str)
@@ -129,7 +129,7 @@ static Function CheckGetDeviceInfoValid([string str])
 	CHECK_EQUAL_VAR(wv[%HardwareType], GetHardwareType(str))
 End
 
-// UTF_TD_GENERATOR NonExistingDevices
+// UTF_TD_GENERATOR DataGenerators#NonExistingDevices
 static Function CheckGetDeviceInfoWithInvalid([string str])
 
 	WAVE/Z wv = GetDeviceInfoWave(str)

--- a/Packages/tests/HistoricData/UTF_AttemptNWB2ExportOnOldData.ipf
+++ b/Packages/tests/HistoricData/UTF_AttemptNWB2ExportOnOldData.ipf
@@ -3,7 +3,7 @@
 #pragma rtFunctionErrors = 1
 #pragma ModuleName       = ExportToNWB
 
-/// UTF_TD_GENERATOR GetHistoricDataFilesPXP
+/// UTF_TD_GENERATOR HistoricDataHelpers#GetHistoricDataFilesPXP
 static Function TestExportingDataToNWB([string str])
 
 	string templateName, nwbFileName, device
@@ -25,7 +25,7 @@ static Function TestExportingDataToNWB([string str])
 	endfor
 End
 
-/// UTF_TD_GENERATOR GetHistoricDataFilesNWB
+/// UTF_TD_GENERATOR HistoricDataHelpers#GetHistoricDataFilesNWB
 static Function TestSweepBrowserExportToNWB([string str])
 
 	string file, win, abWin, sweepBrowsers, fileType, dataFolder, nwbFileName

--- a/Packages/tests/HistoricData/UTF_EpochRecreation.ipf
+++ b/Packages/tests/HistoricData/UTF_EpochRecreation.ipf
@@ -66,7 +66,7 @@ Function ExportEpochsFromFileToDF(string dfNameTemp)
 	endfor
 End
 
-/// UTF_TD_GENERATOR GetHistoricDataFilesPXP
+/// UTF_TD_GENERATOR HistoricDataHelpers#GetHistoricDataFilesPXP
 static Function TestEpochRecreationFromLoadedPXP([string str])
 
 	string win, device, bsPanel
@@ -97,7 +97,7 @@ static Function TestEpochRecreationFromLoadedPXP([string str])
 	endfor
 End
 
-/// UTF_TD_GENERATOR GetHistoricDataFiles
+/// UTF_TD_GENERATOR HistoricDataHelpers#GetHistoricDataFiles
 static Function TestEpochRecreationShortNames([string str])
 
 	string file, win, abWin, sweepBrowsers, refEpFolder, dfName, device, dataFolder

--- a/Packages/tests/HistoricData/UTF_HistoricAnalysisBrowser.ipf
+++ b/Packages/tests/HistoricData/UTF_HistoricAnalysisBrowser.ipf
@@ -17,7 +17,7 @@ static StrConstant LOADHISTORY_FILENAME     = "input:nwb2_H17.03.016.11.09.01.nw
 static StrConstant CHECKCOLLAPSED_FILENAME1 = "input:nwb2_H17.03.016.11.09.01.nwb"
 static StrConstant CHECKCOLLAPSED_FILENAME2 = "input:Pvalb-IRES-Cre;Ai14-646904.13.03.02.pxp"
 
-/// UTF_TD_GENERATOR GetHistoricDataNoData
+/// UTF_TD_GENERATOR HistoricDataHelpers#GetHistoricDataNoData
 static Function TestEmptyPXP([string str])
 
 	string file, abWin, sweepBrowsers
@@ -186,7 +186,7 @@ static Function TestNWBvsPXP_Selection()
 	CHECK_EQUAL_STR(fType, ANALYSISBROWSER_FILE_TYPE_NWBv1)
 End
 
-/// UTF_TD_GENERATOR GetHistoricDataLoadResults
+/// UTF_TD_GENERATOR HistoricDataHelpers#GetHistoricDataLoadResults
 static Function TestLoadResults([string str])
 
 	string abWin, sweepBrowsers, file
@@ -206,7 +206,7 @@ static Function TestLoadResults([string str])
 	CHECK_EQUAL_VAR(DataFolderExistsDFR(dfr), 1)
 End
 
-/// UTF_TD_GENERATOR GetHistoricDataLoadUserComment
+/// UTF_TD_GENERATOR HistoricDataHelpers#GetHistoricDataLoadUserComment
 static Function TestLoadComments([string str])
 
 	string abWin, sweepBrowsers, file

--- a/Packages/tests/HistoricData/UTF_HistoricDashboard.ipf
+++ b/Packages/tests/HistoricData/UTF_HistoricDashboard.ipf
@@ -40,7 +40,7 @@ static Function TestCompression()
 	CHECK_EQUAL_STR(refData, data)
 End
 
-/// UTF_TD_GENERATOR GetHistoricDataFiles
+/// UTF_TD_GENERATOR HistoricDataHelpers#GetHistoricDataFiles
 Function TestDashboardWithHistoricData([string str])
 
 	string abWin, sweepBrowsers, file, bsPanel, sbWin
@@ -65,7 +65,7 @@ Function TestAnalysisBrowserAddingFiles()
 	string abWin, sweepBrowsers, fileToReadd
 	variable holeIndex
 
-	WAVE/T files = GetHistoricDataFiles()
+	WAVE/T files = HistoricDataHelpers#GetHistoricDataFiles()
 	files[] = "input:" + files[p]
 
 	[abWin, sweepBrowsers] = OpenAnalysisBrowser(files)
@@ -90,7 +90,7 @@ Function TestDashboardDependentControlHandling()
 
 	string abWin, sweepBrowsers, file, sweepBrowser, bsPanel, scPanel
 
-	WAVE/T files = GetHistoricDataFiles()
+	WAVE/T files = HistoricDataHelpers#GetHistoricDataFiles()
 	file = "input:" + files[0]
 
 	[abWin, sweepBrowsers] = OpenAnalysisBrowser({file}, loadSweeps = 1)
@@ -145,7 +145,7 @@ Function TestDashboardSelections()
 
 	string abWin, sweepBrowsers, file, sweepBrowser, bsPanel
 
-	WAVE/T files = GetHistoricDataFiles()
+	WAVE/T files = HistoricDataHelpers#GetHistoricDataFiles()
 	file = "input:" + files[0]
 
 	[abWin, sweepBrowsers] = OpenAnalysisBrowser({file}, loadSweeps = 1)

--- a/Packages/tests/HistoricData/UTF_HistoricDataHelpers.ipf
+++ b/Packages/tests/HistoricData/UTF_HistoricDataHelpers.ipf
@@ -105,7 +105,7 @@ static Function SetLabelsForDGWave(WAVE/T files)
 	SetDimensionLabels(files, TextWaveToList(labels, ";"), ROWS)
 End
 
-Function/WAVE GetHistoricDataFiles()
+static Function/WAVE GetHistoricDataFiles()
 
 	WAVE/T pxpFiles = GetHistoricDataFilesPXP()
 	WAVE/T nwbFiles = GetHistoricDataFilesNWB()
@@ -118,7 +118,7 @@ Function/WAVE GetHistoricDataFiles()
 	return files
 End
 
-Function/WAVE GetHistoricDataFilesPXP()
+static Function/WAVE GetHistoricDataFilesPXP()
 
 	Make/FREE/T files = {"C57BL6J-629713.05.01.02.pxp",                       \
 	                     "Chat-IRES-Cre-neo;Ai14-582723.15.10.01.pxp",        \
@@ -135,7 +135,7 @@ Function/WAVE GetHistoricDataFilesPXP()
 	return files
 End
 
-Function/WAVE GetHistoricDataFilesWithTTLData()
+static Function/WAVE GetHistoricDataFilesWithTTLData()
 
 	Make/FREE/T files = {"C57BL6J-684963.02.04.01_pislocin_puff_2023_07_19_141829-compressed.nwb"}
 	DownloadFilesIfRequired(files)
@@ -144,7 +144,7 @@ Function/WAVE GetHistoricDataFilesWithTTLData()
 	return files
 End
 
-Function/WAVE GetHistoricDataFilesNWB()
+static Function/WAVE GetHistoricDataFilesNWB()
 
 	Make/FREE/T files = {"nwb2_H17.03.016.11.09.01.nwb",           \
 	                     "C57BL6J-628261.02.01.02.nwb",            \
@@ -158,7 +158,7 @@ Function/WAVE GetHistoricDataFilesNWB()
 	return files
 End
 
-Function/WAVE GetHistoricDataFilesSweepUpgrade()
+static Function/WAVE GetHistoricDataFilesSweepUpgrade()
 
 	Make/FREE/T files = {"single_numeric_sweep.pxp"}
 
@@ -168,7 +168,7 @@ Function/WAVE GetHistoricDataFilesSweepUpgrade()
 	return files
 End
 
-Function/WAVE GetHistoricDataNoData()
+static Function/WAVE GetHistoricDataNoData()
 
 	Make/FREE/T files = {"Labnotebook-has-sweep-but-no-data.pxp"}
 
@@ -178,7 +178,7 @@ Function/WAVE GetHistoricDataNoData()
 	return files
 End
 
-Function/WAVE GetHistoricDataLoadResults()
+static Function/WAVE GetHistoricDataLoadResults()
 
 	// Files in list must contain results waves
 	Make/FREE/T files = {"AB_LoadSweepsFromIgorData.pxp", "Gad2-IRES-Cre;Ai14-709273.06.02.02.nwb"}
@@ -189,7 +189,7 @@ Function/WAVE GetHistoricDataLoadResults()
 	return files
 End
 
-Function/WAVE GetHistoricDataLoadUserComment()
+static Function/WAVE GetHistoricDataLoadUserComment()
 
 	// Files in list must contain user comment
 	Make/FREE/T files = {"Pvalb-IRES-Cre;Ai14-646904.13.03.02.pxp", "nwb2_H17.03.016.11.09.01.nwb"}

--- a/Packages/tests/HistoricData/UTF_HistoricEpochClipping.ipf
+++ b/Packages/tests/HistoricData/UTF_HistoricEpochClipping.ipf
@@ -3,7 +3,7 @@
 #pragma rtFunctionErrors = 1
 #pragma ModuleName       = HistoricEochClipping
 
-/// UTF_TD_GENERATOR GetHistoricDataFiles
+/// UTF_TD_GENERATOR HistoricDataHelpers#GetHistoricDataFiles
 static Function TestEpochClipping([string str])
 
 	string abWin, sweepBrowsers, file, bsPanel, sbWin

--- a/Packages/tests/HistoricData/UTF_HistoricSweepBrowser.ipf
+++ b/Packages/tests/HistoricData/UTF_HistoricSweepBrowser.ipf
@@ -3,7 +3,7 @@
 #pragma rtFunctionErrors = 1
 #pragma ModuleName       = SweepBrowserTests
 
-/// UTF_TD_GENERATOR GetHistoricDataFilesWithTTLData
+/// UTF_TD_GENERATOR HistoricDataHelpers#GetHistoricDataFilesWithTTLData
 static Function TestTTLDisplayWithNoEpochInfo([string str])
 
 	string file, abWin, sweepBrowsers, win
@@ -28,7 +28,7 @@ Function TestSweepFormulaPowerSpectrumAverage()
 
 	string abWin, sweepBrowsers, file, sweepBrowser, bsPanel, scPanel, code
 
-	WAVE/T files = GetHistoricDataFiles()
+	WAVE/T files = HistoricDataHelpers#GetHistoricDataFiles()
 	file = "input:" + files[0]
 
 	[abWin, sweepBrowsers] = OpenAnalysisBrowser({file}, loadSweeps = 1)

--- a/Packages/tests/HistoricData/UTF_HistoricSweepUpgrade.ipf
+++ b/Packages/tests/HistoricData/UTF_HistoricSweepUpgrade.ipf
@@ -3,7 +3,7 @@
 #pragma rtFunctionErrors = 1
 #pragma ModuleName       = HistoricSweepUpgrade
 
-/// UTF_TD_GENERATOR GetHistoricDataFilesSweepUpgrade
+/// UTF_TD_GENERATOR HistoricDataHelpers#GetHistoricDataFilesSweepUpgrade
 static Function TestSweepUpgrade([string str])
 
 	string abWin, sweepBrowsers, file, bsPanel, sbWin, dataFolder, device, preUpgradeName

--- a/Packages/tests/PAPlot/UTF_PA_Tests.ipf
+++ b/Packages/tests/PAPlot/UTF_PA_Tests.ipf
@@ -2173,23 +2173,7 @@ static Function PAT_MultiSweepAvg()
 	endfor
 End
 
-static Function/WAVE PAT_IncrementalSweepAdd_Generator()
-
-	Make/FREE/WAVE/N=4 w
-
-	Make/FREE sweeps = {0, 1, 2, 3, 4, 5}
-	w[0] = sweeps
-	Make/FREE sweeps = {5, 4, 3, 2, 1, 0}
-	w[1] = sweeps
-	Make/FREE sweeps = {2, 1, 5, 3, 4, 0}
-	w[2] = sweeps
-	Make/FREE sweeps = {4, 3, 5, 0, 1, 2}
-	w[3] = sweeps
-
-	return w
-End
-
-// UTF_TD_GENERATOR PAT_IncrementalSweepAdd_Generator
+// UTF_TD_GENERATOR DataGenerators#PAT_IncrementalSweepAdd_Generator
 static Function PAT_IncrementalSweepAdd([WAVE wv])
 
 	string bspName, graph

--- a/Packages/tests/UTF_Constants.ipf
+++ b/Packages/tests/UTF_Constants.ipf
@@ -14,3 +14,5 @@ StrConstant ZSTD_SUFFIX = ".zst"
 Constant TP_DURATION_S = 5
 
 Constant PSQ_TEST_VERY_LARGE_FREQUENCY = 1e350
+
+StrConstant PGCT_POPUPMENU_ENTRIES = "Entry1;Entry2;Entry3"

--- a/Packages/tests/UTF_DataGenerators.ipf
+++ b/Packages/tests/UTF_DataGenerators.ipf
@@ -3,7 +3,7 @@
 #pragma rtFunctionErrors = 1
 #pragma ModuleName       = DataGenerators
 
-Function/WAVE MajorNWBVersions()
+static Function/WAVE MajorNWBVersions()
 
 	Make/FREE wv = {1, 2}
 
@@ -12,7 +12,7 @@ Function/WAVE MajorNWBVersions()
 	return wv
 End
 
-Function/WAVE IndexingPossibilities()
+static Function/WAVE IndexingPossibilities()
 
 	Make/FREE wv = {0, 1}
 
@@ -21,7 +21,7 @@ Function/WAVE IndexingPossibilities()
 	return wv
 End
 
-Function/WAVE InsertedTPPossibilities()
+static Function/WAVE InsertedTPPossibilities()
 
 	Make/FREE wv = {0, 1}
 
@@ -30,7 +30,7 @@ Function/WAVE InsertedTPPossibilities()
 	return wv
 End
 
-Function/WAVE SingleMultiDeviceDAQ()
+static Function/WAVE SingleMultiDeviceDAQ()
 
 	WAVE multiDevices  = DeviceNameGeneratorMD1()
 	WAVE singleDevices = DeviceNameGeneratorMD0()
@@ -46,12 +46,12 @@ Function/WAVE SingleMultiDeviceDAQ()
 	return wv
 End
 
-Function/WAVE DeviceNameGenerator()
+static Function/WAVE DeviceNameGenerator()
 
 	return DeviceNameGeneratorMD1()
 End
 
-Function/WAVE DeviceNameGeneratorMD1()
+static Function/WAVE DeviceNameGeneratorMD1()
 
 	string devList = ""
 	string lblList = ""
@@ -85,7 +85,7 @@ Function/WAVE DeviceNameGeneratorMD1()
 	return data
 End
 
-Function/WAVE DeviceNameGeneratorMD0()
+static Function/WAVE DeviceNameGeneratorMD0()
 
 #ifdef TESTS_WITH_NI_HARDWARE
 	// NI Hardware has no single device support
@@ -109,7 +109,7 @@ Function/WAVE DeviceNameGeneratorMD0()
 
 End
 
-Function/WAVE NWBVersionStrings()
+static Function/WAVE NWBVersionStrings()
 
 	variable i, numEntries
 	string name
@@ -118,7 +118,7 @@ Function/WAVE NWBVersionStrings()
 	return data
 End
 
-Function/WAVE NeuroDataRefTree()
+static Function/WAVE NeuroDataRefTree()
 
 	variable i, numEntries
 	string name
@@ -130,7 +130,7 @@ Function/WAVE NeuroDataRefTree()
 	return data
 End
 
-Function/WAVE SpikeCountsStateValues()
+static Function/WAVE SpikeCountsStateValues()
 
 	variable numEntries = 6
 	variable idx
@@ -149,7 +149,7 @@ Function/WAVE SpikeCountsStateValues()
 	return wv
 End
 
-Function/WAVE GenerateBaselineValues()
+static Function/WAVE GenerateBaselineValues()
 
 	Make/FREE wv = {25, 35, 45}
 
@@ -158,7 +158,7 @@ Function/WAVE GenerateBaselineValues()
 	return wv
 End
 
-Function/WAVE GetITCDevices()
+static Function/WAVE GetITCDevices()
 
 #ifdef TESTS_WITH_NI_HARDWARE
 	Make/FREE/T/N=0 wv
@@ -173,7 +173,7 @@ Function/WAVE GetITCDevices()
 	return DeviceNameGeneratorMD1()
 End
 
-Function/WAVE GetChannelNumbersForDATTL()
+static Function/WAVE GetChannelNumbersForDATTL()
 
 	string list
 
@@ -188,7 +188,7 @@ Function/WAVE GetChannelNumbersForDATTL()
 	return channelNumbers
 End
 
-Function/WAVE GetClampModesWithoutIZero()
+static Function/WAVE GetClampModesWithoutIZero()
 
 	Make/FREE clampModes = {V_CLAMP_MODE, I_CLAMP_MODE}
 	SetDimensionLabels(clampModes, "VC;IC;", ROWS)
@@ -196,7 +196,7 @@ Function/WAVE GetClampModesWithoutIZero()
 	return clampModes
 End
 
-Function/WAVE GetClampModes()
+static Function/WAVE GetClampModes()
 
 	Make/FREE clampModes = {V_CLAMP_MODE, I_CLAMP_MODE, I_EQUAL_ZERO_MODE}
 	SetDimensionLabels(clampModes, "VC;IC;IZ;", ROWS)
@@ -204,7 +204,7 @@ Function/WAVE GetClampModes()
 	return clampModes
 End
 
-Function/WAVE GetChannelTypes()
+static Function/WAVE GetChannelTypes()
 
 	Make/FREE channelTypes = {CHANNEL_TYPE_DAC, CHANNEL_TYPE_TTL}
 
@@ -213,7 +213,7 @@ Function/WAVE GetChannelTypes()
 	return channelTypes
 End
 
-Function/WAVE NonExistingDevices()
+static Function/WAVE NonExistingDevices()
 
 	Make/FREE/T wv = {"Dev0815", "ITC16_DEV_15"}
 
@@ -295,7 +295,7 @@ static Function/WAVE SF_TestVariablesGen()
 	return wv
 End
 
-Function/WAVE GetMiesMacrosWithPanelType()
+static Function/WAVE GetMiesMacrosWithPanelType()
 
 	WAVE/T allMiesMacros = GetMIESMacros()
 
@@ -391,7 +391,7 @@ static Function/WAVE EpochTestTTL_OD_Gen()
 	return w
 End
 
-Function/WAVE InfiniteValues()
+static Function/WAVE InfiniteValues()
 
 	Make/FREE wv = {NaN, Inf, -Inf}
 
@@ -410,14 +410,14 @@ static Function/WAVE RoundTripStimsetFileType()
 	return wv
 End
 
-Function/WAVE IndexAfterDecimation_Positions()
+static Function/WAVE IndexAfterDecimation_Positions()
 
 	Make/FREE/D wv = {e / 11.1, Pi / 11.1, 0.73, 0.51}
 
 	return wv
 End
 
-Function/WAVE IndexAfterDecimation_Sizes()
+static Function/WAVE IndexAfterDecimation_Sizes()
 
 	// These are variations of the target size, the source size is fixed 1000
 	Make/FREE/D wv = {345, 678, 1234, 5678}
@@ -425,7 +425,7 @@ Function/WAVE IndexAfterDecimation_Sizes()
 	return wv
 End
 
-Function/WAVE CountObjectTypeFlags()
+static Function/WAVE CountObjectTypeFlags()
 
 	Make/FREE/D input0 = {COUNTOBJECTS_WAVES}
 	Make/FREE/T result0 = {"wv1;wv2;"}
@@ -458,7 +458,7 @@ Function/WAVE CountObjectTypeFlags()
 	return wv
 End
 
-Function/WAVE TrailSepOptions()
+static Function/WAVE TrailSepOptions()
 
 	Make/FREE wv = {0, 1}
 
@@ -976,7 +976,7 @@ static Function/WAVE SF_TestOperationSelNoArg()
 	return wt
 End
 
-Function/WAVE GetAmplifierFuncs()
+static Function/WAVE GetAmplifierFuncs()
 
 	variable numEntries
 
@@ -991,7 +991,7 @@ Function/WAVE GetAmplifierFuncs()
 	return funcs
 End
 
-Function/WAVE GetNoAmplifierFuncs()
+static Function/WAVE GetNoAmplifierFuncs()
 
 	variable numEntries
 
@@ -1033,4 +1033,748 @@ static Function/WAVE GetConcatSingleElementWaves()
 	SetDimensionLabels(waves, "Numeric;Text;DFREF;WAVE", ROWS)
 
 	return waves
+End
+
+static Function/WAVE GetAnalysisFunctions()
+
+	string funcs
+
+	funcs = AFH_GetAnalysisFunctions(ANALYSIS_FUNCTION_VERSION_V3, includeUserFunctions = 0)
+
+	// remove our test help functions which do nasty things
+	funcs = GrepList(funcs, ".*_V3", 1)
+	funcs = GrepList(funcs, ".*_.*")
+
+	WAVE/T wv = ListToTextWave(funcs, ";")
+
+	SetDimensionLabels(wv, funcs, ROWS)
+
+	Sort/DIML wv, wv
+
+	return wv
+End
+
+static Function/WAVE GetAnalysisParameterValues()
+
+	Make/FREE/N=(5)/WAVE waves
+
+	Make/FREE/T wv0 = {"var", "123"}
+	waves[0] = wv0
+
+	Make/FREE/T wv1 = {"str", "abcd"}
+	waves[1] = wv1
+
+	Make/FREE/T wv2 = {"wv", "1;2;"}
+	waves[2] = wv2
+
+	Make/FREE/T wv3 = {"txtwv", "a;b;"}
+	waves[3] = wv3
+
+	Make/FREE/T wv4 = {"i_dont_exist", ""}
+	waves[4] = wv4
+
+	return waves
+End
+
+static Function/WAVE OldEpochsFormats()
+
+	Make/WAVE/N=2/FREE oldFormats = {root:EpochsWave:EpochsWave_4e534e298, root:EpochsWave:EpochsWave_d150d896e}
+
+	SetDimensionLabels(oldFormats, "EpochsWave_4e534e298;EpochsWave_d150d896e", ROWS)
+
+	return oldFormats
+End
+
+static Function/WAVE LBNInvalidValidPairs()
+
+	Make/WAVE/N=5/FREE waves
+
+	Make/T/FREE wv0 = {"a:b", "a [b]"}
+	waves[0] = wv0
+
+	Make/T/FREE wv1 = {"\"", "_"}
+	waves[1] = wv1
+
+	Make/T/FREE wv2 = {"\'", "_"}
+	waves[2] = wv2
+
+	Make/T/FREE wv3 = {";", "_"}
+	waves[3] = wv3
+
+	Make/T/FREE wv4 = {":", "_"}
+	waves[4] = wv4
+
+	return waves
+End
+
+static Function/WAVE AllDescriptionWaves()
+
+	Make/FREE/WAVE/N=1 wvs
+
+	// GetLBNumericalDescription creates a wave within the MIES datafolder, but that is killed at Test Begin
+	// Thus, we use a copy of that wave here
+	WAVE wDesc = GetLBNumericalDescription()
+	Duplicate/FREE wDesc, wT
+	wvs[0] = wT
+
+	return wvs
+End
+
+static Function/WAVE ControlTypesWhichOnlyAcceptVar()
+
+	Make/T/FREE wv = {"checkbox_ctrl_mode_checkbox", "slider_ctrl", "tab_ctrl", "valdisp_ctrl", "button_ctrl", "listbox_ctrl"}
+
+	return wv
+End
+
+static Function/WAVE ControlTypesWhichRequireOneParameter()
+
+	// all except button
+	Make/T/FREE wv = {"checkbox_ctrl_mode_checkbox", "slider_ctrl", "tab_ctrl", "valdisp_ctrl", "popup_ctrl", "setvar_str_ctrl", "setvar_num_ctrl", "listbox_ctrl"}
+
+	return wv
+End
+
+static Function/WAVE ControlTypesWhichOnlyAcceptVarOrStr()
+
+	Make/T/FREE wv = {"popup_ctrl", "setvar_str_ctrl", "setvar_num_ctrl"}
+
+	return wv
+End
+
+static Function/WAVE InvalidPopupMenuOtherIndizes()
+
+	Make/FREE wv = {-1, NaN, Inf, -Inf, ItemsInList(PGCT_POPUPMENU_ENTRIES)}
+
+	return wv
+End
+
+static Function/WAVE InvalidPopupMenuColorTableIndizes()
+
+	Make/FREE wv = {-1, NaN, Inf, -Inf, ItemsInList(CTabList())}
+
+	return wv
+End
+
+static Function/WAVE VariousModeFlags()
+
+	Make/FREE/D modes = {-1, PGC_MODE_ASSERT_ON_DISABLED, PGC_MODE_FORCE_ON_DISABLED, PGC_MODE_SKIP_ON_DISABLED}
+
+	return modes
+End
+
+static Function/WAVE StatsTest_GetInput()
+
+	Make/T/FREE/N=(3) template
+	SetDimensionLabels(template, "prop;state;postProc", ROWS)
+
+	// wv0
+	Duplicate/FREE/T template, wv0
+	WAVE/T input = wv0
+
+	input[%prop]     = "estate"
+	input[%state]    = "accept"
+	input[%postProc] = "nothing"
+
+	JWN_SetWaveInWaveNote(input, "/results", {PSX_ACCEPT, PSX_ACCEPT, PSX_ACCEPT, PSX_ACCEPT})
+	JWN_SetWaveInWaveNote(input, "/xValues", {1, 3, 5, 7})
+	JWN_SetWaveInWaveNote(input, "/marker", {PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT})
+
+	// wv1
+	Duplicate/FREE/T template, wv1
+	WAVE/T input = wv1
+
+	input[%prop]     = "estate"
+	input[%state]    = "reject"
+	input[%postProc] = "nothing"
+
+	JWN_SetWaveInWaveNote(input, "/results", {PSX_REJECT, PSX_REJECT, PSX_REJECT})
+	JWN_SetWaveInWaveNote(input, "/xValues", {0, 4, 8})
+	JWN_SetWaveInWaveNote(input, "/marker", {PSX_MARKER_REJECT, PSX_MARKER_REJECT, PSX_MARKER_REJECT})
+
+	// wv2
+	Duplicate/FREE/T template, wv2
+	WAVE/T input = wv2
+
+	input[%prop]     = "estate"
+	input[%state]    = "undetermined"
+	input[%postProc] = "nothing"
+
+	JWN_SetWaveInWaveNote(input, "/results", {PSX_UNDET, PSX_UNDET, PSX_UNDET})
+	JWN_SetWaveInWaveNote(input, "/xValues", {2, 6, 9})
+	JWN_SetWaveInWaveNote(input, "/marker", {PSX_MARKER_UNDET, PSX_MARKER_UNDET, PSX_MARKER_UNDET})
+
+	// wv3
+	Duplicate/FREE/T template, wv3
+	WAVE/T input = wv3
+
+	input[%prop]     = "tau"
+	input[%state]    = "accept"
+	input[%postProc] = "nothing"
+
+	JWN_SetWaveInWaveNote(input, "/results", {0e-6, 4e-6, 8e-6})
+	JWN_SetWaveInWaveNote(input, "/xValues", {0, 4, 8})
+	JWN_SetWaveInWaveNote(input, "/marker", {PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT})
+
+	// wv4
+	Duplicate/FREE/T template, wv4
+	WAVE/T input = wv4
+
+	input[%prop]     = "amp"
+	input[%state]    = "accept"
+	input[%postProc] = "stats"
+
+	JWN_SetWaveInWaveNote(input, "/results", {40, 40, 20, 25.81988897471611, 0, -2.0775})
+	JWN_SetWaveInWaveNote(input, "/xValues", ListToTextWave(PSX_STATS_LABELS, ";"))
+	JWN_SetWaveInWaveNote(input, "/marker", {PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT, \
+	                                         PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT})
+
+	// wv5
+	Duplicate/FREE/T template, wv5
+	WAVE/T input = wv5
+
+	input[%prop]     = "fstate"
+	input[%state]    = "undetermined"
+	input[%postProc] = "count"
+
+	JWN_SetWaveInWaveNote(input, "/results", {5})
+	// no xValues
+	JWN_SetWaveInWaveNote(input, "/marker", {PSX_MARKER_UNDET})
+
+	// wv6
+	Duplicate/FREE/T template, wv6
+	WAVE/T input = wv6
+
+	input[%prop]     = "peaktime"
+	input[%state]    = "undetermined"
+	input[%postProc] = "hist"
+
+	JWN_SetWaveInWaveNote(input, "/results", {1, 2})
+	// no xValues
+	JWN_SetWaveInWaveNote(input, "/marker", {PSX_MARKER_UNDET, PSX_MARKER_UNDET})
+
+	// wv7
+	Duplicate/FREE/T template, wv7
+	WAVE/T input = wv7
+
+	input[%prop]     = "xinterval"
+	input[%state]    = "undetermined"
+	input[%postProc] = "log10"
+
+	Make/FREE/D result = {NaN, log(60 - 20), log(90 - 60)}
+	JWN_SetWaveInWaveNote(input, "/results", result)
+	JWN_SetWaveInWaveNote(input, "/xValues", {2, 6, 9})
+	JWN_SetWaveInWaveNote(input, "/marker", {PSX_MARKER_UNDET, PSX_MARKER_UNDET, PSX_MARKER_UNDET})
+
+	// wv8
+	Duplicate/FREE/T template, wv8
+	WAVE/T input = wv8
+
+	input[%prop]     = "fitresult"
+	input[%state]    = "undetermined"
+	input[%postProc] = "nothing"
+
+	JWN_SetWaveInWaveNote(input, "/results", {1, 1, 1, 1, 1})
+	JWN_SetWaveInWaveNote(input, "/xValues", {1, 3, 5, 7, 9})
+	JWN_SetWaveInWaveNote(input, "/marker", {PSX_MARKER_UNDET, PSX_MARKER_UNDET, PSX_MARKER_UNDET, PSX_MARKER_UNDET, PSX_MARKER_UNDET})
+
+	// wv9
+	Duplicate/FREE/T template, wv9
+	WAVE/T input = wv9
+
+	input[%prop]     = "risetime"
+	input[%state]    = "undetermined"
+	input[%postProc] = "nothing"
+
+	JWN_SetWaveInWaveNote(input, "/results", {0.2, 0.6, 0.9})
+	JWN_SetWaveInWaveNote(input, "/xValues", {2, 6, 9})
+	JWN_SetWaveInWaveNote(input, "/marker", {PSX_MARKER_UNDET, PSX_MARKER_UNDET, PSX_MARKER_UNDET})
+
+	// wv10
+	Duplicate/FREE/T template, wv10
+	WAVE/T input = wv10
+
+	input[%prop]     = "peaktime"
+	input[%state]    = "all"
+	input[%postProc] = "nonfinite"
+
+	JWN_SetWaveInWaveNote(input, "/results", {1, 3, 5, 7, 9})
+	JWN_SetWaveInWaveNote(input, "/xValues", {0, -1, +1, 0, -1})
+	JWN_SetWaveInWaveNote(input, "/marker", {PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT, PSX_MARKER_UNDET})
+	Make/FREE/T lbl = {"-inf", "NaN", "inf"}
+	JWN_SetWaveInWaveNote(input, "/XTickLabels", lbl)
+	JWN_SetWaveInWaveNote(input, "/XTickPositions", {-1, 0, 1})
+
+	// end
+	Make/FREE/WAVE results = {wv0, wv1, wv2, wv3, wv4, wv5, wv6, wv7, wv8, wv9, wv10}
+
+	return results
+End
+
+Function/WAVE StatsTestSpecialCases_GetInput()
+
+	Make/T/FREE/N=(7) template
+	SetDimensionLabels(template, "prop;state;postProc;refNumOutputRows;numEventsCombo0;numEventsCombo1;outOfRange", ROWS)
+
+	// wv0
+	// every
+	Duplicate/FREE/T template, wv0
+	WAVE/T input = wv0
+
+	input[%prop]             = "estate"
+	input[%state]            = "every"
+	input[%postProc]         = "nothing"
+	input[%refNumOutputRows] = "3"
+	input[%numEventsCombo0]  = "5"
+	input[%numEventsCombo1]  = "3"
+	input[%outOfRange]       = "0"
+
+	JWN_CreatePath(input, "/0")
+	JWN_SetWaveInWaveNote(input, "/0/results", {PSX_ACCEPT, PSX_ACCEPT, PSX_ACCEPT})
+	JWN_SetWaveInWaveNote(input, "/0/xValues", {1, 3, 1})
+	JWN_SetWaveInWaveNote(input, "/0/marker", {PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT})
+
+	JWN_CreatePath(input, "/1")
+	JWN_SetWaveInWaveNote(input, "/1/results", {PSX_REJECT, PSX_REJECT, PSX_REJECT})
+	JWN_SetWaveInWaveNote(input, "/1/xValues", {0, 4, 0})
+	JWN_SetWaveInWaveNote(input, "/1/marker", {PSX_MARKER_REJECT, PSX_MARKER_REJECT, PSX_MARKER_REJECT})
+
+	JWN_CreatePath(input, "/2")
+	JWN_SetWaveInWaveNote(input, "/2/results", {PSX_UNDET, PSX_UNDET})
+	JWN_SetWaveInWaveNote(input, "/2/xValues", {2, 2})
+	JWN_SetWaveInWaveNote(input, "/2/marker", {PSX_MARKER_UNDET, PSX_MARKER_UNDET})
+
+	// wv1
+	// no match
+	Duplicate/FREE/T template, wv1
+	WAVE/T input = wv1
+
+	input[%prop]             = "estate"
+	input[%state]            = "accept"
+	input[%postProc]         = "nothing"
+	input[%refNumOutputRows] = "0"
+	input[%numEventsCombo0]  = "1"
+	input[%numEventsCombo1]  = "1"
+	input[%outOfRange]       = "0"
+
+	// wv2
+	// histogram works also with just one point
+	Duplicate/FREE/T template, wv2
+	WAVE/T input = wv2
+
+	input[%prop]             = "estate"
+	input[%state]            = "reject"
+	input[%postProc]         = "hist"
+	input[%refNumOutputRows] = "1"
+	input[%numEventsCombo0]  = "1"
+	input[%numEventsCombo1]  = "0"
+	input[%outOfRange]       = "0"
+
+	JWN_CreatePath(input, "/0")
+	JWN_SetWaveInWaveNote(input, "/0/results", {1})
+	// no x values
+	JWN_SetWaveInWaveNote(input, "/0/marker", {PSX_MARKER_REJECT})
+
+	// wv3
+	// histogram with no match as the tau values are out-of-range
+	Duplicate/FREE/T template, wv3
+	WAVE/T input = wv3
+
+	input[%prop]             = "tau"
+	input[%state]            = "undetermined"
+	input[%postProc]         = "hist"
+	input[%refNumOutputRows] = "0"
+	input[%numEventsCombo0]  = "3"
+	input[%numEventsCombo1]  = "0"
+	input[%outOfRange]       = "1"
+
+	// wv4
+	// histogram with match but cut out data
+	Duplicate/FREE/T template, wv4
+	WAVE/T input = wv4
+
+	input[%prop]             = "amp"
+	input[%state]            = "all"
+	input[%postProc]         = "hist"
+	input[%refNumOutputRows] = "1"
+	input[%numEventsCombo0]  = "3"
+	input[%numEventsCombo1]  = "0"
+	input[%outOfRange]       = "1"
+
+	JWN_CreatePath(input, "/0")
+	JWN_SetWaveInWaveNote(input, "/0/results", {1})
+	// no xValues
+	JWN_SetWaveInWaveNote(input, "/0/marker", {PSX_MARKER_REJECT})
+
+	// wv5
+	// stats ignores NaN
+	Duplicate/FREE/T template, wv5
+	WAVE/T input = wv5
+
+	input[%prop]             = "amp"
+	input[%state]            = "all"
+	input[%postProc]         = "stats"
+	input[%refNumOutputRows] = "1"
+	input[%numEventsCombo0]  = "2"
+	input[%numEventsCombo1]  = "2"
+	input[%outOfRange]       = "0"
+
+	JWN_CreatePath(input, "/0")
+	JWN_SetWaveInWaveNote(input, "/0/results", {10, NaN, 0, 0, NaN, NaN})
+	JWN_SetWaveInWaveNote(input, "/0/xValues", ListToTextWave(PSX_STATS_LABELS, ";"))
+	JWN_SetWaveInWaveNote(input, "/0/marker", {PSX_MARKER_REJECT, PSX_MARKER_REJECT, PSX_MARKER_REJECT, \
+	                                           PSX_MARKER_REJECT, PSX_MARKER_REJECT, PSX_MARKER_REJECT})
+
+	// wv6
+	// stats ignores NaN and with all data NaN we don't get anything
+	Duplicate/FREE/T template, wv6
+	WAVE/T input = wv6
+
+	input[%prop]             = "amp"
+	input[%state]            = "all"
+	input[%postProc]         = "stats"
+	input[%refNumOutputRows] = "0"
+	input[%numEventsCombo0]  = "1"
+	input[%numEventsCombo1]  = "1"
+	input[%outOfRange]       = "0"
+
+	// no results
+	// no xValues
+	// no marker
+
+	// wv7
+	// xinterval with multiple combos
+	Duplicate/FREE/T template, wv7
+	WAVE/T input = wv7
+
+	input[%prop]             = "xinterval"
+	input[%state]            = "accept"
+	input[%postProc]         = "nothing"
+	input[%refNumOutputRows] = "1"
+	input[%numEventsCombo0]  = "5"
+	input[%numEventsCombo1]  = "5"
+	input[%outOfRange]       = "0"
+
+	JWN_CreatePath(input, "/0")
+	JWN_SetWaveInWaveNote(input, "/0/results", {NaN, 20, NaN, 20})
+	JWN_SetWaveInWaveNote(input, "/0/xValues", {1, 3, 1, 3})
+	JWN_SetWaveInWaveNote(input, "/0/marker", {PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT, PSX_MARKER_ACCEPT})
+
+	// end
+	Make/FREE/WAVE results = {wv0, wv1, wv2, wv3, wv4, wv5, wv6, wv7}
+
+	return results
+End
+
+static Function/WAVE GetAllStatsProperties()
+
+	WAVE wv = MIES_PSX#PSX_GetAllStatsProperties()
+	CHECK_WAVE(wv, TEXT_WAVE)
+
+	SetDimensionLabelsFromWaveContents(wv)
+
+	return wv
+End
+
+static Function/WAVE GetKernelAmplitude()
+
+	Make/D/FREE wv = {5, -5}
+
+	return wv
+End
+
+static Function/WAVE SupportedPostProcForEventSelection()
+
+	// nonfinite is tested elsewhere
+	Make/FREE/T wv = {"nothing", "log10"}
+	SetDimensionLabels(wv, AddPrefixToEachListItem("PostProc=", TextWavetoList(wv, ";")), ROWS)
+
+	return wv
+End
+
+static Function/WAVE SupportedAxisModesForEventSelection()
+
+	Make/FREE wv = {MODIFY_GRAPH_LOG_MODE_NORMAL, MODIFY_GRAPH_LOG_MODE_LOG10, MODIFY_GRAPH_LOG_MODE_LOG2}
+	SetDimensionLabels(wv, "LeftAxis=linear;LeftAxis=log10;LeftAxis=log2", ROWS)
+
+	return wv
+End
+
+static Function/WAVE GetCodeVariations()
+
+	string code
+
+	Make/T/N=(3)/FREE wv
+
+	wv[0] = GetTestCode("nothing")
+	code  = ""
+
+	// one sweep per operation separated with `with`
+	code  = "psx(myId, psxKernel(select(selrange([50, 150]), selchannels(AD6), selsweeps([0]), selvis(all))), 2, 100, 0)"
+	code += "\r with \r"
+	code += "psx(myId, psxKernel(select(selrange([50, 150]), selchannels(AD6), selsweeps([2]), selvis(all))), 1.5, 100, 0)"
+	code += "\r and \r"
+	code += "psxStats(myId, select(selrange([50, 150]), selchannels(AD6), selsweeps([0, 2]), selvis(all)), peak, all, nothing)"
+	wv[1] = code
+	code  = ""
+
+	// same as code[1] but with a select array for stats
+	code  = "psx(myId, psxKernel(select(selrange([50, 150]), selchannels(AD6), selsweeps([0]), selvis(all))), 2, 100, 0)"
+	code += "\r with \r"
+	code += "psx(myId, psxKernel(select(selrange([50, 150]), selchannels(AD6), selsweeps([2]), selvis(all))), 1.5, 100, 0)"
+	code += "\r and \r"
+	code += "psxStats(myId, [select(selrange([50, 150]), selchannels(AD6), selsweeps([0]), selvis(all)), select(selrange([50, 150]), selchannels(AD6), selsweeps([2]), selvis(all))], peak, all, nothing)"
+	wv[2] = code
+	code  = ""
+
+	return wv
+End
+
+static Function/WAVE SomeTextWaves()
+
+	Make/WAVE/FREE/N=5 all
+
+	Make/FREE/T/N=0 wv1
+
+	// both empty and null roundtrip to an empty wave
+	all[0] = wv1
+	all[1] = $""
+
+	Make/FREE/T/N=(3, 3) wv2 = {{"1", "2", "3"}, {"4", "5", "6"}, {"7", "8", "9"}}
+	all[2] = wv2
+
+	Make/FREE/T/N=(2, 2, 2) wv3 = {{{"1", "2"}, {"3", "4"}}, {{"5", "6"}, {"7", "8"}}}
+	all[3] = wv3
+
+	Make/FREE/T/N=(2, 2, 2, 2) wv4 = {{{{"1", "2"}, {"3", "4"}}, {{"5", "6"}, {"7", "8"}}}, {{{"9", "10"}, {"11", "12"}}, {{"13", "14"}, {"15", "16"}}}}
+	all[4] = wv4
+
+	return all
+End
+
+static Function/WAVE STIW_TestAbortGetter()
+
+	Make/D/FREE data = {4, -1, 0.1, NaN, Inf, -Inf}
+	return data
+End
+
+static Function/WAVE GetValidStringsWithSweepNumber()
+
+	Make/FREE/T wv = {"Sweep_100", "Sweep_100_bak", "Config_Sweep_100", "Config_Sweep_100_bak", "X_100"}
+
+	return wv
+End
+
+static Function/WAVE GetInvalidStringsWithSweepNumber()
+
+	Make/FREE/T wv = {"", "A", "A__", "Sweep_-100"}
+
+	return wv
+End
+
+static Function/WAVE SupportedTypeGetter()
+
+	Make/FREE result = {IGOR_TYPE_32BIT_FLOAT, IGOR_TYPE_64BIT_FLOAT}
+
+	SetDimLabel 0, 0, $"float", result
+	SetDimLabel 0, 1, $"double", result
+
+	return result
+End
+
+static Function/WAVE WB_GatherStimsets()
+
+	string list
+
+	DFREF dfr = root:wavebuilder_misc:DAParameterWaves
+	list = GetListOfObjects(dfr, "WP_.*")
+	list = RemovePrefixFromListItem("WP_", list)
+	WAVE/T wv = ListToTextWave(list, ";")
+
+	SetDimensionLabels(wv, list, ROWS)
+
+	return wv
+End
+
+static Function/WAVE PAT_IncrementalSweepAdd_Generator()
+
+	Make/FREE/WAVE/N=4 w
+
+	Make/FREE sweeps = {0, 1, 2, 3, 4, 5}
+	w[0] = sweeps
+	Make/FREE sweeps = {5, 4, 3, 2, 1, 0}
+	w[1] = sweeps
+	Make/FREE sweeps = {2, 1, 5, 3, 4, 0}
+	w[2] = sweeps
+	Make/FREE sweeps = {4, 3, 5, 0, 1, 2}
+	w[3] = sweeps
+
+	return w
+End
+
+static Function/WAVE AllDatabrowserSubWindows()
+
+	string win
+
+	win = DB_OpenDatabrowser()
+
+	WAVE/Z/T allWindows = ListToTextWave(GetAllWindows(win), ";")
+	CHECK_WAVE(allWindows, TEXT_WAVE)
+
+	allWindows[] = StringFromList(1, allWindows[p], "#")
+
+	RemoveTextWaveEntry1D(allWindows, "", all = 1)
+
+	WAVE/Z/T allWindowsUnique = GetUniqueEntries(allWindows)
+	CHECK_WAVE(allWindowsUnique, TEXT_WAVE)
+
+	SetDimensionLabels(allWindowsUnique, TextWaveToList(allWindowsUnique, ";"), ROWS)
+
+	KillWindow $win
+
+	return allWindowsUnique
+End
+
+static Function/WAVE VariousInputForHasRequiredQCOrder()
+
+	// IPT_FORMAT_OFF
+
+	// all zero
+	Make/FREE firstQC      = {0, 0, 0, 0}
+	Make/FREE checkQCFirst = {0, 0, 0}
+	Make/FREE lastQC       = {0, 0, 0, 0}
+	Make/FREE checkQCLast  = {0, 0, 0}
+	Make/FREE result       = {0}
+
+	Make/FREE/WAVE wv0 = {firstQC, checkQCFirst, lastQC, checkQCLast, result}
+
+	// only first
+	Make/FREE firstQC      = {0, 0, 0, 0}
+	Make/FREE checkQCFirst = {1, 1, 1}
+	Make/FREE lastQC       = {0, 0, 0, 0}
+	Make/FREE checkQCLast  = {0, 0, 0}
+	Make/FREE result       = {0}
+
+	Make/FREE/WAVE wv1 = {firstQC, checkQCFirst, lastQC, checkQCLast, result}
+
+	// only last
+	Make/FREE firstQC      = {0, 0, 0, 0}
+	Make/FREE checkQCFirst = {0, 0, 0}
+	Make/FREE lastQC       = {0, 0, 0, 0}
+	Make/FREE checkQCLast  = {1, 1, 1}
+	Make/FREE result       = {0}
+
+	Make/FREE/WAVE wv2 = {firstQC, checkQCFirst, lastQC, checkQCLast, result}
+
+	// wrong order
+	Make/FREE firstQC      = {0, 1, 1, 0}
+	Make/FREE checkQCFirst = {0, 1, 0}
+	Make/FREE lastQC       = {0, 1, 1, 0}
+	Make/FREE checkQCLast  = {1, 0, 0}
+	Make/FREE result       = {0}
+
+	Make/FREE/WAVE wv3 = {firstQC, checkQCFirst, lastQC, checkQCLast, result}
+
+	// correct order
+	Make/FREE firstQC      = {0, 1, 1, 0}
+	Make/FREE checkQCFirst = {1, 0, 0}
+	Make/FREE lastQC       = {0, 1, 1, 0}
+	Make/FREE checkQCLast  = {0, 1, 0}
+	Make/FREE result       = {1}
+
+	Make/FREE/WAVE wv4 = {firstQC, checkQCFirst, lastQC, checkQCLast, result}
+
+	// correct order but last sweep failed
+	Make/FREE firstQC      = {0, 1, 0, 0}
+	Make/FREE checkQCFirst = {1, 0, 0}
+	Make/FREE lastQC       = {0, 1, 0, 0}
+	Make/FREE checkQCLast  = {0, 1, 0}
+	Make/FREE result       = {0}
+
+	Make/FREE/WAVE wv5 = {firstQC, checkQCFirst, lastQC, checkQCLast, result}
+
+	// correct order but first sweep failed
+	Make/FREE firstQC      = {0, 0, 0, 0}
+	Make/FREE checkQCFirst = {1, 0, 0}
+	Make/FREE lastQC       = {0, 0, 1, 0}
+	Make/FREE checkQCLast  = {0, 1, 0}
+	Make/FREE result       = {0}
+
+	Make/FREE/WAVE wv6 = {firstQC, checkQCFirst, lastQC, checkQCLast, result}
+
+	// passes with fail gap
+	Make/FREE firstQC      = {0, 0, 1, 0, 0}
+	Make/FREE checkQCFirst = {0, 1, 0, 0}
+	Make/FREE lastQC       = {0, 0, 0, 0, 1}
+	Make/FREE checkQCLast  = {0, 0, 0, 1}
+	Make/FREE result       = {1}
+
+	Make/FREE/WAVE wv7 = {firstQC, checkQCFirst, lastQC, checkQCLast, result}
+
+	// fails due to gap with firstQC passing
+	Make/FREE firstQC      = {0, 0, 1, 1, 0}
+	Make/FREE checkQCFirst = {0, 1, 0, 0}
+	Make/FREE lastQC       = {0, 0, 0, 0, 1}
+	Make/FREE checkQCLast  = {0, 0, 0, 1}
+	Make/FREE result       = {0}
+
+	Make/FREE/WAVE wv8 = {firstQC, checkQCFirst, lastQC, checkQCLast, result}
+
+	// fails due to gap with lastQC passing
+	Make/FREE firstQC      = {0, 1, 0, 0, 0}
+	Make/FREE checkQCFirst = {1, 0, 0, 0}
+	Make/FREE lastQC       = {0, 0, 1, 1, 0}
+	Make/FREE checkQCLast  = {0, 0, 1, 0}
+	Make/FREE result       = {0}
+
+	// IPT_FORMAT_ON
+
+	Make/FREE/WAVE wv9 = {firstQC, checkQCFirst, lastQC, checkQCLast, result}
+
+	Make/FREE/WAVE wv = {wv0, wv1, wv2, wv3, wv4, wv5, wv6, wv7, wv8, wv9}
+
+	return wv
+End
+
+static Function/WAVE VariousInputForCalculateFillinQC()
+
+	// all constant
+	Make/FREE DAScales = {1, 1, 1, 1}
+	Make/FREE ref = {0, 0, 0, 0}
+
+	Make/FREE/WAVE wv0 = {DAScales, ref}
+
+	// sorted
+	Make/FREE DAScales = {1, 2, 3, 4}
+	Make/FREE ref = {0, 0, 0, 0}
+
+	Make/FREE/WAVE wv1 = {DAScales, ref}
+
+	// reverse sorted
+	Make/FREE DAScales = {4, 3, 2, 1}
+	Make/FREE ref = {0, 1, 1, 1}
+
+	Make/FREE/WAVE wv2 = {DAScales, ref}
+
+	// first is largest
+	Make/FREE DAScales = {8, 4, 7, 6, 5}
+	Make/FREE ref = {0, 1, 1, 1, 1}
+
+	Make/FREE/WAVE wv3 = {DAScales, ref}
+
+	// complicated, smallest first
+	Make/FREE DAScales = {1, 4, 3, 6, 5}
+	Make/FREE ref = {0, 0, 1, 0, 1}
+
+	Make/FREE/WAVE wv4 = {DAScales, ref}
+
+	// complicated, middle one first
+	Make/FREE DAScales = {3, 4, 1, 6, 5}
+	Make/FREE ref = {0, 0, 1, 0, 1}
+
+	Make/FREE/WAVE wv5 = {DAScales, ref}
+
+	Make/FREE/WAVE wv = {wv0, wv1, wv2, wv3, wv4, wv5}
+
+	return wv
 End

--- a/Packages/tests/UTF_HardwareHelperFunctions.ipf
+++ b/Packages/tests/UTF_HardwareHelperFunctions.ipf
@@ -1342,7 +1342,7 @@ End
 /// \rst
 /// .. code-block:: igorpro
 ///
-///		/// UTF_TD_GENERATOR DeviceNameGeneratorMD1
+///		/// UTF_TD_GENERATOR DataGenerators#DeviceNameGeneratorMD1
 /// 	static Function MyTest([string str])
 ///
 ///			struct DAQSettings s

--- a/Packages/tests/UTF_HelperFunctions.ipf
+++ b/Packages/tests/UTF_HelperFunctions.ipf
@@ -1810,6 +1810,28 @@ threadsafe Function WaitRandomProcessingTime()
 	Sleep/S (millis * MILLI_TO_ONE)
 End
 
+// two sweeps in one operation
+Function/S GetTestCode(string postProc, [string eventState, string prop])
+
+	string code
+
+	if(ParamIsDefault(eventState))
+		eventState = "all"
+	endif
+
+	if(ParamIsDefault(prop))
+		prop = "peaktime"
+	endif
+
+	code = "psx(myId, psxKernel(select(selrange([50, 150]), selchannels(AD6), selsweeps([0, 2]), selvis(all))), 5, 100, 0)"
+
+	code  = "psx(myId, psxKernel(select(selrange([50, 150]), selchannels(AD6), selsweeps([0, 2]), selvis(all))), 1.5, 100, 0)"
+	code += "\r and \r"
+	code += "psxStats(myId, select(selrange([50, 150]), selchannels(AD6), selsweeps([0, 2]), selvis(all)), " + prop + ", " + eventState + ", " + postProc + ")"
+
+	return code
+End
+
 // Entry point for igortest
 Function run()
 

--- a/Packages/tests/UTF_TestNWBExportV2.ipf
+++ b/Packages/tests/UTF_TestNWBExportV2.ipf
@@ -745,7 +745,7 @@ Function TestNwbExportV2()
 	HDF5CloseFile/Z fileID
 End
 
-// UTF_TD_GENERATOR NWBVersionStrings
+// UTF_TD_GENERATOR DataGenerators#NWBVersionStrings
 Function TestNWBVersionStrings([string str])
 
 	variable version0, version1, version2
@@ -757,7 +757,7 @@ Function TestNWBVersionStrings([string str])
 	REQUIRE_NEQ_VAR(version1, NaN)
 End
 
-// UTF_TD_GENERATOR NeuroDataRefTree
+// UTF_TD_GENERATOR DataGenerators#NeuroDataRefTree
 Function TestNeuroDataRefTree([string str])
 
 	string neurodata_type, ancestry

--- a/tools/check-code.sh
+++ b/tools/check-code.sh
@@ -169,6 +169,15 @@ then
   ret=1
 fi
 
+matches=$(git grep $opts '^// I?UTF_TD_GENERATOR [^#]+$' '**/MIES_*.ipf' '**/UTF*.ipf')
+
+if [[ -n "$matches" ]]
+then
+  echo "All igortest data generator functions used with UTF_TD_GENERATORS must be static."
+  echo "$matches"
+  ret=1
+fi
+
 # ripgrep checks
 
 files=$(git ls-files '*.ipf' '*.sh' '*.rst' '*.dot' '*.md' ':!:**/releasenotes_template.rst' ':^*/IPA_Control.ipf')


### PR DESCRIPTION
This forces us to include the module name which makes the functions easier
to understand.

We also move all other data generators to this file.

Close #1668

Will merge once CI passes.