### PR TITLE
SF: add assert frame stack (prepare ivscc_apfrequency)

### DIFF
--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -2994,3 +2994,9 @@ Function SF_TableWindowHook(STRUCT WMWinHookStruct &s)
 
 	return 0
 End
+
+/// @brief Adds an expression to a formula string with the proper termination character
+Function/S SF_AddExpressionToFormula(string formula, string expr)
+
+	return formula + expr + SF_CHAR_CR
+End

--- a/Packages/MIES/MIES_SweepFormula.ipf
+++ b/Packages/MIES/MIES_SweepFormula.ipf
@@ -2035,6 +2035,11 @@ static Function SF_ClearSFOutputState()
 	result = ""
 	NVAR severity = $GetSweepFormulaOutputSeverity()
 	severity = SF_MSG_OK
+
+	// defensively drop any assert-data stack frames left behind by a previous run that
+	// aborted inside a nested operation call (e.g. ivscc_apfrequency), so they can never leak
+	// into, or get misread as belonging to, the next run, see SFH_ResetAssertDataStack
+	SFH_ResetAssertDataStack()
 End
 
 Function SF_DisplayOutputStateInGUI(string databrowser)
@@ -2860,7 +2865,12 @@ static Function [variable paragraph, variable charPosition] SF_CalculateErrorLoc
 	text  = SF_PreprocessInput(text)
 	WAVE/T wText = ListToTextWave(text, SF_CHAR_CR)
 
-	WAVE/T info = GetSFAssertData()
+	// use the outermost stack frame here (not the innermost/currently-failing one): its
+	// LINE/OFFSET/INFORMULAOFFSET are the only ones that describe a position in the real,
+	// on-screen SF notebook text below -- any nested frame's LINE/OFFSET instead describe a
+	// position inside an operation's own internally-generated formula string, see
+	// GetSFAssertDataStack and SFH_GetOutermostAssertDataFrame
+	WAVE/T info = SFH_GetOutermostAssertDataFrame()
 	line = str2numSafe(info[%LINE])
 
 	// find line in text and look how many CR are between 0 and offset

--- a/Packages/MIES/MIES_SweepFormula_Executor.ipf
+++ b/Packages/MIES/MIES_SweepFormula_Executor.ipf
@@ -29,7 +29,8 @@ static Constant SFE_VARIABLE_PREFIX = 36
 ///                                            Also the current error information for SFH_ASSERT is kept as is. The current variable storage is used.
 ///                                            This allows to internally execute a formula  where a triggered SFH_ASSERT should result in the marking
 ///                                            of the "outer" formula in the current SF notebook.
-Function/WAVE SFE_ExecuteFormula(string formula, string graph, [variable singleResult, variable checkExist, variable useVariables, variable line, variable offset, variable preProcess])
+/// @param newFrame     [optional, default 0] when set then execution runs in a new assert data frame
+Function/WAVE SFE_ExecuteFormula(string formula, string graph, [variable singleResult, variable checkExist, variable useVariables, variable line, variable offset, variable preProcess, variable newFrame])
 
 	STRUCT SF_ExecutionData exd
 	variable jsonId, srcLocId
