### PR TITLE
AD_SelectResult: Do nothing without bound device

### DIFF
--- a/Packages/MIES/MIES_AnalysisFunctions_Dashboard.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_Dashboard.ipf
@@ -1233,6 +1233,10 @@ static Function AD_SelectResult(string win)
 	string bspPanel, list
 	variable numEntries, i
 
+	if(!BSP_HasBoundDevice(win))
+		return NaN
+	endif
+
 	bspPanel = BSP_GetPanel(win)
 
 	DFREF dfr = BSP_GetFolder(win, MIES_BSP_PANEL_FOLDER)


### PR DESCRIPTION
Since ce3089dd (Force setting disabled checkboxes during control configuration, 2025-09-15) we also set controls which are disabled with the JSON configuration.

This made the RestoreAndSaveConfiguration test fail [1] as that checks the Passed/Failed checkboxes for the Databrowser dashboard which in turn calls AD_SelectResult.

Teach AD_SelectResult to not do anything without bound device.

[1]: https://github.com/AllenInstitute/MIES/actions/runs/18236758301/job/51935043869
