### PR TITLE
tools/run-ipt.sh: Don't require the repository root as CWD

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -171,6 +171,7 @@ jobs:
     needs:
       - BuildInstaller
       - Linting
+      - Ipt
       - CompilationTest
     strategy:
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,6 @@ Packages/tests/**/*.nwb
 # intermediate test files
 rewritten_config.json
 CheckIfConfigurationRestoresMCCFilterGain.json
-config.toml
 
 # Renamed experiments during tests
 Packages/tests/**/20*.pxp

--- a/tools/initial-repo-config.sh
+++ b/tools/initial-repo-config.sh
@@ -21,6 +21,9 @@ fi
 git config --local filter.compress.clean "gzip -3 --no-name --stdout"
 git config --local filter.compress.smudge "gzip --decompress --stdout"
 
+# required so we get the expected line endings in the repo
+git config --local core.autocrlf false
+
 # remove Git index
 git read-tree --empty
 

--- a/tools/run-ipt.sh
+++ b/tools/run-ipt.sh
@@ -24,6 +24,7 @@ else
 fi
 
 config=$(pwd)/config.toml
+trap 'rm -f $config' SIGINT SIGQUIT SIGTSTP EXIT
 
 echo "[lint]" > $config
 

--- a/tools/run-ipt.sh
+++ b/tools/run-ipt.sh
@@ -23,12 +23,14 @@ else
   ipt="ipt"
 fi
 
-echo "[lint]" > config.toml
+config=$(pwd)/config.toml
 
-echo "noreturn-func=FATAL_ERROR|SFH_FATAL_ERROR|FAIL" >> config.toml
+echo "[lint]" > $config
+
+echo "noreturn-func=FATAL_ERROR|SFH_FATAL_ERROR|FAIL" >> $config
 
 while read -r line; do
-    echo "files = \"$line\"" >> config.toml
-done < <(git ls-files ':(attr:ipt)')
+    echo "files = \"$line\"" >> $config
+done < <(git ls-files --full-name ':(attr:ipt)')
 
-(cd $top_level && $ipt --arg-file config.toml lint -i)
+(cd $top_level && $ipt --arg-file $config lint -i)


### PR DESCRIPTION
We are now independent of the current working directory (CWD). The fixes
are having an absolute path to the config.toml and using the full path
relative to the repository root.