### PR TITLE
SF_FormulaPlotter: Avoid assertion when mixing colorgroup and non-colorgroup operations

### DIFF
--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -347,7 +347,8 @@ static Function/WAVE SF_GetColorGroups(WAVE/WAVE formulaResults, WAVE/Z colorGro
 	refColorGroup = JWN_GetNumberFromWaveNote(data, SF_META_COLOR_GROUP)
 
 	if(IsNaN(refColorGroup))
-		return colorGroups
+		// current formula does not use color groups
+		return $""
 	endif
 
 	Make/FREE/N=(numFormulas)/D newColorGroups = JWN_GetNumberFromWaveNote(formulaResults[p][%FORMULAY], SF_META_COLOR_GROUP)

--- a/Packages/tests/Basic/UTF_SweepFormula.ipf
+++ b/Packages/tests/Basic/UTF_SweepFormula.ipf
@@ -2234,13 +2234,13 @@ static Function TestTraceColors()
 	TestTraceColor(graph, traces, 0, {7967, 7710, 7710})
 	TestTraceColor(graph, traces, 1, {60395, 52685, 15934})
 
-	code    = "data(select(selchannels(AD6)))\r with\r data(select(selchannels(AD6)))"
+	code    = "data(select(selchannels(AD6)))\r with\r data(select(selchannels(AD6)))\r with\r 1"
 	winBase = ExecuteSweepFormulaCode(win, code)
 
 	graph = winBase + "#Graph0"
 
 	traces = TraceNameList(graph, ";", 1 + 2)
-	CHECK_EQUAL_VAR(ItemsInList(traces), 2)
+	CHECK_EQUAL_VAR(ItemsInList(traces), 3)
 
 	// color groups:
 	// black
@@ -2249,6 +2249,9 @@ static Function TestTraceColors()
 	// and
 	// yellow
 	TestTraceColor(graph, traces, 1, {59110, 40863, 0})
+
+	// and red (as default color) as `1` does not have a color group
+	TestTraceColor(graph, traces, 2, {65535, 0, 0})
 End
 
 // UTF_TD_GENERATOR DataGenerators#DG_SourceLocationsBrackets


### PR DESCRIPTION


The sweepformula code

data()
with
1

with at least one sweep displayed, bugs out with an assertion in SF_GetTraceColor that the colorIndex is invalid for the second formula (1).

This is because we do have a color group for data, but not for 1.

Now we have two options:
- We can fake a color group for 1
- Or we don't use a color group for 1

This commit choose the latter option as that is more correct.

Close #2572 