### PR TITLE
SF: Remove scale copy for Min and Max

### DIFF
--- a/Packages/MIES/MIES_SweepFormula_Operations.ipf
+++ b/Packages/MIES/MIES_SweepFormula_Operations.ipf
@@ -1469,8 +1469,6 @@ static Function/WAVE SFO_OperationMaxImpl(WAVE/Z input)
 	SFH_ASSERT(WaveDims(input) <= 2, "max accepts only upto 2d data")
 	SFH_ASSERT(DimSize(input, ROWS) > 0, "max requires at least one data point")
 	MatrixOP/FREE out = maxCols(input)^t
-	CopyScales input, out
-	SetScale/P x, DimOffset(out, ROWS), DimDelta(out, ROWS), "", out
 	SF_FormulaWaveScaleTransfer(input, out, COLS, ROWS)
 
 	return out
@@ -1539,8 +1537,6 @@ static Function/WAVE SFO_OperationMinImpl(WAVE/Z input)
 	SFH_ASSERT(WaveDims(input) <= 2, "min accepts only upto 2d data")
 	SFH_ASSERT(DimSize(input, ROWS) > 0, "min requires at least one data point")
 	MatrixOP/FREE out = minCols(input)^t
-	CopyScales input, out
-	SetScale/P x, DimOffset(out, ROWS), DimDelta(out, ROWS), "", out
 
 	SF_FormulaWaveScaleTransfer(input, out, COLS, ROWS)
 

--- a/Packages/tests/Basic/UTF_SweepFormula_Operations.ipf
+++ b/Packages/tests/Basic/UTF_SweepFormula_Operations.ipf
@@ -487,8 +487,18 @@ static Function TestOperationMinMax()
 	// note: TestOperationMinMaxHelper calls GetSingleResult that verifies that [1,2] is evaluated as single argument
 	TestOperationMinMaxHelper(win, "{\"min\":[[1,2]]}", "min([1,2])", 1)
 
+	// Check DimOffset/unit removal
+	Make/O/D/N=(1) input = p
+	SetScale/P x, 10, 10, "unit", input
+	wavePath = GetWavesDataFolder(input, 2)
+	str      = "min(wave(" + wavePath + "))"
+	WAVE data = SFE_ExecuteFormula(str, win, singleResult = 1, useVariables = 0)
+	CHECK_EQUAL_VAR(DimOffset(data, ROWS), 0)
+	str = WaveUnits(data, ROWS)
+	CHECK_EMPTY_STR(str)
+
 	// check limit to 2d waves for min, max, avg
-	Make/D/N=(2, 2, 2) input = p + 2 * q + 4 * r
+	Make/O/D/N=(2, 2, 2) input = p + 2 * q + 4 * r
 	wavePath = GetWavesDataFolder(input, 2)
 	str      = "min(wave(" + wavePath + "))"
 	try


### PR DESCRIPTION
The scale copy resulted in a DimOffset of the resulting wave that equaled the DimOffset of the input.
This had drawbacks:
- The result of max or min is only a single data point and the offset was not the position of the maximum. This was originally also possible as a 2D sweep data block might have different max positions per sweep. Now with sweep data in datasets this would be possible but see the next point
- When further processing the data a different x-offset for the max value can pose issues, e.g. when averaging with x-offset awareness. The result is that the values are not averaged, but instead distributed along x. This is unintended for these cases.

Thus, it is better to clear any x-scaling/x-offset for the result. As MatrixOP sets the DimOffset/DimDelta/Unit in the new output wave to Igor defaults, it is sufficient to remove the scale transfer.

Since
2542bdf2 (SF: Adapt operation min to waveRef approach, 2022-06-03)
