### PR TITLE
MIES_AnalysisBrowser.ipf: Show files with loaded file type

### DIFF
--- a/Packages/MIES/MIES_AnalysisBrowser.ipf
+++ b/Packages/MIES/MIES_AnalysisBrowser.ipf
@@ -3156,6 +3156,7 @@ Function AB_ButtonProc_AddFiles(STRUCT WMButtonAction &ba) : ButtonControl
 			endif
 			WAVE/T selFiles = ListToTextWave(fileList, "\r")
 			AB_AddFiles(ba.win, selFiles)
+			AB_CheckFileTypeCheckbox(ba.win, selFiles)
 			AB_CollapseAll()
 			break
 		default:
@@ -3163,6 +3164,34 @@ Function AB_ButtonProc_AddFiles(STRUCT WMButtonAction &ba) : ButtonControl
 	endswitch
 
 	return 0
+End
+
+static Function AB_CheckFileTypeCheckbox(string win, WAVE/T files)
+
+	variable numEntries
+	string   extension
+
+	WAVE/T folderList = GetAnalysisBrowserGUIFolderList()
+
+	numEntries = DimSize(folderList, ROWS)
+
+	if(numEntries == 0)
+		return NaN
+	endif
+
+	extension = GetFileSuffix(folderList[numEntries - 1])
+
+	strswitch(extension)
+		case "pxp": // fallthrough
+		case "uxp":
+			PGC_SetAndActivateControl(win, "check_load_pxp", val = CHECKBOX_SELECTED)
+			break
+		case "nwb":
+			PGC_SetAndActivateControl(win, "check_load_nwb", val = CHECKBOX_SELECTED)
+			break
+		default:
+			FATAL_ERROR("Unknown file type")
+	endswitch
 End
 
 static Function AB_AddFiles(string win, WAVE/T selFiles)


### PR DESCRIPTION
It can happen that a user selects NWB but then adds a PXP to the Analysis Browser. This then results in nothing being shown.

This is not very intuitive, so let's show the files from the currently loaded type.

Thanks for opening a PR in MIES :sparkles:!

- Code can only be merged if the continous integration tests pass
- [ ] Please ensure that the branch is named correctly. See
  [here](https://alleninstitute.github.io/MIES/developers.html#branch-naming-scheme) for the detailed explanation.
