### PR TITLE
Reset data acquisition start button when aborting DAQ during indexing/RA

### DIFF
--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -3615,7 +3615,7 @@ End
 ///
 /// @param device device
 /// @param mode       One of @ref ToggleAcquisitionButtonConstants
-Function DAP_ToggleAcquisitionButton(string device, variable mode)
+static Function DAP_ToggleAcquisitionButton(string device, variable mode)
 
 	ASSERT(mode == DATA_ACQ_BUTTON_TO_STOP || mode == DATA_ACQ_BUTTON_TO_DAQ, "Invalid mode")
 

--- a/Packages/MIES/MIES_DataAcquisition_Multi.ipf
+++ b/Packages/MIES/MIES_DataAcquisition_Multi.ipf
@@ -219,6 +219,8 @@ End
 /// @param device      device
 /// @param initialSetupReq [optional, defaults to true] performs initialization routines
 ///                        at the very beginning of DAQ, turn off for RA
+///
+/// @return 0 on success, 1 if aborted
 Function DQM_StartDAQMultiDevice(string device, [variable initialSetupReq])
 
 	variable ADCConfig
@@ -242,11 +244,9 @@ Function DQM_StartDAQMultiDevice(string device, [variable initialSetupReq])
 	catch
 		if(initialSetupReq)
 			DAP_OneTimeCallAfterDAQ(device, DQ_STOP_REASON_CONFIG_FAILED, forcedStop = 1)
-		else // required for RA
-			DQ_StopDAQDeviceTimer(device)
 		endif
 
-		return NaN
+		return 1
 	endtry
 
 	// configure passed device
@@ -256,6 +256,8 @@ Function DQM_StartDAQMultiDevice(string device, [variable initialSetupReq])
 
 	DAP_UpdateITIAcrossSets(device, maxITI)
 	DQM_BkrdDataAcq(device)
+
+	return 0
 End
 
 /// @brief Start the background timer for the inter trial interval (ITI)

--- a/Packages/MIES/MIES_MiesUtilities_Recreation.ipf
+++ b/Packages/MIES/MIES_MiesUtilities_Recreation.ipf
@@ -42,7 +42,18 @@ Function RecreateMissingSweepAndConfigWaves(string device, DFREF deviceDataDFR)
 	WAVE/Z sweepsFromText = GetSweepsWithSetting(textualValues, "SweepNum")
 
 	// consistency check
-	ASSERT(WaveExists(sweepsFromNum) && WaveExists(sweepsFromText) && EqualWaves(sweepsFromNum, sweepsFromText, EQWAVES_DATA), "Unexpected numerical/textual LBN entries")
+	ASSERT(WaveExists(sweepsFromNum) && WaveExists(sweepsFromText), "Could not find the SweepNum column in the numerical/textual labnotebook")
+
+	if(EqualWaves(sweepsFromNum, sweepsFromText, EQWAVES_DATA))
+		// do nothing
+	elseif(DimSize(sweepsFromNum, ROWS) == (DimSize(sweepsFromText, ROWS) + 1))
+		// it is okay if we have more sweeps in the numerical labnotebook than the textual one
+		// iff the additional entry is for the DAQ stop reason
+		WAVE/Z values = GetSweepsWithSetting(numericalValues, "DAQ stop reason")
+		ASSERT(WaveMax(values) == sweepsFromNum[Inf], "Additional sweeps in the numerical labnotebook need to be from \"DAQ stop reason\"")
+	else
+		FATAL_ERROR("Inconsistent sweep numbers from numerical and textual labnotebook")
+	endif
 
 	WAVE sweeps = sweepsFromNum
 

--- a/Packages/MIES/MIES_RepeatedAcquisition.ipf
+++ b/Packages/MIES/MIES_RepeatedAcquisition.ipf
@@ -113,7 +113,7 @@ static Function RA_HandleITI(string device)
 			aborted = RA_WaitUntiIITIDone(device, ITI)
 
 			if(aborted)
-				RA_FinishAcquisition(device, forcedStop = 1)
+				RA_FinishAcquisition(device, stopReason = DQ_STOP_REASON_ESCAPE_KEY, forcedStop = 1)
 			else
 				ExecuteListOfFunctions(funcList)
 			endif
@@ -133,7 +133,7 @@ static Function RA_HandleITI(string device)
 		TP_Teardown(device)
 
 		if(aborted)
