### PR TITLE
CONF_RestoreDAEphys: Don't output mixed forward and backward slashes

### DIFF
--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -692,6 +692,8 @@ Function/S CONF_RestoreDAEphys(variable jsonID, string fullFilePath, [variable m
 
 		StimSetPath = CONF_GetStringFromSettings(jsonID, EXPCONFIG_JSON_STIMSET_NAME)
 		StimSetPath = HFSPathToNative(StimSetPath)
+		// @todo workaround IP issue #7584 in ParseFilePath
+		StimSetPath = ReplaceString(":/\\", StimSetPath, ":/")
 		if(!IsEmpty(StimSetPath))
 			ASSERT(FileExists(StimSetPath), "Specified StimSet file at " + StimSetPath + " not found!", extendedOutput = 0)
 			err = NWB_LoadAllStimSets(overwrite = 1, fileName = StimSetPath)


### PR DESCRIPTION
When setting the stimset path with forward slashes in the JSON configuration HFSPathToNative, and also the more appropriate ParseFilePath(5, "*", 0, 0) do output mixed slashes.

Workaround it with a plain string replacement.

Close #2514