### PR TITLE
PS_ApplyStoredWindowCoordinate: Make it work with non-100% scaling

### DIFF
--- a/Packages/MIES/MIES_GuiUtilities.ipf
+++ b/Packages/MIES/MIES_GuiUtilities.ipf
@@ -2298,12 +2298,10 @@ Function ReflowNotebookText(string win)
 
 	variable width
 
-	GetWindow $win, wsizeDC
+	GetWindow $win, wsizeRM
 	width = V_right - V_left
 	// make it a bit shorter
 	width -= 10
-	// pixel -> points
-	width = width * (72 / ScreenResolution)
 	// redefine ruler
 	Notebook $win, ruler=Normal, rulerUnits=0, margins={0, 0, width}
 	// select everything

--- a/Packages/MIES/MIES_GuiUtilities.ipf
+++ b/Packages/MIES/MIES_GuiUtilities.ipf
@@ -1901,14 +1901,14 @@ End
 /// @brief Conversion between pixel <-> points
 ///
 ///@{
-Function PointsToPixel(variable var)
+Function PointsToPixel(string win, variable var)
 
-	return var * (ScreenResolution / 72)
+	return var * (ScreenResolution / PanelResolution(win))
 End
 
-Function PixelToPoints(variable var)
+Function PixelToPoints(string win, variable var)
 
-	return var * (72 / ScreenResolution)
+	return var * (PanelResolution(win) / ScreenResolution)
 End
 ///@}
 

--- a/Packages/MIES/MIES_PackageSettings.ipf
+++ b/Packages/MIES/MIES_PackageSettings.ipf
@@ -177,16 +177,16 @@ static Function PS_ApplyStoredWindowCoordinate(variable JSONid, string win, vari
 				// left, top, right, bottom
 				// coordinates are relative to [top, left] of the main window
 				case EXT_SUBWINDOW_ORIENTATION_BOTTOM:
-					MoveSubWindow/W=$win fnum=(0, 0, PointsToPixel(right - left), PointsToPixel(bottom - top)); AbortOnRTE
+					MoveSubWindow/W=$win fnum=(0, 0, PointsToPixel(win, right - left), PointsToPixel(win, bottom - top)); AbortOnRTE
 					break
 				case EXT_SUBWINDOW_ORIENTATION_TOP:
-					MoveSubWindow/W=$win fnum=(0, PointsToPixel(bottom - top), PointsToPixel(right - left), 0); AbortOnRTE
+					MoveSubWindow/W=$win fnum=(0, PointsToPixel(win, bottom - top), PointsToPixel(win, right - left), 0); AbortOnRTE
 					break
 				case EXT_SUBWINDOW_ORIENTATION_LEFT:
-					MoveSubWindow/W=$win fnum=(PointsToPixel(right - left), 0, 0, PointsToPixel(bottom - top)); AbortOnRTE
+					MoveSubWindow/W=$win fnum=(PointsToPixel(win, right - left), 0, 0, PointsToPixel(win, bottom - top)); AbortOnRTE
 					break
 				case EXT_SUBWINDOW_ORIENTATION_RIGHT:
-					MoveSubWindow/W=$win fnum=(0, 0, PointsToPixel(right - left), PointsToPixel(bottom - top)); AbortOnRTE
+					MoveSubWindow/W=$win fnum=(0, 0, PointsToPixel(win, right - left), PointsToPixel(win, bottom - top)); AbortOnRTE
 					break
 				default:
 					FATAL_ERROR("Unknown orientation")


### PR DESCRIPTION
When the Display Scaling is something like 125% we would increase the
subwindows on every save/restore cycle. The reason is that the scaling
factor of 72 in PointsToPixel/PixelToPoints is only correct for 100%
scaling. In order to support the panel expansion factor which can make the scaling per panel, we now use the scaling of the panel.

Close #2493