-			RA_FinishAcquisition(device, forcedStop = 1)
+			RA_FinishAcquisition(device, stopReason = DQ_STOP_REASON_ESCAPE_KEY, forcedStop = 1)
 		else
 			ExecuteListOfFunctions(funcList)
 		endif
@@ -226,16 +226,21 @@ Function RA_Counter(string device)
 			endif
 		catch
 			ClearRTError()
-			RA_FinishAcquisition(device, forcedStop = 1)
+			RA_FinishAcquisition(device, stopReason = DQ_STOP_REASON_CONFIG_FAILED, forcedStop = 1)
 		endtry
 	else
 		RA_FinishAcquisition(device)
 	endif
 End
 
-static Function RA_FinishAcquisition(string device, [variable forcedStop])
+static Function RA_FinishAcquisition(string device, [variable stopReason, variable forcedStop])
 
 	forcedStop = ParamIsDefault(forcedStop) ? 0 : !!forcedStop
+
+	if(ParamIsDefault(stopReason))
+		ASSERT(!forcedStop, "Need to supply a stop reason for forced stop")
+		stopReason = DQ_STOP_REASON_FINISHED
+	endif
 
 	DQ_StopDAQDeviceTimer(device)
 
@@ -243,7 +248,7 @@ static Function RA_FinishAcquisition(string device, [variable forcedStop])
 	RA_PerfFinish(device)
 #endif // PERFING_RA
 
-	DAP_OneTimeCallAfterDAQ(device, DQ_STOP_REASON_FINISHED, forcedStop = forcedStop)
+	DAP_OneTimeCallAfterDAQ(device, stopReason, forcedStop = forcedStop)
 End
 
 static Function RA_BckgTPwithCallToRACounter(string device)
@@ -314,7 +319,7 @@ Function RA_CounterMD(string device)
 		aborted = DQM_StartDAQMultiDevice(device, initialSetupReq = 0)
 
 		if(aborted)
-			RA_FinishAcquisition(device, forcedStop = 1)
+			RA_FinishAcquisition(device, stopReason = DQ_STOP_REASON_CONFIG_FAILED, forcedStop = 1)
 		endif
 	else
 		RA_FinishAcquisition(device)

--- a/Packages/MIES/MIES_RepeatedAcquisition.ipf
+++ b/Packages/MIES/MIES_RepeatedAcquisition.ipf
@@ -281,7 +281,7 @@ End
 
 Function RA_CounterMD(string device)
 
-	variable numTotalSweeps
+	variable numTotalSweeps, aborted
 	NVAR count          = $GetCount(device)
 	NVAR activeSetCount = $GetActiveSetCount(device)
 	variable i, runMode
@@ -311,7 +311,11 @@ Function RA_CounterMD(string device)
 	numTotalSweeps = RA_GetTotalNumberOfSweeps(device)
 
 	if(count < numTotalSweeps)
-		DQM_StartDAQMultiDevice(device, initialSetupReq = 0)
+		aborted = DQM_StartDAQMultiDevice(device, initialSetupReq = 0)
+
+		if(aborted)
+			RA_FinishAcquisition(device, forcedStop = 1)
+		endif
 	else
 		RA_FinishAcquisition(device)
 	endif

--- a/Packages/MIES/MIES_RepeatedAcquisition.ipf
+++ b/Packages/MIES/MIES_RepeatedAcquisition.ipf
@@ -113,7 +113,7 @@ static Function RA_HandleITI(string device)
 			aborted = RA_WaitUntiIITIDone(device, ITI)
 
 			if(aborted)
-				RA_FinishAcquisition(device)
+				RA_FinishAcquisition(device, forcedStop = 1)
 			else
 				ExecuteListOfFunctions(funcList)
 			endif
@@ -133,7 +133,7 @@ static Function RA_HandleITI(string device)
 		TP_Teardown(device)
 
 		if(aborted)
-			RA_FinishAcquisition(device)
+			RA_FinishAcquisition(device, forcedStop = 1)
 		else
 			ExecuteListOfFunctions(funcList)
 		endif
@@ -226,14 +226,16 @@ Function RA_Counter(string device)
 			endif
 		catch
 			ClearRTError()
