### PR TITLE
treewide: Provide an absolute path for cmd.exe

### DIFF
--- a/Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf
+++ b/Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf
@@ -254,11 +254,12 @@ End
 /// @return zero on success, aborts on failure
 static Function ExecuteGitForMIESVersion(string gitPathOrName, string gitDir, string topDir, string fullVersionPath)
 
-	string cmd, userName
+	string cmd, userName, shellPath
 
 	gitPathOrName = HFSPathToNative(gitPathOrName)
 	gitDir        = HFSPathToNative(gitDir)
 	topDir        = HFSPathToNative(topDir)
+	shellPath     = GetCmdPath()
 
 	// git is installed, try to regenerate version.txt
 	DEBUGPRINT("Found git at: ", str = gitPathOrName)
@@ -270,22 +271,22 @@ static Function ExecuteGitForMIESVersion(string gitPathOrName, string gitDir, st
 #if defined(WINDOWS)
 	// explanation:
 	// cmd /C "<full path to git.exe> --git-dir=<mies repository .git> describe <options> redirect everything into <mies respository>/version.txt"
-	sprintf cmd, "cmd.exe /C \"\"%s\" --git-dir=\"%s\" describe --always --tags --match \"Release_*\" > \"%sversion.txt\" 2>&1\"", gitPathOrName, gitDir, topDir
+	sprintf cmd, "%s /C \"\"%s\" --git-dir=\"%s\" describe --always --tags --match \"Release_*\" > \"%sversion.txt\" 2>&1\"", shellPath, gitPathOrName, gitDir, topDir
 	DEBUGPRINT("Cmd to execute: ", str = cmd)
 	ExecuteScriptText/B/Z cmd
 	ASSERT(!V_flag, "We have git installed but could not regenerate version.txt")
 
-	sprintf cmd, "cmd.exe /C \"echo | set /p=\"Date and time of last commit: \" >> \"%sversion.txt\" 2>&1\"", topDir
+	sprintf cmd, "%s /C \"echo | set /p=\"Date and time of last commit: \" >> \"%sversion.txt\" 2>&1\"", shellPath, topDir
 	DEBUGPRINT("Cmd to execute: ", str = cmd)
 	ExecuteScriptText/B/Z cmd
 	ASSERT(!V_flag, "We have git installed but could not regenerate version.txt")
 
-	sprintf cmd, "cmd.exe /C \"\"%s\" --git-dir=\"%s\" log -1 --pretty=format:%%cI%%n >> \"%sversion.txt\" 2>&1\"", gitPathOrName, gitDir, topDir
+	sprintf cmd, "%s /C \"\"%s\" --git-dir=\"%s\" log -1 --pretty=format:%%cI%%n >> \"%sversion.txt\" 2>&1\"", shellPath, gitPathOrName, gitDir, topDir
 	DEBUGPRINT("Cmd to execute: ", str = cmd)
 	ExecuteScriptText/B/Z cmd
 	ASSERT(!V_flag, "We have git installed but could not regenerate version.txt")
 
-	sprintf cmd, "cmd.exe /C \"echo Submodule status: >> \"%sversion.txt\" 2>&1\"", topDir
+	sprintf cmd, "%s /C \"echo Submodule status: >> \"%sversion.txt\" 2>&1\"", shellPath, topDir
 	DEBUGPRINT("Cmd to execute: ", str = cmd)
 	ExecuteScriptText/B/Z cmd
 	ASSERT(!V_flag, "We have git installed but could not regenerate version.txt")
@@ -293,7 +294,7 @@ static Function ExecuteGitForMIESVersion(string gitPathOrName, string gitDir, st
 	// git submodule status can not be used here as submodule is currently a sh script and executing that with --git-dir does not work
 	// but we can use the helper command which outputs a slightly uglier version, but is much faster
 	// the submodule helper is shipped with git 2.7 and later, therefore its failed execution is not fatal
-	sprintf cmd, "cmd.exe /C \"\"%s\" --git-dir=\"%s\" submodule--helper status >> \"%sversion.txt\" 2>&1\"", gitPathOrName, gitDir, topDir
+	sprintf cmd, "%s /C \"\"%s\" --git-dir=\"%s\" submodule--helper status >> \"%sversion.txt\" 2>&1\"", shellPath, gitPathOrName, gitDir, topDir
 	DEBUGPRINT("Cmd to execute: ", str = cmd)
 	ExecuteScriptText/B/Z cmd
 #elif defined(MACINTOSH)

--- a/Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf
+++ b/Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf
@@ -271,7 +271,7 @@ static Function ExecuteGitForMIESVersion(string gitPathOrName, string gitDir, st
 #if defined(WINDOWS)
 	// explanation:
 	// cmd /C "<full path to git.exe> --git-dir=<mies repository .git> describe <options> redirect everything into <mies respository>/version.txt"
-	sprintf cmd, "%s /C \"\"%s\" --git-dir=\"%s\" describe --always --tags --match \"Release_*\" > \"%sversion.txt\" 2>&1\"", shellPath, gitPathOrName, gitDir, topDir
+	sprintf cmd, "%s /C \"\"%s\" --git-dir=\"%s\" describe --always --dirty --broken --tags --match \"Release_*\" > \"%sversion.txt\" 2>&1\"", shellPath, gitPathOrName, gitDir, topDir
 	DEBUGPRINT("Cmd to execute: ", str = cmd)
 	ExecuteScriptText/B/Z cmd
 	ASSERT(!V_flag, "We have git installed but could not regenerate version.txt")

--- a/Packages/MIES/MIES_Utilities_File.ipf
+++ b/Packages/MIES/MIES_Utilities_File.ipf
@@ -846,3 +846,9 @@ Function OpenExplorerAtFile(string fullFilePath)
 
 	ExecuteScriptText/Z cmdLine
 End
+
+/// @brief Return the absolute path to cmd.exe
+Function/S GetCmdPath()
+
+	return GetEnvironmentVariable("COMSPEC")
+End

--- a/Packages/tests/HistoricData/UTF_HistoricDataHelpers.ipf
+++ b/Packages/tests/HistoricData/UTF_HistoricDataHelpers.ipf
@@ -45,13 +45,14 @@ End
 /// @param file name of the uncompressed file
 Function CompressFile(string file)
 
-	string folder, cmd
+	string folder, cmd, shellPath
 
-	folder = GetInputPath()
+	folder    = GetInputPath()
+	shellPath = GetCmdPath()
 
 	ASSERT(FileExists(folder + file), "Missing file for compression: " + folder + file)
 
-	sprintf cmd, "cmd.exe /C %s..\\..\..\\..\\tools\\zstd.exe -f --check --ultra -22 -k %s -o %s", GetWindowsPath(folder), GetWindowsPath(folder + file), GetWindowsPath(folder + file + ZSTD_SUFFIX)
+	sprintf cmd, "%s /C %s..\\..\..\\..\\tools\\zstd.exe -f --check --ultra -22 -k %s -o %s", shellPath, GetWindowsPath(folder), GetWindowsPath(folder + file), GetWindowsPath(folder + file + ZSTD_SUFFIX)
 	ExecuteScriptText/B/Z cmd
 	ASSERT(!V_flag, "Compression error: " + S_Value)
 End
@@ -61,14 +62,15 @@ End
 /// @param file name of the **uncompressed** file
 Function DecompressFile(string file)
 
-	string cmd, folder, compPath
+	string cmd, folder, compPath, shellPath
 
-	folder = GetInputPath()
+	folder    = GetInputPath()
+	shellPath = GetCmdPath()
 
 	compPath = folder + file + ZSTD_SUFFIX
 	ASSERT(FileExists(compPath), "Missing file for decompression: " + compPath)
 
-	sprintf cmd, "cmd.exe /C %s..\\..\..\\..\\tools\\zstd.exe -f --check --decompress %s -o %s", GetWindowsPath(folder), GetWindowsPath(compPath), GetWindowsPath(folder + file)
+	sprintf cmd, "%s /C %s..\\..\..\\..\\tools\\zstd.exe -f --check --decompress %s -o %s", shellPath, GetWindowsPath(folder), GetWindowsPath(compPath), GetWindowsPath(folder + file)
 	ExecuteScriptText/B/Z cmd
 	ASSERT(!V_flag, "Decompression error: " + S_Value)
 End


### PR DESCRIPTION
Igor Pro needs to search for an executable if we don't pass in an absolute path. On some rig machines with ~10 entries in the PATH variable this can take a significant amount of time.

Let's use an absolute path instead. We also do use the COMSPEC environment variable for the unlikely case that Windows is not installed on C:\Windows.

Gathering the MIES version from git now takes 400ms on rig8.