### PR TITLE
CONF_RestoreDAEphys: Fix path conversion

### DIFF
--- a/Packages/MIES/MIES_Configuration.ipf
+++ b/Packages/MIES/MIES_Configuration.ipf
@@ -693,9 +693,7 @@ Function/S CONF_RestoreDAEphys(variable jsonID, string fullFilePath, [variable m
 		endif
 
 		StimSetPath = CONF_GetStringFromSettings(jsonID, EXPCONFIG_JSON_STIMSET_NAME)
-		StimSetPath = HFSPathToNative(StimSetPath)
-		// @todo workaround IP issue #7584 in ParseFilePath
-		StimSetPath = ReplaceString(":/\\", StimSetPath, ":/")
+		StimSetPath = GetWindowsPath(StimSetPath)
 		if(!IsEmpty(StimSetPath))
 			ASSERT(FileExists(StimSetPath), "Specified StimSet file at " + StimSetPath + " not found!", extendedOutput = 0)
 			err = NWB_LoadAllStimSets(overwrite = 1, fileName = StimSetPath)

--- a/Packages/MIES/MIES_Utilities_File.ipf
+++ b/Packages/MIES/MIES_Utilities_File.ipf
@@ -164,6 +164,10 @@ End
 /// @brief Return the path converted to a windows style path
 threadsafe Function/S GetWindowsPath(string path)
 
+	// forward slashes to backslashes
+	// @todo workaround IP issue #7584 in ParseFilePath
+	path = ReplaceString("/", path, "\\")
+
 	return ParseFilepath(5, path, "\\", 0, 0)
 End
 

--- a/Packages/tests/Basic/UTF_Utils_File.ipf
+++ b/Packages/tests/Basic/UTF_Utils_File.ipf
@@ -11,7 +11,6 @@
 // GetBaseName
 // GetFileSuffix
 // GetFile
-// GetWindowsPath
 // GetHFSPath
 // GetUniqueSymbolicPath
 // AskUserForExistingFolder
@@ -389,4 +388,21 @@ static Function TestResolveAlias()
 
 	KillPath $symbPath
 	CHECK_NO_RTE()
+End
+
+static Function TestGetWindowsPath()
+
+	string windowsPath = "C:\\windows\\system.ini"
+
+	// backward aka idempotent
+	CHECK_EQUAL_STR(windowsPath, GetWindowsPath(windowsPath))
+
+	// forward
+	CHECK_EQUAL_STR(windowsPath, GetWindowsPath("C:/windows/system.ini"))
+
+	// mixed
+	CHECK_EQUAL_STR(windowsPath, GetWindowsPath("C:/windows\\system.ini"))
+
+	// colon (HFS)
+	CHECK_EQUAL_STR(windowsPath, GetWindowsPath("C:windows:system.ini"))
 End


### PR DESCRIPTION
In cf0030f1b7 (CONF_RestoreDAEphys: Don't output mixed forward and backward slashes, 2025-10-02) we added a hacky solution for not having mixed forward/backward slashes in filenames.

This did not work for some cases. So let's get a working solution in GetWindowsPath, test that and use it.

Close #2514