-			RA_FinishAcquisition(device)
+			RA_FinishAcquisition(device, forcedStop = 1)
 		endtry
 	else
 		RA_FinishAcquisition(device)
 	endif
 End
 
-static Function RA_FinishAcquisition(string device)
+static Function RA_FinishAcquisition(string device, [variable forcedStop])
+
+	forcedStop = ParamIsDefault(forcedStop) ? 0 : !!forcedStop
 
 	DQ_StopDAQDeviceTimer(device)
 
@@ -241,7 +243,7 @@ static Function RA_FinishAcquisition(string device)
 	RA_PerfFinish(device)
 #endif // PERFING_RA
 
-	DAP_OneTimeCallAfterDAQ(device, DQ_STOP_REASON_FINISHED)
+	DAP_OneTimeCallAfterDAQ(device, DQ_STOP_REASON_FINISHED, forcedStop = forcedStop)
 End
 
 static Function RA_BckgTPwithCallToRACounter(string device)

--- a/Packages/MIES/MIES_WaveBuilder.ipf
+++ b/Packages/MIES/MIES_WaveBuilder.ipf
@@ -1931,7 +1931,7 @@ End
 /// @brief Update the shorthand/stimset wave for the epoch type `Combine`
 ///
 /// The rows are sorted by creationDate of the WP/stimset wave to try to keep
-/// the shorthands constants even when new stimsets are added.
+/// the shorthands constant even when new stimsets are added.
 Function WB_UpdateEpochCombineList(WAVE/T epochCombineList, variable channelType)
 
 	string list, setPath, setParamPath, entry

--- a/Packages/tests/HardwareBasic/UTF_BasicHardwareTests.ipf
+++ b/Packages/tests/HardwareBasic/UTF_BasicHardwareTests.ipf
@@ -2544,3 +2544,23 @@ static Function GetDataLimitsCheckWorks_REENTRY([string str])
 	DAScaleLimit = DAP_GetDAScaleMax(str, headstage, stimset, 0)
 	CHECK(IsNaN(DAScaleLimit))
 End
+
+// UTF_TD_GENERATOR v0:DataGenerators#SingleMultiDeviceDAQ
+// UTF_TD_GENERATOR s0:DataGenerators#DeviceNameGenerator
+static Function AnalysisFunctionNotCalledForAbortedIndexing([STRUCT IUTF_MDATA &md])
+
+	ST_SetStimsetParameter("AnaFuncIdx2_DA_0", "Amplitude", epochIndex = 0, var = 10e3)
+
+	STRUCT DAQSettings s
+	InitDAQSettingsFromString(s, "MD" + num2str(md.v0) + "_RA1_I1_L0_BKG1"                         + \
+	                             "__HS0_DA0_AD0_CM:IC:_ST:AnaFuncIdx1_DA_0:_IST:AnaFuncIdx2_DA_0:" + \
+	                             "_AF:FailPostDAQ:_IAF:FailPostDAQ:")
+	AcquireData_NG(s, md.s0)
+End
+
+// UTF_TD_GENERATOR v0:DataGenerators#SingleMultiDeviceDAQ
+// UTF_TD_GENERATOR s0:DataGenerators#DeviceNameGenerator
+static Function AnalysisFunctionNotCalledForAbortedIndexing_REENTRY([STRUCT IUTF_MDATA &md])
+
+	CheckDAQStopReason(md.s0, DQ_STOP_REASON_CONFIG_FAILED)
+End

--- a/Packages/tests/UserAnalysisFunctions.ipf
+++ b/Packages/tests/UserAnalysisFunctions.ipf
@@ -1151,3 +1151,15 @@ Function LastSweepInSetWithoutSkip(string device, STRUCT AnalysisFunction_V3 &s)
 	values[INDEP_HEADSTAGE] = AFH_LastSweepInSet(device, s.sweepNo, s.headstage, s.eventType)
 	ED_AddEntryToLabnotebook(device, key, values, overrideSweepNo = s.sweepNo)
 End
+
+Function FailPostDAQ(string device, STRUCT AnalysisFunction_V3 &s)
+
+	switch(s.eventType)
+		case POST_DAQ_EVENT:
+			FAIL()
+			break
+		default:
+			break
+		// do nothing
+	endswitch
+End


### PR DESCRIPTION
While at it I also fixed the DAQ stop reason when aborting RA.

Close #2651