### PR TITLE
treewide: Fix formatting

### DIFF
--- a/Packages/MIES/MIES_AmplifierInteraction.ipf
+++ b/Packages/MIES/MIES_AmplifierInteraction.ipf
@@ -1719,7 +1719,7 @@ static Function AI_SendToAmp(string device, variable headStage, variable mode, v
 	DEBUGPRINT(str)
 
 	nonScaledValue = value
-	value *= scale
+	value         *= scale
 
 	if(checkBeforeWrite)
 		ret = AI_ReadFromMCC(func)

--- a/Packages/tests/HardwareBasic/UTF_ConfigurationHardware.ipf
+++ b/Packages/tests/HardwareBasic/UTF_ConfigurationHardware.ipf
@@ -118,7 +118,7 @@ static Function CheckIfConfigurationRestoresMCCFilterGain([string str])
 	PGC_SetAndActivateControl(str, "setvar_DataAcq_Hold_IC", val = biasCurrent)
 
 	jsonID = FetchAndParseMessage(AMPLIFIER_SET_VALUE)
-	path = "/amplifier action/BiasCurrent"
+	path   = "/amplifier action/BiasCurrent"
 	CHECK_EQUAL_STR(JSON_GetString(jsonID, path + "/unit"), "pA")
 	CHECK_EQUAL_VAR(JSON_GetVariable(jsonID, path + "/value"), biasCurrent)
 	JSON_Release(jsonID)


### PR DESCRIPTION
Forgotten in e6a96b5e08 (.pre-commit-config.yaml: Use inplace autofixing for IPT, 2025-10-24).
