### PR TITLE
CONF_AutoLoader: Be more lenient with rig file naming

### DIFF
--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -329,7 +329,7 @@ End
 Function CONF_AutoLoader([string customIPath])
 
 	variable i, numFiles
-	string rigCandidate
+	string rigCandidate, pattern
 
 	if(ParamIsDefault(customIPath))
 		WAVE/Z/T rawFileList = CONF_GetConfigFiles()
@@ -347,12 +347,16 @@ Function CONF_AutoLoader([string customIPath])
 	Sort mainFileList, mainFileList
 	numFiles = DimSize(mainFileList, ROWS)
 	for(i = 0; i < numFiles; i += 1)
-		rigCandidate = mainFileList[i]
-		rigCandidate = rigCandidate[0, strlen(rigCandidate) - 6] + EXPCONFIG_RIGFILESUFFIX
-		FindValue/TXOP=4/TEXT=rigCandidate rigFileList
-		if(V_Value == -1)
+		pattern = "^.*" + "\Q" + GetBaseName(mainFileList[i]) + "\E" + ".*" + "\Q" + EXPCONFIG_RIGFILESUFFIX + "\E$"
+		WAVE/Z/T result = GrepTextWave(rigFileList, pattern)
+
+		if(WaveExists(result))
+			ASSERT(DimSize(result, ROWS) == 1, "Expected at most one rig file per main configuration file")
+			rigCandidate = result[0]
+		else
 			rigCandidate = ""
 		endif
+
 		CONF_RestoreWindow(mainFileList[i], rigFile = rigCandidate)
 	endfor
 End


### PR DESCRIPTION
The new naming scheme for JSON configuration files used in MIES [1] has files like 1_daephys.json and 1_daephys1_rig.json. But this is currently not supported as the main filename needs match the rig file name exactly.

Be more lenient and just required that the basename of the main file is included in the rig file.