@@ -42,6 +43,13 @@ Function/WAVE SFE_ExecuteFormula(string formula, string graph, [variable singleR
 	line         = ParamIsDefault(line) ? NaN : line
 	offset       = ParamIsDefault(offset) ? NaN : offset
 	preProcess   = ParamIsDefault(preProcess) ? 1 : !!preProcess
+	newFrame     = ParamIsDefault(newFrame) ? 0 : !!newFrame
+
+	if(newFrame)
+		// Ensure the base frame exists so we can safely push/pop a nested frame
+		GetSFAssertData()
+		SFH_PushAssertDataFrame()
+	endif
 
 	if(preProcess)
 		formula = SF_PreprocessInput(formula)
@@ -62,7 +70,16 @@ Function/WAVE SFE_ExecuteFormula(string formula, string graph, [variable singleR
 		WAVE/Z data = out[0]
 		SFH_ASSERT(!(checkExist && !WaveExists(data)), "No data in dataSet returned from executed formula.")
 		SFH_CleanUpInput(out)
+
+		if(newFrame)
+			SFH_PopAssertDataFrame()
+		endif
+
 		return data
+	endif
+
+	if(newFrame)
+		SFH_PopAssertDataFrame()
 	endif
 
 	return out
@@ -74,13 +91,15 @@ End
 /// @param preProcCode    preprocessed sweep formula notebook text
 /// @param allowEmptyCode [optional, default 0] when set then the check for empty formula code is disabled, such that
 ///                       input that contains only variable expressions can be evaluated
-Function/S SFE_ExecuteVariableAssignments(string graph, string preProcCode, [variable allowEmptyCode])
+/// @param newFrame       [optional, default 0] when set then execution runs in a new assert data frame
+Function/S SFE_ExecuteVariableAssignments(string graph, string preProcCode, [variable allowEmptyCode, variable newFrame])
 
 	STRUCT SF_ExecutionData exd
 	variable i, numAssignments, jsonId, srcLocId, line, offset
 	string code, sfWin, nbText
 
 	allowEmptyCode = ParamisDefault(allowEmptyCode) ? 0 : !!allowEmptyCode
+	newFrame       = ParamisDefault(newFrame) ? 0 : !!newFrame
 
 	exd.graph = graph
 
@@ -91,6 +110,12 @@ Function/S SFE_ExecuteVariableAssignments(string graph, string preProcCode, [var
 	[WAVE/T varAssignments, code] = SF_GetVariableAssignments(preProcCode)
 	if(!WaveExists(varAssignments))
 		return code
+	endif
+
+	if(newFrame)
+		// Ensure the base frame exists so we can safely push/pop a nested frame
+		GetSFAssertData()
+		SFH_PushAssertDataFrame()
 	endif
 
 	numAssignments = DimSize(varAssignments, ROWS)
@@ -121,6 +146,10 @@ Function/S SFE_ExecuteVariableAssignments(string graph, string preProcCode, [var
 
 		SFH_StoreAssertInfoParser(line + 1, 0, formula = "")
 		SFH_FATAL_ERROR("Only variables are present")
+	endif
+
+	if(newFrame)
+		SFH_PopAssertDataFrame()
 	endif
 
 	return code

--- a/Packages/MIES/MIES_SweepFormula_Helpers.ipf
+++ b/Packages/MIES/MIES_SweepFormula_Helpers.ipf
@@ -356,12 +356,137 @@ Function/WAVE SFH_GetArgumentAsWave(STRUCT SF_ExecutionData &exd, string opShort
 	return defWave
 End
 
-static Function/S SFH_GetAssertLocationMessage()
+/// @brief Push a new (blank) frame onto the SweepFormula assert-data LIFO stack, see
+///        GetSFAssertDataStack for the full picture.
+///
+/// Before pushing, if a frame is already active, its error-location message is rendered and
+/// frozen into its own LOCMSG field right now -- this is the last moment at which the global,
+/// single-slot execution-position trackers (GetSweepFormulaJSONPathTracker /
+/// GetSweepFormulaBufferOffsetTracker) still reflect *that* frame's position; the moment the
+/// nested formula execution we are pushing this frame for starts running, those trackers get
+/// overwritten with its position instead.
+Function SFH_PushAssertDataFrame()
+
+	variable numFrames
+
+	WAVE/WAVE assertDataStack = GetSFAssertDataStack()
+	numFrames = DimSize(assertDataStack, ROWS)
+
+	if(numFrames > 0)
+		WAVE/T outerFrame = assertDataStack[numFrames - 1]
+		if(str2numSafe(outerFrame[%STEP]) != SF_STEP_OUTSIDE)
+			outerFrame[%LOCMSG] = SFH_GetAssertLocationMessageForFrame(outerFrame)
+		endif
+	endif
+
+	WAVE/T newFrame = GetNewSFAssertDataFrame()
+
+	Redimension/N=(numFrames + 1) assertDataStack
+	assertDataStack[numFrames] = newFrame
+End
+
+/// @brief Pop the innermost frame off the SweepFormula assert-data LIFO stack once a nested
+///        formula execution (e.g. the internal formula run by an operation like
+///        ivscc_apfrequency, see SFO_OperationIVSCCApFrequencyPrepareVariables) has returned
+///        *normally*.
+///
+/// Deliberately does not release the popped frame's JSONID/SRCLOCID: by the time a nested
+/// execution finishes normally, its own JSON ids have already been released by the ordinary
+/// executor success path (SFE_ExecuteFormula/SFE_ExecuteVariableAssignments); releasing them
+/// again here would double-release. If the nested execution instead aborts (SFH_ASSERT), this
+/// function is simply never reached for that frame -- it is deliberately left on the stack, see
+/// GetSFAssertDataStack -- and its ids are only ever cleaned up defensively, tolerant of
+/// already-released ids, by SFH_ResetAssertDataStack.
+Function SFH_PopAssertDataFrame()
+
+	variable numFrames
+
+	WAVE/WAVE assertDataStack = GetSFAssertDataStack()
+	numFrames = DimSize(assertDataStack, ROWS)
+
+	ASSERT(numFrames > 1, "SFH_PopAssertDataFrame: refusing to pop the base frame")
+
+	Redimension/N=(numFrames - 1) assertDataStack
+
+	// The frame that resumes being "top of stack" was frozen (its LOCMSG populated) by
+	// SFH_PushAssertDataFrame right before the frame we just popped was pushed. Clear it now
+	// so that if *another* nested frame gets pushed later from this same resumed frame (e.g. a
+	// second, different operation call further along in the same formula), its location message
+	// gets recomputed fresh from the (by-then-different) live execution-position trackers,
+	// rather than reusing this stale, first-call-site message.
+	WAVE/T resumedFrame = assertDataStack[numFrames - 2]
+	resumedFrame[%LOCMSG] = ""
+End
+
+/// @brief Return the outermost (bottom-of-stack, index 0) SF assert-data frame.
+///
+/// This is the only frame whose LINE/OFFSET describe a position in the real, on-screen
+/// SweepFormula notebook text (see SF_CalculateErrorLocationInNotebook) -- any inner/nested
+/// frame's LINE/OFFSET instead describe a position inside an operation's own
+/// internally-generated formula string, which was never displayed in the notebook.
+Function/WAVE SFH_GetOutermostAssertDataFrame()
+
+	WAVE/WAVE assertDataStack = GetSFAssertDataStack()
+
+	if(DimSize(assertDataStack, ROWS) == 0)
+		SFH_PushAssertDataFrame()
+	endif
+
+	WAVE/T wv = assertDataStack[0]
+
+	return wv
+End
+
+/// @brief Defensively empty the SweepFormula assert-data LIFO stack, releasing every remaining
+///        frame's JSONID/SRCLOCID.
+///
+/// Call this whenever SweepFormula output state is cleared for a fresh run (see
+/// SF_ClearSFOutputState) so that frames left behind by a previous aborted nested execution
+/// (see SFH_PopAssertDataFrame) never leak into, or get misread as belonging to, the next run.
+/// JSON_Release(..., ignoreErr=1) tolerates ids that are already invalid or already released, so
+/// this is safe to call unconditionally, whether or not the previous run actually aborted inside
+/// a nested call.
+Function SFH_ResetAssertDataStack()
+
+	variable i, numFrames, jsonId, srcLocId
+
+	WAVE/WAVE assertDataStack = GetSFAssertDataStack()
+	numFrames = DimSize(assertDataStack, ROWS)
+
+	for(i = 0; i < numFrames; i += 1)
+		WAVE/T frame = assertDataStack[i]
+		jsonId   = str2numSafe(frame[%JSONID])
+		srcLocId = str2numSafe(frame[%SRCLOCID])
+		JSON_Release(jsonId, ignoreErr = 1)
+		JSON_Release(srcLocId, ignoreErr = 1)
+	endfor
+
+	Redimension/N=0 assertDataStack
+End
+
+/// @brief Render the error-location message for a single SF assert-data frame.
+///
+/// Extracted from the former (single-frame) SFH_GetAssertLocationMessage so it can be applied
+/// either to the live, currently-executing frame (reading the global execution-position
+/// trackers, which are only ever valid for whatever is executing *right now*) or, via the
+/// frozen LOCMSG field written by SFH_PushAssertDataFrame, to a suspended outer frame.
+///
+/// Deliberately does *not* release SRCLOCID: unlike the original single-frame version, this can
+/// now run opportunistically during perfectly normal, non-aborting execution (via
+/// SFH_PushAssertDataFrame, to freeze an outer frame's message before pushing a nested one on
+/// top of it), where the outer frame's SRCLOCID is still needed afterward. Releasing it here
+/// would strand the outer frame with an invalid id the next time its message needs (re-)rendering.
+/// SRCLOCID release is instead the sole responsibility of SFH_GetAssertLocationMessage (the only
+/// call site guaranteed to run right before an actual Abort) and SFH_ResetAssertDataStack.
+static Function/S SFH_GetAssertLocationMessageForFrame(WAVE/T assertData)
 
 	variable parserBufferOffset, srcLocId, srcLoc, sfStep
 	string attemptedFormula, currentExePath
 
-	WAVE/T assertData = GetSFAssertData()
+	if(!IsEmpty(assertData[%LOCMSG]))
+		return assertData[%LOCMSG]
+	endif
+
 	sfStep = str2numSafe(assertData[%STEP])
 	if(sfStep == SF_STEP_OUTSIDE)
 		return ""
@@ -386,11 +511,9 @@ static Function/S SFH_GetAssertLocationMessage()
 			if(!IsNaN(srcLoc))
 				attemptedFormula             = JSON_GetString(srcLocId, "/")
 				assertData[%INFORMULAOFFSET] = num2istr(srcLoc)
-				JSON_Release(srcLocId)
 				return SFH_FormatSourceLocationError(attemptedFormula, srcLoc)
 			endif
 
-			JSON_Release(srcLocId)
 			BUG("SFH_ASSERT: source path not found: " + currentExePath)
 			return ""
 		endif
@@ -400,6 +523,51 @@ static Function/S SFH_GetAssertLocationMessage()
 	endif
 
 	FATAL_ERROR("Unknown SF execution step")
+End
+
+/// @brief Build the full, possibly multi-level, error-location message for the currently
+///        active SweepFormula assert-data stack, see GetSFAssertDataStack.
+///
+/// Walks the stack from the innermost (top, currently-failing) frame down to the outermost
+/// (bottom, the formula visible in the SF notebook), rendering each frame's own location
+/// message (SFH_GetAssertLocationMessageForFrame) and joining more than one with a
+/// "Called from:" separator, so a failure inside a nested operation call (e.g.
+/// ivscc_apfrequency running its own internal formula, see
+/// SFO_OperationIVSCCApFrequencyPrepareVariables) reports both where inside that internal
+/// formula it failed *and* where in the user's own notebook formula the nested call was made.
+static Function/S SFH_GetAssertLocationMessage()
+
+	variable i, numFrames
+	string msg, frameMsg
+
+	WAVE/WAVE assertDataStack = GetSFAssertDataStack()
+	numFrames = DimSize(assertDataStack, ROWS)
+
+	msg = ""
+	for(i = numFrames - 1; i >= 0; i -= 1)
+		WAVE/T frame = assertDataStack[i]
+		frameMsg = SFH_GetAssertLocationMessageForFrame(frame)
+
+		// This walk only ever runs immediately before SFH_ASSERT calls Abort, so every frame's
+		// SRCLOCID is guaranteed to no longer be needed after this -- release it here rather
+		// than inside SFH_GetAssertLocationMessageForFrame itself, which can also run
+		// opportunistically during normal, non-aborting execution (via SFH_PushAssertDataFrame,
+		// to freeze an outer frame before a nested push). ignoreErr=1 tolerates frames whose
+		// SRCLOCID was never valid (e.g. a PARSER-step frame) or already released.
+		JSON_Release(str2numSafe(frame[%SRCLOCID]), ignoreErr = 1)
+
+		if(IsEmpty(frameMsg))
+			continue
+		endif
+
+		if(IsEmpty(msg))
+			msg = frameMsg
+		else
+			msg += "\rCalled from:" + frameMsg
+		endif
+	endfor
+
+	return msg
 End
 
 /// @brief Assertion for sweep formula

--- a/Packages/MIES/MIES_WaveDataFolderGetters.ipf
+++ b/Packages/MIES/MIES_WaveDataFolderGetters.ipf
@@ -32,6 +32,9 @@ static StrConstant TP_SETTINGS_LABELS = "bufferSize;resistanceTol;sendToAllHS;ba
 
 static Constant SWEEP_SETTINGS_WAVE_VERSION = 43
 
+/// @brief Number of tracked fields in one SF assert-data stack frame, see GetSFAssertDataStack
+static Constant SF_ASSERTDATA_NUMFIELDS = 9
+
 /// @brief Return a wave reference to the corresponding Logbook keys wave from an values wave input
 threadsafe Function/WAVE GetLogbookValuesFromKeys(WAVE keyWave)
 
@@ -9522,9 +9525,22 @@ Function/WAVE GetNewSourceLocationWave()
 	return srcLocs
 End
 
-/// @brief Creates a global wave storing data for the case the SF executor runs into an SFH_ASSERT
+/// @brief Return the wave-reference-wave backing the SweepFormula assert-data LIFO stack.
 ///
-/// Rows:
+/// One frame per currently-active (possibly nested) formula-execution level. The base frame
+/// (index 0) represents the outermost, user-visible formula execution (from the SF notebook).
+/// The stack (including the base frame) is created lazily on first use and can be cleared by
+/// SFH_ResetAssertDataStack (e.g. when SF output state is cleared between runs). Additional frames get pushed
+/// *inside* an already-executing formula -- e.g. an operation like ivscc_apfrequency running
+/// its own internal formula against the same graph (see
+/// SFO_OperationIVSCCApFrequencyPrepareVariables) -- and popped (SFH_PopAssertDataFrame) once
+/// that nested execution returns normally. If it aborts instead (SFH_ASSERT), the frame is
+/// deliberately left on the stack so the failure's exact context remains available for
+/// building a multi-level error message (see SFH_GetAssertLocationMessage) and is only
+/// cleaned up later, defensively, by SFH_ResetAssertDataStack.
+///
+/// Frame rows (each frame is its own Make/T/N=(SF_ASSERTDATA_NUMFIELDS) text wave):
+/// JSONID : json id of the currently executing formula
 /// SRCLOCID : json id of the JSON storing the source location information
 /// JSONPATH : last json path the executor was working on, this element is updated by the executor while executing
 /// STEP : step in the sweepformula exection, one of @sa SFExecutionSteps
@@ -9532,30 +9548,77 @@ End
 /// OFFSET : character offset in the line where the current formula starts in the SF notebook
 /// FORMULA : current formula string
 /// INFORMULAOFFSET : character offset in the formula where the error is located
-Function/WAVE GetSFAssertData()
+/// LOCMSG : pre-rendered error-location message text (see SFH_GetAssertLocationMessageForFrame),
+///          frozen for this frame by SFH_PushAssertDataFrame at the moment a *deeper* frame is
+///          pushed on top of it. Empty for the current top-of-stack frame, whose location message
+///          is instead computed on demand from the live execution-position trackers (see
+///          GetSweepFormulaJSONPathTracker/GetSweepFormulaBufferOffsetTracker), since those
+///          trackers only ever reflect the position of whatever is executing *right now*, not any
+///          suspended outer frame.
+Function/WAVE GetSFAssertDataStack()
 
-	string name = "SFAssertData"
+	string name = "SFAssertDataStack"
 
 	DFREF dfr = GetSweepFormulaPath()
 
-	WAVE/Z/T/SDFR=dfr wv = $name
+	WAVE/Z/WAVE/SDFR=dfr wv = $name
 
 	if(WaveExists(wv))
 		return wv
 	endif
 
-	Make/T/N=(8) dfr:$name/WAVE=wv
+	Make/WAVE/N=0 dfr:$name/WAVE=wv
 
-	SetDimLabel ROWS, 0, JSONID, wv
-	SetDimLabel ROWS, 1, SRCLOCID, wv
-	SetDimLabel ROWS, 2, JSONPATH, wv
-	SetDimLabel ROWS, 3, STEP, wv
-	SetDimLabel ROWS, 4, LINE, wv
-	SetDimLabel ROWS, 5, OFFSET, wv
-	SetDimLabel ROWS, 6, FORMULA, wv
-	SetDimLabel ROWS, 7, INFORMULAOFFSET, wv
+	return wv
+End
 
-	wv[%STEP] = num2istr(SF_STEP_OUTSIDE)
+/// @brief Create a single, blank SweepFormula assert-data stack frame (see
+///        GetSFAssertDataStack for the field list and the LIFO stack this is a frame of).
+///
+/// Used by SFH_PushAssertDataFrame to create each new frame it pushes, and internally by
+/// GetSFAssertDataStack's own base-frame consumers -- pulled out into its own function so the
+/// frame layout (field count/dimension labels) is defined in exactly one place.
+Function/WAVE GetNewSFAssertDataFrame()
+
+	Make/T/N=(SF_ASSERTDATA_NUMFIELDS)/FREE newFrame
+
+	SetDimLabel ROWS, 0, JSONID, newFrame
+	SetDimLabel ROWS, 1, SRCLOCID, newFrame
+	SetDimLabel ROWS, 2, JSONPATH, newFrame
+	SetDimLabel ROWS, 3, STEP, newFrame
+	SetDimLabel ROWS, 4, LINE, newFrame
+	SetDimLabel ROWS, 5, OFFSET, newFrame
+	SetDimLabel ROWS, 6, FORMULA, newFrame
+	SetDimLabel ROWS, 7, INFORMULAOFFSET, newFrame
+	SetDimLabel ROWS, 8, LOCMSG, newFrame
+
+	newFrame[%STEP] = num2istr(SF_STEP_OUTSIDE)
+
+	return newFrame
+End
+
+/// @brief Return the current (innermost/top-of-stack) SF assert-data frame -- "the formula
+///        execution episode that is active right now" -- creating the stack and its base
+///        frame if this is the very first call. See GetSFAssertDataStack for the full stack
+///        and why more than one frame can exist at once.
+///
+/// This is what all of the existing single-frame-oriented code (SFH_StoreAssertInfoParser/
+/// Executor, SFH_ASSERT, SF_IsExecutionErrorInVariable, ...) should keep using unchanged --
+/// they all care about "whatever is currently executing", which is always the top frame.
+/// The one exception is locating the error visually in the on-screen SF notebook
+/// (SF_CalculateErrorLocationInNotebook), which needs the *outermost* frame instead, via
+/// SFH_GetOutermostAssertDataFrame -- only that frame's LINE/OFFSET are ever meaningful
+/// positions in the real notebook text; any inner frame's LINE/OFFSET describe a position in
+/// an operation's own internally-generated formula string, which was never displayed there.
+Function/WAVE GetSFAssertData()
+
+	WAVE/WAVE assertDataStack = GetSFAssertDataStack()
+
+	if(DimSize(assertDataStack, ROWS) == 0)
+		SFH_PushAssertDataFrame()
+	endif
+
+	WAVE/T wv = assertDataStack[DimSize(assertDataStack, ROWS) - 1]
 
 	return wv
 End

--- a/Packages/tests/Basic/UTF_SweepFormula.ipf
+++ b/Packages/tests/Basic/UTF_SweepFormula.ipf
@@ -3337,3 +3337,98 @@ static Function TestSFHIsArray()
 	Make/FREE/WAVE/N=1 anArray
 	CHECK_EQUAL_VAR(SFH_IsArray(anArray), 1)
 End
+
+static Function/WAVE TestAssertDataStackOP(STRUCT SF_ExecutionData &exd)
+
+	variable result
+	string formula, expr
+
+	string opShort = SF_OP_TESTOP
+
+	result = SFH_GetArgumentAsNumeric(exd, SF_OP_TESTOP, 0)
+	SFH_ASSERT(result < 3, "TestOP result threshold reached")
+
+	sprintf expr, "result=testop(%d)", result + 1
+	formula = SF_AddExpressionToFormula("", expr)
+	SFE_ExecuteVariableAssignments(exd.graph, formula, allowEmptyCode = 1, newFrame = 1)
+
+	Make/FREE/D output = {0}
+
+	return SFH_GetOutputForExecutorSingle(output, exd.graph, opShort)
+End
+
+static Function/WAVE TestAssertDataStack2OP(STRUCT SF_ExecutionData &exd)
+
+	variable result
+	string   formula
+
+	string opShort = SF_OP_TESTOP
+
+	result = SFH_GetArgumentAsNumeric(exd, SF_OP_TESTOP, 0)
+	SFH_ASSERT(result < 3, "TestOP result threshold reached")
+
+	sprintf formula, "testop(%d)", result + 1
+	SFE_ExecuteFormula(formula, exd.graph, newFrame = 1)
+	Make/FREE/D output = {0}
+
+	return SFH_GetOutputForExecutorSingle(output, exd.graph, opShort)
+End
+
+/// @brief Test op for TestAssertDataStack3: dispatched once, as the base ("testop(0)") frame. From
+/// there it makes *two sequential* nested (newFrame = 1) calls at two different call sites:
+/// - "testop(1)": succeeds normally, so its frame is pushed and popped again before the second call
+///   is made. This is what used to (a) freeze the base frame's LOCMSG and (b) release the base
+///   frame's SRCLOCID as a side effect of rendering that frozen message.
+/// - "testop(2)": fails via SFH_ASSERT, forcing the base frame's location to be rendered a second
+///   time for the final error message.
+///
+/// In between the two nested calls, the base frame's own SRCLOCID is checked directly: it must
+/// still be valid, i.e. not released by the first (already completed, popped) nested call.
+static Function/WAVE TestAssertDataStack3OP(STRUCT SF_ExecutionData &exd)
+
+	variable result
+	string opShort = SF_OP_TESTOP
+
+	result = SFH_GetArgumentAsNumeric(exd, SF_OP_TESTOP, 0)
+
+	if(result == 0)
+		SFE_ExecuteFormula("testop(1)", exd.graph, newFrame = 1)
+
+		WAVE/T baseFrame = SFH_GetOutermostAssertDataFrame()
+		CHECK_EQUAL_VAR(JSON_IsValid(str2numSafe(baseFrame[%SRCLOCID])), 1)
+
+		SFE_ExecuteFormula("testop(2)", exd.graph, newFrame = 1)
+	elseif(result == 2)
+		SFH_FATAL_ERROR("TestOP result threshold reached")
+	endif
+	// result == 1: succeeds trivially, no assert, no further nesting
+
+	Make/FREE/D output = {0}
+
+	return SFH_GetOutputForExecutorSingle(output, exd.graph, opShort)
+End
+
+// IUTF_TD_GENERATOR DataGenerators#SF_AssertDataStackCases
+static Function TestAssertDataStack([WAVE/T input])
+
+	string win, device, err
+
+	[win, device] = CreateEmptyUnlockedDataBrowserWindow()
+	win           = CreateFakeSweepData(win, device, sweepNo = 0)
+
+	SVAR funcName = $GetSFTestopName(win)
+	funcName = input[0]
+
+	try
+		SFE_ExecuteFormula("testop(0)", win)
+		FAIL()
+	catch
+		SVAR sfError = $GetSweepFormulaOutputMessage()
+		err = sfError
+		CHECK_EQUAL_STR(err, input[1])
+
+		SFH_ResetAssertDataStack()
+		WAVE/WAVE assertDataStack = GetSFAssertDataStack()
+		CHECK_EQUAL_VAR(DimSize(assertDataStack, ROWS), 0)
+	endtry
+End

--- a/Packages/tests/UTF_DataGenerators.ipf
+++ b/Packages/tests/UTF_DataGenerators.ipf
@@ -2148,6 +2148,37 @@ static Function/WAVE SF_ErrorBarStyles()
 	return wv
 End
 
+/// @brief TestOp function name and expected SFH_ASSERT error message for the three
+/// UTF_SweepFormula assert-data-stack scenarios (see UTF_SweepFormula#TestAssertDataStack):
+/// - VariableAssignmentRecursion: recursive newFrame pushes via SFE_ExecuteVariableAssignments
+///   (TestAssertDataStackOP), four nested frames deep (testop(0) -> testop(3)).
+/// - ExecuteFormulaRecursion: the same recursive scenario, but pushing newFrame via
+///   SFE_ExecuteFormula directly instead (TestAssertDataStack2OP). Same expected message since
+///   only the formula text ("testop(N)") is rendered, not which op implementation produced it.
+/// - SrcLocPreservation: a base frame that pushes/pops a first, successful nested frame and then
+///   pushes a second, failing one (TestAssertDataStack3OP). The base frame's own location must
+///   still be correctly attributed in the final message, proving that neither its SRCLOCID nor
+///   its LOCMSG were left in a stale/invalid state by the first, already completed nested call.
+static Function/WAVE SF_AssertDataStackCases()
+
+	string recursionError
+
+	Make/FREE/WAVE/N=3 wv
+
+	SetDimensionLabels(wv, "VariableAssignmentRecursion;ExecuteFormulaRecursion;SrcLocPreservation;", ROWS)
+
+	// TestOp name, expected error message
+	recursionError = "TestOP result threshold reached\rtestop(3)\r-------^\rCalled from:\rtestop(2)\r-------^\rCalled from:\rtestop(1)\r-------^\rCalled from:\rtestop(0)\r-------^"
+	Make/FREE/T wvt = {"UTF_SWEEPFORMULA#TestAssertDataStackOP", recursionError}
+	wv[%VariableAssignmentRecursion] = wvt
+	Make/FREE/T wvt = {"UTF_SWEEPFORMULA#TestAssertDataStack2OP", recursionError}
+	wv[%ExecuteFormulaRecursion] = wvt
+	Make/FREE/T wvt = {"UTF_SWEEPFORMULA#TestAssertDataStack3OP", "TestOP result threshold reached\rtestop(2)\r-------^\rCalled from:\rtestop(0)\r-------^"}
+	wv[%SrcLocPreservation] = wvt
+
+	return wv
+End
+
 static Function/WAVE VariousInputForConsecutivePasses()
 
 	// IPT_FORMAT_OFF


### PR DESCRIPTION
This PR adds a stack for assert frame information. This allows error information to be retrieved from the current frame level up to the top level and a proper error message generated. ivscc_apfrequency uses the approach to execute operations itself as part of the ivscc_apfrequency operation. Errors in these operations cause until now the function creating the error message to fail, because it only worked on the top level.