### PR TITLE
PSQ_DS_CalculateMaxSlope: Handle non-existing result from PSQ_DS_FilterPassingData

### DIFF
--- a/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
@@ -3808,9 +3808,13 @@ static Function PSQ_DS_CalculateMaxSlope(WAVE fitSlopes, WAVE apfreq, variable m
 
 	passingMinCount[] = (apfreq[p] >= minimumSpikeCountForMaxSlope)
 
-	WAVE fitSlopesFiltered = PSQ_DS_FilterPassingData(fitSlopes, passingMinCount, inbetween = 1)
+	WAVE/Z fitSlopesFiltered = PSQ_DS_FilterPassingData(fitSlopes, passingMinCount, inbetween = 1)
 
-	return WaveMax(fitSlopesFiltered)
+	if(WaveExists(fitSlopesFiltered))
+		return WaveMax(fitSlopesFiltered)
+	endif
+
+	return NaN
 End
 
 static Structure PSQ_DS_DAScaleParams

--- a/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
+++ b/Packages/MIES/MIES_AnalysisFunctions_PatchSeq.ipf
@@ -3608,7 +3608,7 @@ static Function/WAVE PSQ_DS_GetPassingRheobaseSweeps(WAVE numericalValues, varia
 	// we don't need to check PSQ_FMT_LBN_SAMPLING_PASS here as failing that always makes the whole SCI fail
 	allQC[] = baselineQC[p] && asyncQC[p]
 
-	WAVE passingSweeps = PSQ_DS_FilterPassingData(sweeps, allQC)
+	WAVE/Z passingSweeps = PSQ_DS_FilterPassingData(sweeps, allQC)
 
 	return passingSweeps
 End
@@ -3653,8 +3653,10 @@ static Function/WAVE PSQ_DS_GetPassingRhSuAdSweepsAndStoreInLBN(string device, v
 	else
 		WAVE numericalValues = GetLBNumericalValues(device)
 
-		WAVE passingRheobaseSweeps = PSQ_DS_GetPassingRheobaseSweeps(numericalValues, passingRheobaseSweep, headstage)
-		WAVE passingSupraSweeps    = PSQ_DS_GetPassingDAScaleSweeps(numericalValues, passingSupraSweep, headstage)
+		WAVE/Z passingRheobaseSweeps = PSQ_DS_GetPassingRheobaseSweeps(numericalValues, passingRheobaseSweep, headstage)
+		ASSERT(WaveExists(passingRheobaseSweeps), "Expected passing rheobase sweeps")
+		WAVE/Z passingSupraSweeps = PSQ_DS_GetPassingDAScaleSweeps(numericalValues, passingSupraSweep, headstage)
+		ASSERT(WaveExists(passingSupraSweeps), "Expected passing supra sweeps")
 
 		Concatenate/NP=(ROWS)/FREE {passingRheobaseSweeps, passingSupraSweeps, passingAdSweepsFailSet}, sweeps
 	endif


### PR DESCRIPTION
We have a report with the following lingering RTE:

```
{"action":"report"
"exp":"2026_03_18_170048"
"id":"71bec88"
"msg":"Encountered pending RTE: 2
 WaveMax;expected wave name"
"source":"ReportBugToLogfile"
"stacktrace":[
  "DAP_ButtonProc_TPDAQ(...)#L4028 [MIES_DAEphys.ipf]"
  "DQM_StartDAQMultiDevice(...)#L239 [MIES_DataAcquisition_Multi.ipf]"
  "DC_Configure(...)#L75 [MIES_DataConfigurator.ipf]"
  "AFM_CallAnalysisFunctions(...)#L166 [MIES_AnalysisFunctionManagement.ipf]"
  "PSQ_DAScale(...)#L4496 [MIES_AnalysisFunctions_PatchSeq.ipf]"
  "ED_AddEntryToLabnotebook(...)#L388 [MIES_ExperimentDocumentation.ipf]"
  "ED_AddEntriesToLabnotebook(...)#L71 [MIES_ExperimentDocumentation.ipf]"
  "ED_createWaveNotes(...)#L300 [MIES_ExperimentDocumentation.ipf]"
  "AssertOnAndClearRTError(...)#L45 [MIES_Utilities_ProgramFlow.ipf]"
  "BUG_TS(...)#L575 [MIES_Debugging.ipf]"
  "ReportBugToLogfile(...)#L531 [MIES_Debugging.ipf]"
  "LOG_AddEntry(...)#L157 [MIES_Logging.ipf]"]
"ts":"2026-03-18T18:03:45.777-07:00"}
```

which uses MIES version Release_2.9_20250502-749-g1c9279590.

The code in question calls PSQ_DS_CalculateMaxSlope before which uses
PSQ_DS_FilterPassingData which can return a null wave.

Fix that by returning NaN instead. This is also what WaveMax($") gives.