### PR TITLE
SetDimensionLabels: Speed it up

### DIFF
--- a/Packages/MIES/MIES_Utilities_WaveHandling.ipf
+++ b/Packages/MIES/MIES_Utilities_WaveHandling.ipf
@@ -542,7 +542,7 @@ threadsafe Function SetDimensionLabels(WAVE wv, string list, variable dim, [vari
 
 	ASSERT_TS(startPos >= 0, "Illegal negative startPos")
 	ASSERT_TS(dimlabelCount <= (DimSize(wv, dim) + startPos), "Dimension label count exceeds dimension size")
-	for(i = 0; i < dimlabelCount; i += 1)
+	for(i = dimlabelCount - 1; i >= 0; i -= 1)
 		labelName = StringFromList(i, list)
 		SetDimLabel dim, i + startPos, $labelName, Wv
 	endfor

--- a/Packages/tests/Basic/UTF_Utils_WaveHandling.ipf
+++ b/Packages/tests/Basic/UTF_Utils_WaveHandling.ipf
@@ -3057,6 +3057,13 @@ Function SDL_WorksWithPartialLabels()
 	CHECK_EQUAL_STR(GetDimLabel(wv, ROWS, 2), "")
 End
 
+Function SDL_WorksWithEmptyList()
+
+	Make/FREE/N=0 wv
+	SetDimensionLabels(wv, "", ROWS)
+	CHECK_EQUAL_STR(GetDimLabel(wv, ROWS, 0), "")
+End
+
 /// @}
 
 /// RemoveAllDimLabels


### PR DESCRIPTION
An observation by Max Brauer revealed that setting the dimension labels starting from the last index is much faster.

With the following diff

```diff
diff --git a/Packages/MIES/MIES_Utilities_WaveHandling.ipf b/Packages/MIES/MIES_Utilities_WaveHandling.ipf index 6fb3bb47e2..4469508b73 100644
--- a/Packages/MIES/MIES_Utilities_WaveHandling.ipf +++ b/Packages/MIES/MIES_Utilities_WaveHandling.ipf @@ -530,7 +530,7 @@ Function/DF MakeDataFolderFree(DFREF dfr)
 /// @param list     List of dimension labels, semicolon separated.
 /// @param dim      Wave dimension, see, @ref WaveDimensions
 /// @param startPos [optional, defaults to 0] First dimLabel index
-threadsafe Function SetDimensionLabels(WAVE wv, string list, variable dim, [variable startPos])
+threadsafe Function SetDimensionLabels(WAVE wv, string list, variable dim, [variable startPos, variable rev])

     string   labelName
     variable i
@@ -540,12 +540,26 @@ threadsafe Function SetDimensionLabels(WAVE wv, string list, variable dim, [vari
         startPos = 0
     endif

+    if(ParamIsDefault(rev))
+        rev = 0
+    else
+        rev = !!rev
+    endif
+
     ASSERT_TS(startPos >= 0, "Illegal negative startPos")
     ASSERT_TS(dimlabelCount <= (DimSize(wv, dim) + startPos), "Dimension label count exceeds dimension size")
-    for(i = 0; i < dimlabelCount; i += 1)
-        labelName = StringFromList(i, list)
-        SetDimLabel dim, i + startPos, $labelName, Wv
-    endfor
+
+    if(rev)
+        for(i = dimlabelCount - 1; i >= 0; i -= 1)
+            labelName = StringFromList(i, list)
+            SetDimLabel dim, i + startPos, $labelName, Wv
+        endfor
+    else
+        for(i = 0; i < dimlabelCount; i += 1)
+            labelName = StringFromList(i, list)
+            SetDimLabel dim, i + startPos, $labelName, Wv
+        endfor
+    endif
 End

 /// @brief Return a wave with deep copies of all referenced waves
```

 and the test code

```igorpro
Function MeasureSetLabelSpeed()
	variable i, timeStart, timeStop

	variable size = 50

	Make/FREE/T/N=(size) labels = num2istr(i)
	string labels_list = TextWaveToList(labels, ";")

	// n..1
	Make/FREE/N=(size) wv
	timeStart = StopMSTimer(-2)
	SetDimensionLabels(wv, labels_list, ROWS, rev = 1)
	timeStop = StopMSTimer(-2)
	printf "Setting label %d->0 took: %g ms\n", size-1, (timeStop - timeStart) * 1e-3
	KillWaves/Z wv

	// 1..n
	Make/FREE/N=(size) wv
	timeStart = StopMSTimer(-2)
	SetDimensionLabels(wv, labels_list, ROWS, rev = 0)
	timeStop = StopMSTimer(-2)
	printf "Setting label 0->%d took: %g ms\n", size-1, (timeStop - timeStart) * 1e-3
	KillWaves/Z wv

End
```

the author of this commit got

```
•MeasureSetLabelSpeed()
  Setting label 49->0 took: 0.0244 ms
  Setting label 0->49 took: 0.0643 ms
```

Which is a factor of 3 for only 50 entries.

So let's reverse it by default.

Helped-by: Max Brauer <max.brauer@byte-physics.de>
