### PR TITLE
SF_CollectPreviousPlotProperties: Fix it

### DIFF
--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -724,12 +724,24 @@ End
 static Function SF_CollectPreviousPlotProperties(string win, WAVE/WAVE prevPlotProperties, variable mode)
 
 	variable restoreCursorInfo, idx
+	string winOrSub
 
-	if(WindowExists(win))
-		Make/FREE/T name = {win}
-		WAVE/Z/T axes     = GetAxesProperties(win)
-		WAVE/Z/T cursors  = GetCursorInfos(win)
-		WAVE/Z/T annoInfo = GetAnnotationInfo(win)
+	if(!WindowExists(win))
+		return 0
+	endif
+
+	WAVE/T allWindows = ListToTextWave(GetAllWindows(GetMainWindow(win)), ";")
+
+	for(winOrSub : allWindows)
+
+		if(WinType(winOrSub) != WINTYPE_GRAPH)
+			continue
+		endif
+
+		Make/FREE/T name = {winOrSub}
+		WAVE/Z/T axes     = GetAxesProperties(winOrSub)
+		WAVE/Z/T cursors  = GetCursorInfos(winOrSub)
+		WAVE/Z/T annoInfo = GetAnnotationInfo(winOrSub)
 
 		if(WaveExists(cursors) && mode == SF_DM_SUBWINDOWS)
 			restoreCursorInfo = 1
