### PR TITLE
Bugfix: Change amp storage row label for button_DataAcq_WCAuto to empty string

### DIFF
--- a/Packages/MIES/MIES_AmplifierInteraction.ipf
+++ b/Packages/MIES/MIES_AmplifierInteraction.ipf
@@ -1246,6 +1246,18 @@ static Function/S AI_AmpStorageControlToRowLabel(string ctrl)
 		case "setvar_DataAcq_PipetteOffset_VC":
 			return "PipetteOffsetVC"
 			break
+		case "check_DataAcq_Amp_Chain":
+			return "RSCompChaining"
+			break
+		case "button_DataAcq_WCAuto":
+			return "WholeCellCap"
+			break
+		case "button_DataAcq_FastComp_VC": // fallthrough
+		case "button_DataAcq_SlowComp_VC": // fallthrough
+		case "button_DataAcq_AutoPipOffset_VC":
+			// no row exists
+			return ""
+			break
 		// I-Clamp controls
 		case "setvar_DataAcq_Hold_IC":
 			return "BiasCurrent"
@@ -1280,17 +1292,8 @@ static Function/S AI_AmpStorageControlToRowLabel(string ctrl)
 		case "setvar_DataAcq_PipetteOffset_IC":
 			return "PipetteOffsetIC"
 			break
-		case "check_DataAcq_Amp_Chain":
-			return "RSCompChaining"
-			break
-		case "button_DataAcq_WCAuto":
-			return "WholeCellCap"
-			break
 		case "button_DataAcq_AutoBridgeBal_IC": // fallthrough
 		case "button_DataAcq_AutoPipOffset_IC": // fallthrough
-		case "button_DataAcq_FastComp_VC": // fallthrough
-		case "button_DataAcq_SlowComp_VC": // fallthrough
-		case "button_DataAcq_AutoPipOffset_VC":
 			// no row exists
 			return ""
 			break

--- a/Packages/MIES/MIES_AmplifierInteraction.ipf
+++ b/Packages/MIES/MIES_AmplifierInteraction.ipf
@@ -594,8 +594,6 @@ static Function AI_UpdateAmpView(string device, variable headStage, [variable fu
 		elseif(StringMatch(ctrl, "check_*"))
 			SetCheckBoxState(device, ctrl, value)
 			DAG_Update(device, ctrl, val = value)
-		elseif(!cmpstr(ctrl, "button_DataAcq_WCAuto"))
-			// do nothing
 		else
 			FATAL_ERROR("Unhandled control: " + ctrl)
 		endif
@@ -1249,9 +1247,7 @@ static Function/S AI_AmpStorageControlToRowLabel(string ctrl)
 		case "check_DataAcq_Amp_Chain":
 			return "RSCompChaining"
 			break
-		case "button_DataAcq_WCAuto":
-			return "WholeCellCap"
-			break
+		case "button_DataAcq_WCAuto": // fallthrough
 		case "button_DataAcq_FastComp_VC": // fallthrough
 		case "button_DataAcq_SlowComp_VC": // fallthrough
 		case "button_DataAcq_AutoPipOffset_VC":

--- a/Packages/tests/Basic/UTF_Amplifier.ipf
+++ b/Packages/tests/Basic/UTF_Amplifier.ipf
@@ -89,3 +89,35 @@ static Function TestAmplifierUnits([variable clampMode])
 		endswitch
 	endfor
 End
+
+static Function TestAmplifierStorageLabels()
+
+	variable clampMode, numFuncs
+
+	WAVE clampModes = DataGenerators#GetClampModesWithoutIZero()
+
+	for(clampMode : clampModes)
+		WAVE aiFuncs = AI_GetFunctionConstantForClampMode(clampMode)
+		numFuncs = DimSize(aiFuncs, ROWS)
+		Make/FREE/T/N=(numFuncs) ctrlNames, ampLabels
+
+		ctrlNames[] = AI_MapFunctionConstantToControl(aiFuncs[p], clampMode)
+		ampLabels[] = MIES_AI#AI_AmpStorageControlToRowLabel(ctrlNames[p])
+
+		Concatenate/FREE/NP=(ROWS)/T {ampLabels}, allAmpLabels
+	endfor
+
+	FindDuplicates/FREE/Z/DT=dupAmpLabels allAmpLabels
+
+	WAVE/Z/T dupAmpLabelsUnique = GetUniqueEntries(dupAmpLabels)
+
+	// all duplicated entries are empty
+	CHECK_EQUAL_TEXTWAVES(dupAmpLabelsUnique, {""})
+
+	WAVE ampStorageWave = GetAmplifierParamStorageWave("RandomDeviceName")
+
+	WAVE/T allAmpLabelsNoEmpty = GetSetDifference(allAmpLabels, dupAmpLabels)
+	Make/FREE/N=(DimSize(allAmpLabelsNoEmpty, ROWS)) rows = FindDimLabel(ampStorageWave, ROWS, allAmpLabelsNoEmpty[p])
+
+	CHECK_GE_VAR(WaveMin(rows), 0)
+End


### PR DESCRIPTION
The button can not return a usable value, but was causing a duplicate row label before.

close #2702

If this fix is working, I could think of a possible test like:

```
	WAVE aiFuncs = AI_GetFunctionConstantForClampMode(clampMode)
	numFuncs = DimSize(aiFuncs, ROWS)
	Make/FREE/T/N=(numFuncs) ctrlNames, ampLabels

	ctrlNames[] = AI_MapFunctionConstantToControl(aiFuncs[p], clampMode)
	ampLabels[] = AI_AmpStorageControlToRowLabel(ctrlNames[p])
        // Do that for all clamp modes and concatenate the retrieved labels
	// Then check if ampLabels have no duplicates as well as check if each label exist as dimlabels in the amp storage wave
```