### PR TITLE
monthly-scheduled.yml: Fix invalid option errror

### DIFF
--- a/.github/workflows/monthly-scheduled.yml
+++ b/.github/workflows/monthly-scheduled.yml
@@ -22,4 +22,5 @@ jobs:
         run: |
             git config gc.auto 1024
             git config gc.packLimit 10
-            git gc --auto --no-detach
+            git config gc.autoDetach false
+            git gc --auto


### PR DESCRIPTION
The version of git on the linux runner is 2.31.1 but the --no-detach is
rather recent (2.47). So let's use the config option instead.

Close #2474