@@ -742,7 +754,7 @@ static Function SF_CollectPreviousPlotProperties(string win, WAVE/WAVE prevPlotP
 		prevPlotProperties[idx][%CURSORS]     = cursors
 		prevPlotProperties[idx][%ANNOTATIONS] = annoInfo
 		SetNumberInWaveNote(prevPlotProperties, NOTE_INDEX, idx + 1)
-	endif
+	endfor
 
 	return restoreCursorInfo
 End
@@ -1323,9 +1335,8 @@ static Function/S SF_CreateDataDisplayWindow(string graph, WAVE/WAVE formulaResu
 		winIndex = GetNumberFromWaveNote(winGraphs, NOTE_INDEX)
 	endif
 	win = SF_GetDataDisplayWindowName(graph, displayType, mode, winIndex)
-	if(!isTableWindow)
-		restoreCursorInfo = SF_CollectPreviousPlotProperties(win, prevPlotProperties, mode)
-	endif
+
+	restoreCursorInfo = SF_CollectPreviousPlotProperties(win, prevPlotProperties, mode)
 
 	if(mode == SF_DM_NORMAL)
 		if(displayType == SF_DISPLAYTYPE_TABLE)

--- a/Packages/tests/Basic/UTF_SweepFormula.ipf
+++ b/Packages/tests/Basic/UTF_SweepFormula.ipf
@@ -1173,6 +1173,94 @@ static Function TestPlottingWithTablesNormal()
 	CHECK_GE_VAR(WhichListItem("mode(x)=3", recMacro), 0)
 End
 
+// UTF_TD_GENERATOR DataGenerators#SweepFormulaWindowModes
+static Function TestPlottingInfoRestore([variable var])
+
+	string sweepBrowser, baseName
+	string code, tracename, cursorInfo, annoInfo, axInfo, firstWin, secondWin
+	variable windowMode = var
+
+	sweepBrowser = CreateFakeSweepBrowser_IGNORE()
+	DFREF dfr = BSP_GetFolder(sweepBrowser, MIES_BSP_PANEL_FOLDER)
+	baseName = MIES_SF#SF_GetFormulaWinNameTemplate(sweepBrowser)
+
+	code = "[1, 3, 4]\r and\r [2, 3] vs [4,5]"
+
+	MIES_SF#SF_FormulaPlotter(sweepBrowser, code, dmMode = windowMode)
+
+	if(windowMode == SF_DM_NORMAL)
+		firstWin  = baseName + "graph0"
+		secondWin = baseName + "graph1"
+	else
+		firstWin  = baseName + "graph#graph0"
+		secondWin = baseName + "graph#graph1"
+	endif
+
+	INFO(firstWin)
+	CHECK(WindowExists(firstWin))
+
+	INFO(secondWin)
+	CHECK(WindowExists(secondWin))
+
+	ShowInfo/CP=1/W=$GetMainWindow(firstWin)
+	tracename = StringFromList(0, TraceNameList(firstwin, ";", 1 + 2))
+	Cursor/W=$firstwin C, $tracename, 2
+	Cursor/W=$firstwin D, $tracename, 1
+
+	Legend/C/W=$firstwin/N=$SF_ANNOTATION_NAME/X=30/Y=60
+
+	// adapt left axis viewport
+	SetAxis/W=$firstwin left, 2.5, 3.5
+
+	ShowInfo/CP=2/W=$GetMainWindow(secondWin)
+	tracename = StringFromList(0, TraceNameList(secondWin, ";", 1 + 2))
+	Cursor/P/W=$secondWin E, $tracename, 1
+	Cursor/P/W=$secondWin F, $tracename, 0
+	Legend/C/W=$secondWin/N=$SF_ANNOTATION_NAME/X=40/Y=90
+
+	// cheat, so that the user selection is kept
+	SVAR lastCode = $GetLastSweepFormulaCode(dfr)
+	lastCode = code
+
+	// now plot it again
+	MIES_SF#SF_FormulaPlotter(sweepBrowser, code, dmMode = windowMode)
+
+	// and check cursor and annotation positions
+
+	cursorInfo = CsrInfo(C, firstWin)
+	INFO(cursorInfo)
+	CHECK_EQUAL_VAR(NumberByKey("POINT", cursorInfo), 2)
+
+	cursorInfo = CsrInfo(D, firstWin)
+	INFO(cursorInfo)
+	CHECK_EQUAL_VAR(NumberByKey("POINT", cursorInfo), 1)
+
+	annoInfo = StringByKey("FLAGS", AnnotationInfo(firstWin, SF_ANNOTATION_NAME))
+
+	CHECK_EQUAL_VAR(NumberByKey("X", annoInfo, "=", "/"), 30)
+	CHECK_EQUAL_VAR(NumberByKey("Y", annoInfo, "=", "/"), 60)
+
+	axInfo = AxisInfo(firstWin, "left")
+	INFO(axInfo)
+	CHECK_EQUAL_STR(StringByKey("SETAXISCMD", axInfo), "SetAxis left 2.5,3.5")
+
+	cursorInfo = CsrInfo(E, secondWin)
+	INFO(cursorInfo)
+	CHECK_EQUAL_VAR(NumberByKey("POINT", cursorInfo), 1)
+
+	cursorInfo = CsrInfo(F, secondWin)
+	INFO(cursorInfo)
+	CHECK_EQUAL_VAR(NumberByKey("POINT", cursorInfo), 0)
+
+	annoInfo = StringByKey("FLAGS", AnnotationInfo(secondWin, SF_ANNOTATION_NAME))
+
+	INFO(annoInfo)
+	CHECK_EQUAL_VAR(NumberByKey("X", annoInfo, "=", "/"), 40)
+
+	INFO(annoInfo)
+	CHECK_EQUAL_VAR(NumberByKey("Y", annoInfo, "=", "/"), 90)
+End
+
 static Function TestSFPreprocessor()
 
 	string input, output

--- a/Packages/tests/UTF_DataGenerators.ipf
+++ b/Packages/tests/UTF_DataGenerators.ipf
@@ -2073,3 +2073,12 @@ static Function/WAVE GetEmptyWavesOfAllTypes()
 
 	return waveRefs
 End
+
+Function/WAVE SweepFormulaWindowModes()
+
+	Make/FREE wv = {SF_DM_NORMAL, SF_DM_SUBWINDOWS}
+
+	SetDimensionLabels(wv, "Normal;Subwindows", ROWS)
+
+	return wv
+End


### PR DESCRIPTION
This is broken since 0964909 (Merge pull request #2592 from AllenInstitute/feature/2592-refactor_sf_plotter2, 2025-12-17) where we refactored the plotting internals.

For the default mode of SF_DM_SUBWINDOWS we need to iterate over all existing subwindows and store the plot properties before we kill them later via SF_ClearPlotPanel.

The check for table or not is now also included in SF_CollectPreviousPlotProperties.

In order to not regress again also a test is now added for both display modes.

Close #2661 

Will merge once CI has passed.