### PR TITLE
SFH_ExecuteFormulaInternal: Remove it

### DIFF
--- a/Packages/MIES/MIES_SweepFormula_Helpers.ipf
+++ b/Packages/MIES/MIES_SweepFormula_Helpers.ipf
@@ -2178,27 +2178,6 @@ Function/WAVE SFH_GetDatasetArrayAsResolvedWaverefs(STRUCT SF_ExecutionData &exd
 	return dataFromEachGroup
 End
 
-/// @brief Executes a formula from within an operation with low overhead
-///        - the currently active variable storage is used
-///        - the formula string is not preprocessed
-Function/WAVE SFH_ExecuteFormulaInternal(string graph, string formula)
-
-	STRUCT SF_ExecutionData exd
-	variable jsonId, srcLocId
-
-	exd.graph          = graph
-	[jsonId, srcLocId] = SFP_ParseFormulaToJSON(formula)
-	exd.jsonId         = jsonId
-	WAVE dataRef = SFE_FormulaExecutor(exd, srcLocId = srcLocId)
-
-	JSON_Release(exd.jsonId)
-	JSON_Release(srcLocId)
-
-	WAVE resolved = SF_ResolveDataset(dataRef)
-
-	return resolved
-End
-
 /// @brief Adds a variable to the variable storage. If the variable already exists it is overwritten.
 Function SFH_AddVariableToStorage(string graph, string name, WAVE result)
 


### PR DESCRIPTION
This was superseeded by f0f72670b0 (SFH: Add option to SFE_ExecuteFormula to execute a formula unpreprocessed, 2026-02-12) but forgotten to be removed.
