### PR TITLE
AI_SendToAmp: Use correct scaling for published amplifier values

### DIFF
--- a/Packages/MIES/MIES_AmplifierInteraction.ipf
+++ b/Packages/MIES/MIES_AmplifierInteraction.ipf
@@ -1666,7 +1666,7 @@ End
 /// @returns return value (for getters, respects `usePrefixes`), success (`0`) or error (`NaN`).
 static Function AI_SendToAmp(string device, variable headStage, variable mode, variable func, variable accessType, [variable checkBeforeWrite, variable usePrefixes, variable selectAmp, variable value])
 
-	variable ret, headstageMode, scale
+	variable ret, headstageMode, scale, nonScaledValue
 	string str
 
 	ASSERT(func > MCC_BEGIN_INVALID_FUNC && func < MCC_END_INVALID_FUNC, "MCC function constant is out for range")
@@ -1718,6 +1718,7 @@ static Function AI_SendToAmp(string device, variable headStage, variable mode, v
 	sprintf str, "headStage=%d, mode=%d, func=%d, value(passed)=%g, scale=%g\r", headStage, mode, func, value, scale
 	DEBUGPRINT(str)
 
+	nonScaledValue = value
 	value *= scale
 
 	if(checkBeforeWrite)
@@ -1752,7 +1753,7 @@ static Function AI_SendToAmp(string device, variable headStage, variable mode, v
 	endswitch
 
 	if(accessType == MCC_WRITE)
-		PUB_AmplifierSettingChange(device, headstage, mode, func, value)
+		PUB_AmplifierSettingChange(device, headstage, mode, func, nonScaledValue)
 	endif
 
 	if(!IsFinite(ret))

--- a/Packages/MIES/MIES_Publish.ipf
+++ b/Packages/MIES/MIES_Publish.ipf
@@ -976,6 +976,8 @@ End
 ///    }
 ///
 /// \endrst
+///
+/// The parameter `value` requires MIES units (SI units with prefixes, so `mV` instead of `V`).
 Function PUB_AmplifierSettingChange(string device, variable headstage, variable mode, variable func, variable value)
 
 	variable jsonID

--- a/Packages/tests/HardwareBasic/UTF_ConfigurationHardware.ipf
+++ b/Packages/tests/HardwareBasic/UTF_ConfigurationHardware.ipf
@@ -101,7 +101,7 @@ End
 static Function CheckIfConfigurationRestoresMCCFilterGain([string str])
 
 	string rewrittenConfig, fName, path
-	variable val, gain, filterFreq, headStage, jsonID
+	variable val, gain, filterFreq, headStage, jsonID, biasCurrent
 
 	PrepareForPublishTest()
 
@@ -113,6 +113,15 @@ static Function CheckIfConfigurationRestoresMCCFilterGain([string str])
 	                             "__HS1_DA1_AD1_CM:IC:_ST:StimulusSetB_DA_0:")
 
 	AcquireData_NG(s, str)
+
+	biasCurrent = 123
+	PGC_SetAndActivateControl(str, "setvar_DataAcq_Hold_IC", val = biasCurrent)
+
+	jsonID = FetchAndParseMessage(AMPLIFIER_SET_VALUE)
+	path = "/amplifier action/BiasCurrent"
+	CHECK_EQUAL_STR(JSON_GetString(jsonID, path + "/unit"), "pA")
+	CHECK_EQUAL_VAR(JSON_GetVariable(jsonID, path + "/value"), biasCurrent)
+	JSON_Release(jsonID)
 
 	gain       = 5
 	filterFreq = 6


### PR DESCRIPTION
In f944d8329d (MIES_Publish.ipf: Add AMPLIFIER_SET_VALUE, 2025-02-26) we added support for publishing changed amplifier values.

And we tried hard to use the correct units as we also sent the units, e.g. pA for the bias current. But we did send the scaled values (without prefixes in MCC application scaling).

This was not caught in the test CheckIfConfigurationRestoresMCCFilterGain as the amplifier value there uses a scaling of 1, see AI_GetMCCScale() for MCC_PRIMARYSIGNALLPF_FUNC.

So we now pass the unscaled value to PUB_AmplifierSettingChange and use a amplifier value in the test with a scaling of unequal to 1.

Close #2544
