### PR TITLE
.pre-commit-config.yaml: Use inplace autofixing for IPT

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
                ACL_UserdataEditor.ipf|
                ZeroMQ_Interop.ipf
                )
-      entry: ./tools/run-ipt.sh lint --noreturn-func=FATAL_ERROR|SFH_FATAL_ERROR|FAIL
+      entry: ./tools/run-ipt.sh lint -i --noreturn-func=FATAL_ERROR|SFH_FATAL_ERROR|FAIL
 - repo: local
   hooks:
     - id: custom-check-code

--- a/Packages/MIES/MIES_ForeignFunctionInterface.ipf
+++ b/Packages/MIES/MIES_ForeignFunctionInterface.ipf
@@ -317,7 +317,7 @@ End
 Function FFI_TestPulseMDSingleResult(string device, variable action)
 
 	variable ret
-	string errorMsg
+	string   errorMsg
 
 	[ret, errorMsg] = FFI_TestPulseMD(device, action)
 

--- a/Packages/MIES/MIES_TestPulse_Multi.ipf
+++ b/Packages/MIES/MIES_TestPulse_Multi.ipf
@@ -210,7 +210,7 @@ Function TPM_BkrdTPFuncMD(STRUCT BackgroundStruct &s)
 						HW_NI_StopAcq(deviceID)
 						HW_NI_PrepareAcq(deviceID, TEST_PULSE_MODE)
 						HW_StartAcq(HARDWARE_NI_DAC, deviceID, triggerMode = HARDWARE_DAC_DEFAULT_TRIGGER)
-						tpCounter = 0
+						tpCounter           = 0
 						lastAcqStartTimeUTC = ParseIsO8601TimeStamp(RoStr(GetLastAcquisitionStartTime(device)))
 					endif
 				while(checkAgain)


### PR DESCRIPTION
Forgotten in the port in e0374e11be (.pre-commit-config.yaml: Integrate IPT linting, 2025-10-04)

And only with that do we get failing CI [1].

So let's fix the formatting as well.

[1]: https://github.com/AllenInstitute/MIES/actions/runs/18791986367/job/53624247621