### PR TITLE
AI_FindConnectedAmps: Only output hints for interactive use

### DIFF
--- a/Packages/MIES/MIES_AmplifierInteraction.ipf
+++ b/Packages/MIES/MIES_AmplifierInteraction.ipf
@@ -2116,6 +2116,7 @@ Function AI_QueryGainsFromMCC(string device)
 	return numConnAmplifiers
 End
 
+/// @brief Return the number of connected amplifiers
 Function AI_FindConnectedAmps([variable rescanHardware])
 
 	string key
@@ -2151,6 +2152,10 @@ Function AI_FindConnectedAmps([variable rescanHardware])
 			CA_StoreEntryIntoCache(key, cache)
 		endif
 	endif
+
+	ASSERT(DimSize(telegraphServers, ROWS) == DimSize(ampMCC, ROWS), "Non-matched number of amplifiers")
+
+	return DimSize(telegraphServers, ROWS)
 End
 
 /// @brief Create the amplifier connection waves
@@ -2173,11 +2178,6 @@ static Function [WAVE telegraphServers, WAVE ampMCC] AI_FindConnectedAmpsNoCache
 	SetDataFolder saveDFR
 
 	list = DAP_FormatTelegraphServerList(telegraphServers)
-
-	if(IsEmpty(list))
-		print "Activate Multiclamp Commander software to populate list of available amplifiers"
-		ControlWindowToFront()
-	endif
 
 	LOG_AddEntry(PACKAGE_MIES, "amplifiers", keys = {"list"}, values = {list})
 

--- a/Packages/MIES/MIES_DAEphys.ipf
+++ b/Packages/MIES/MIES_DAEphys.ipf
@@ -1791,7 +1791,10 @@ Function DAP_ButtonCtrlFindConnectedAmps(STRUCT WMButtonAction &ba) : ButtonCont
 
 	switch(ba.eventcode)
 		case 2: // mouse up
-			AI_FindConnectedAmps(rescanHardware = 1)
+			if(AI_FindConnectedAmps(rescanHardware = 1) == 0)
+				print "Activate Multiclamp Commander software to populate list of available amplifiers"
+				ControlWindowToFront()
+			endif
 			break
 		default:
 			break


### PR DESCRIPTION
Since 8a5ea2efdc (removed bug in query of connected amps in hardware tab - now works when no amps are connected, 2014-01-13) we output a hint message to the history when we could not find any amplifiers.

While this makes sense for interactive use, this is a bit distracting when using JSON configuration files.

Let's only warn when rescanning for amplifiers.

Close #2677
