### PR TITLE
BeforeUncompiledHook: Ensure that all preemptive threads are stopped

### DIFF
--- a/Packages/MIES/MIES_IgorHooks.ipf
+++ b/Packages/MIES/MIES_IgorHooks.ipf
@@ -294,6 +294,8 @@ End
 
 static Function BeforeUncompiledHook(variable changeCode, string procedureWindowTitleStr, string textChangeStr)
 
+	variable ret
+
 	LOG_AddEntry(PACKAGE_MIES, "start")
 
 	// catch all error conditions, asserts and aborts
@@ -308,7 +310,11 @@ static Function BeforeUncompiledHook(variable changeCode, string procedureWindow
 	// dito
 	AssertOnAndClearRTError()
 	try
-		ASYNC_Stop(timeout = 5); AbortOnRTE
+		ret = ASYNC_Stop(timeout = 5); AbortOnRTE
+
+		if(ret) // error stopping it, stop all threads
+			ret = ThreadGroupRelease(-2)
+		endif
 	catch
 		ClearRTError()
 	endtry


### PR DESCRIPTION
When you do

killdataFolder root:packages

and then uncompile/recompile the code you get the message

Function module in use by preemptive threads. Kill the thread?

The reason is that ASYNC_Stop does not stop the async threads as it's tgID is gone. The only thing we can do is stopping/killing all threads before the IP popup tells us.
