### PR TITLE
Test/AutoTP_ClampModeChange: Adjust starting times

### DIFF
--- a/Packages/tests/HardwareBasic/UTF_AutoTestpulse.ipf
+++ b/Packages/tests/HardwareBasic/UTF_AutoTestpulse.ipf
@@ -308,8 +308,8 @@ static Function AutoTP_ClampModeChange([string str])
 	[STRUCT DAQSettings s] = AutoTP_GetDAQSettings(str)
 	AcquireData_NG(s, str)
 
-	CtrlNamedBackGround ChangeClampModeToVC, start=(ticks + 120), period=20, proc=ClampModeDuringTP_IGNORE
-	CtrlNamedBackGround StopTPAfterSomeTime, start=(ticks + 420), period=60, proc=StopTP_IGNORE
+	CtrlNamedBackGround ChangeClampModeToVC, start=(ticks + 60), period=60, proc=ClampModeDuringTP_IGNORE
+	CtrlNamedBackGround StopTPAfterSomeTime, start=(ticks + 600), period=60, proc=StopTP_IGNORE
 End
 
 static Function AutoTP_ClampModeChange_REENTRY([string str])


### PR DESCRIPTION
The test is currently flaky when run in succession via

runwithOpts(testcase = "AutoTP_SpecialCases;AutoTP_ClampModeChange")

Adjust the start times of the background tasks to avoid that.

Will merge once CI passed.
