### PR TITLE
updates to how rig config files are recognized

### DIFF
--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -378,7 +378,7 @@ Function CONF_AutoLoader()
 	numMain = DimSize(mainFileList, ROWS)
 	nRigs   = DimSize(rigFileList, ROWS)
 	if(numMain <= 0)
-		printf "The %s folder.\r only contains rig specific file(s)", EXPCONFIG_SETTINGS_FOLDER
+		printf "The %s folder only contains rig specific file(s).\r", EXPCONFIG_SETTINGS_FOLDER
 		ControlWindowToFront()
 		Abort
 	endif


### PR DESCRIPTION
To work with the [new method](https://github.com/AllenInstitute/icp_rig_configurations/tree/MIES_config/Main) of distributing configuration files on production rigs, the configuration code that recognizes the _rig file was adapted such that the file name no longer needs to be an exact match with the main da_ephys config file name plus the suffix "_rig.json". Instead, the rig file name needs only contain the main da_ephys config file name.
