### PR TITLE
treewide: Don't treat abort codes like error codes

### DIFF
--- a/Packages/MIES/MIES_Async.ipf
+++ b/Packages/MIES/MIES_Async.ipf
@@ -260,7 +260,7 @@ Function ASYNC_ThreadReadOut()
 		catch
 			msg = GetRTErrMessage()
 			ASSERT(!ClearRTError(), "ReadOut function " + RFunc + " encountered an RTE: " + msg)
-			ASSERT(!V_AbortCode, "ReadOut function " + RFunc + " aborted with code: " + GetErrMessage(V_AbortCode))
+			ASSERT(!V_AbortCode, "ReadOut function " + RFunc + " aborted with code: " + num2str(V_AbortCode))
 		endtry
 
 	endfor

--- a/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
+++ b/Packages/MIES/MIES_NeuroDataWithoutBorders.ipf
@@ -383,7 +383,7 @@ Function NWB_ASYNC_Readout(STRUCT ASYNC_ReadOutStruct &ar)
 		BUG("Async jobs finished with RTE: " + ar.rtErrMsg)
 	endif
 	if(ar.abortCode)
-		BUG("Async jobs finished with Abort: " + GetErrMessage(ar.abortCode))
+		BUG("Async jobs finished with Abort: " + num2str(ar.abortCode))
 	endif
 End
 

--- a/Packages/MIES/MIES_TestPulse.ipf
+++ b/Packages/MIES/MIES_TestPulse.ipf
@@ -323,7 +323,7 @@ Function TP_ROAnalysis(STRUCT ASYNC_ReadOutStruct &ar)
 
 	if(ar.rtErr || ar.abortCode)
 		ASSERT(!ar.rtErr, "TP analysis thread encountered RTE " + ar.rtErrMsg)
-		ASSERT(!ar.abortCode, "TP analysis thread aborted with code: " + GetErrMessage(ar.abortCode))
+		ASSERT(!ar.abortCode, "TP analysis thread aborted with code: " + num2str(ar.abortCode))
 	endif
 
 	DFREF dfr = ar.dfr


### PR DESCRIPTION
When code aborts and this is caught in a try-catch statement Igor Pro sets the V_AbortCode variable.

This gives a value, see the IgorAbortCodes doxygen group, which denotes what type of abort was issued.

But the abort codes are nothing which can be fed to GetErrMessage as these only take error codes from runtime errors.

Close #2577