### PR TITLE
PS_RemoveCoordinateSaving: Don't remove the window group

### DIFF
--- a/Packages/MIES/MIES_PackageSettings.ipf
+++ b/Packages/MIES/MIES_PackageSettings.ipf
@@ -213,7 +213,6 @@ Function PS_RemoveCoordinateSaving(string win)
 
 	SetWindow $win, userdata($PS_STORE_COORDINATES)=""
 	SetWindow $win, userdata($PS_WINDOW_NAME)=""
-	SetWindow $win, userdata($PS_WINDOW_GROUP)=""
 
 	SetWindow $win, hook($PS_COORDINATE_SAVING_HOOK)=$""
 End

--- a/Packages/MIES/MIES_WaveBuilderPanel.ipf
+++ b/Packages/MIES/MIES_WaveBuilderPanel.ipf
@@ -159,10 +159,6 @@ Function WBP_StartupSettings()
 
 	HideTools/A/W=$panel
 
-	// @todo workaround IP issue #7316
-	WAVE/Z wv = $""
-	ListBox listbox_combineEpochMap, listWave=wv, win=$panel
-
 	PS_RemoveCoordinateSaving(panel)
 
 	KillWindow/Z $WBP_GetFFTSpectrumPanel()
@@ -192,6 +188,7 @@ Function WBP_StartupSettings()
 	CallFunctionForEachListItem(WBP_AdjustDeltaControls, ControlNameList(panel, ";", "popup_WaveBuilder_op_*"))
 
 	SetWindow $panel, userdata(panelVersion)=""
+	ListBox listbox_combineEpochMap, listWave=$"", win=$panel
 
 	Execute/P/Q/Z "DoWindow/R " + panel
 	Execute/P/Q/Z "COMPILEPROCEDURES "


### PR DESCRIPTION
We need that to be set. Bug introduced in 91e7dcd
(MIES_PackageSettings.ipf: Enhance it, 2025-07-23).

Will merge once CI passed.