### PR TITLE
MEN_OpenAboutDialog: Add comment about screen resolution calculations

### DIFF
--- a/Packages/MIES/MIES_Menu.ipf
+++ b/Packages/MIES/MIES_Menu.ipf
@@ -107,6 +107,7 @@ Function MEN_OpenAboutDialog()
 		return NaN
 	endif
 
+	// rescale the sizes as the panel was designed with 100% scaling
 	sfactor = ScreenResolution / 96
 	NewPanel/N=$panel/K=1/W=(332 / sfactor, 252 / sfactor, 928 / sfactor, 724 / sfactor) as "About MIES"
 


### PR DESCRIPTION
In 89a5194d2a (OpenAboutDialog: Scale the panel and notebook actions correctly, 2020-08-09) we added a rescaling of the original panel sizes and contents. On a recent discussion with Michael Huth, it came up that this code looks fishy as it has hardcoded the 96 (aka 100% scaling).

But that makes sense here as the panel was designed with 100% and then get's resized.

This might not be the best possible code, but it is working.
