### PR TITLE
SF: add direct support for waveref wave arrays in executor (prepare ivscc_apfrequency)

### DIFF
--- a/Packages/MIES/MIES_SweepFormula_Executor.ipf
+++ b/Packages/MIES/MIES_SweepFormula_Executor.ipf
@@ -166,6 +166,7 @@ Function/WAVE SFE_FormulaExecutor(STRUCT SF_ExecutionData &exd, [variable srcLoc
 	string opName, str
 	variable i, size, JSONType, arrayElemJSONType, effectiveArrayDimCount, dim, onTopLevel
 	variable colSize, layerSize, chunkSize, operationsWithScalarResultCount
+	variable containsDataset, numElems, index
 
 	STRUCT SF_ExecutionData exdop
 
@@ -225,9 +226,60 @@ Function/WAVE SFE_FormulaExecutor(STRUCT SF_ExecutionData &exd, [variable srcLoc
 
 		// Get indices of Objects, Arrays and Strings on current level
 		EXTRACT/FREE/INDX types, arrElemAt, (types[p] == JSON_OBJECT) || (types[p] == JSON_ARRAY) || (types[p] == JSON_STRING) || (types[p] == JSON_NUMERIC)
+
+		// Resolve every element once
+		numElems = DimSize(arrElemAt, ROWS)
+		Make/FREE/WAVE/N=(numElems) genericElements = SF_ResolveDatasetFromJSON(exd, arrElemAt[p])
+
+		// Prescan: check every element once, without committing to out/outT/outW yet, so we can
+		// tell up front whether any element is a dataset. If so, the whole array is promoted to a
+		// uniform wave-of-datasets, wrapping plain text/numeric elements individually.
+		numElems = DimSize(arrElemAt, ROWS)
+		Make/FREE/WAVE/N=(numElems) preResolved
+		Make/FREE/D/N=(numElems) preIsDataset
+		for(i = 0; i < numElems; i += 1)
+			index = arrElemAt[i]
+			WAVE/WAVE genericElement = genericElements[i]
+			if(DimSize(genericElement, ROWS) == 1)
+				WAVE/Z subArray = genericElement[0]
+				SFH_ASSERT(WaveExists(subArray), "no data in array element")
+				if(IsTextWave(subArray))
+					WAVE/Z numericalAttempt = SFE_ConvertNonFiniteElements(subArray)
+					if(WaveExists(numericalAttempt))
+						WAVE subArray = numericalAttempt
+					endif
+				elseif(!IsNumericWave(subArray))
+					preIsDataset[i] = 1
+					containsDataset = 1
+				endif
+			else
+				// multi dataset
+				WAVE subArray = genericElement
+				preIsDataset[i] = 1
+				containsDataset = 1
+			endif
+			preResolved[i] = subArray
+		endfor
+
+		if(containsDataset)
+			WAVE/WAVE outW = SFE_ExecutorCreateOrCheckWaveRef($"", topArraySize[0])
+			for(i = 0; i < numElems; i += 1)
+				index = arrElemAt[i]
+				WAVE subArray = preResolved[i]
+				if(!preIsDataset[i])
+					Make/FREE/WAVE promoted = {subArray}
+					WAVE subArray = promoted
+				endif
+				outW[index] = subArray
+			endfor
+
+			return SFE_ExeReturn(SFH_GetOutputForExecutorSingle(outW, exd.graph, "ExecutorArrayReturn"), onTopLevel)
+		endif
+
 		// Iterate over all subarrays and objects on current level
-		for(index : arrElemAt)
-			WAVE/WAVE genericElement = SF_ResolveDatasetFromJSON(exd, index)
+		for(i = 0; i < numElems; i += 1)
+			index = arrElemAt[i]
+			WAVE/WAVE genericElement = genericElements[i]
 			if(DimSize(genericElement, ROWS) == 1)
 				// single dataset
 				WAVE/Z subArray = genericElement[0]

--- a/Packages/MIES/MIES_SweepFormula_Executor.ipf
+++ b/Packages/MIES/MIES_SweepFormula_Executor.ipf
@@ -219,8 +219,9 @@ Function/WAVE SFE_FormulaExecutor(STRUCT SF_ExecutionData &exd, [variable srcLoc
 		topArraySize[] = (topArraySize[p] != 0) ? topArraySize[p] : 1
 
 		Make/FREE/D/N=0 indicesOfOperationsWithScalarResult
-		WAVE/ZZ   out
-		WAVE/ZZ/T outT
+		WAVE/ZZ      out
+		WAVE/ZZ/T    outT
+		WAVE/ZZ/WAVE outW
 
 		// Get indices of Objects, Arrays and Strings on current level
 		EXTRACT/FREE/INDX types, arrElemAt, (types[p] == JSON_OBJECT) || (types[p] == JSON_ARRAY) || (types[p] == JSON_STRING) || (types[p] == JSON_NUMERIC)
@@ -232,6 +233,7 @@ Function/WAVE SFE_FormulaExecutor(STRUCT SF_ExecutionData &exd, [variable srcLoc
 				WAVE/Z subArray = genericElement[0]
 				SFH_ASSERT(WaveExists(subArray), "no data in array element")
 				if(IsTextWave(subArray))
+					SFH_ASSERT(!WaveExists(outW), "mixed array types")
 					WAVE/Z numericalAttempt = SFE_ConvertNonFiniteElements(subArray)
 					if(WaveExists(numericalAttempt))
 						WAVE subArray = numericalAttempt
@@ -240,23 +242,27 @@ Function/WAVE SFE_FormulaExecutor(STRUCT SF_ExecutionData &exd, [variable srcLoc
 						[out, outT] = SFE_ExecutorCreateOrCheckTextual(out, outT, topArraySize[0], topArraySize[1], topArraySize[2], topArraySize[3])
 					endif
 				elseif(IsNumericWave(subArray))
+					SFH_ASSERT(!WaveExists(outW), "mixed array types")
 					[out, outT] = SFE_ExecutorCreateOrCheckNumeric(out, outT, topArraySize[0], topArraySize[1], topArraySize[2], topArraySize[3])
 				else
-					[out, outT] = SFE_ExecutorCreateOrCheckTextual(out, outT, topArraySize[0], topArraySize[1], topArraySize[2], topArraySize[3])
-					WAVE subArrayWrapped = SFH_GetOutputForExecutor(subArray, exd.graph, "WrappedArrayElement")
-					WAVE subArray        = subArrayWrapped
+					// dataset (WAVE/WAVE) — store the reference directly, no marker string, no rewrap
+					SFH_ASSERT(!WaveExists(out) && !WaveExists(outT), "mixed array types")
+					WAVE/Z/WAVE outWtmp = outW
+					WAVE/WAVE   outW    = SFE_ExecutorCreateOrCheckWaveRef(outWtmp, topArraySize[0])
 				endif
 			else
-				// multi dataset
-				[out, outT] = SFE_ExecutorCreateOrCheckTextual(out, outT, topArraySize[0], topArraySize[1], topArraySize[2], topArraySize[3])
-				WAVE subArray = SFH_GetOutputForExecutor(genericElement, exd.graph, "WrappedArrayElement")
+				// multi dataset — same treatment, store genericElement directly as one unit
+				SFH_ASSERT(!WaveExists(out) && !WaveExists(outT), "mixed array types")
+				WAVE/Z/WAVE outWtmp  = outW
+				WAVE/WAVE   outW     = SFE_ExecutorCreateOrCheckWaveRef(outWtmp, topArraySize[0])
+				WAVE        subArray = genericElement
 			endif
 
 			SFH_ASSERT(numpnts(subArray), "Encountered subArray with zero size.")
 			SFH_ASSERT(GetWaveDimensionality(subArray) != CHUNKS, "Encountered 4d sub array at " + exd.jsonPath)
 
-			// Promote WaveNote with meta data if topArray is 1 point.
-			// The single topArray element is object or array at this point
+			// Promote WaveNote with meta data if topArray is 1 point. Only applies to out/outT —
+			// outW elements already carry their own note, nothing to promote.
 			if(WaveExists(out) && numpnts(out) == 1)
 				Note/K out, note(subArray)
 			endif
@@ -268,18 +274,32 @@ Function/WAVE SFE_FormulaExecutor(STRUCT SF_ExecutionData &exd, [variable srcLoc
 			// - original source was a array
 			// - original source was not: a string that resolved to a scalar datum (the source string can refer to a variable that was resolved)
 			// - original source was not: a object (aka operation) that resolved to a scalar datum
-			if(types[index] == JSON_ARRAY || !((types[index] == JSON_STRING || types[index] == JSON_OBJECT || types[index] == JSON_NUMERIC) && WaveDims(subArray) == 1 && numpnts(subArray) == 1))
-				// subArray will be inserted into the current array, thus the dimension will be WaveDims(subArray) + 1
-				// Thus, [1, [2]] returns the correct wave of size (2, 1) with {{1, 2}}.
-				effectiveArrayDimCount = max(effectiveArrayDimCount, WaveDims(subArray) + 1)
+			// Datasets are placed as one opaque reference (see SFE_PlaceSubArrayAt) — their own internal
+			// shape must never influence the outer array's dimensionality or size.
+			if(!WaveExists(outW))
+				if(types[index] == JSON_ARRAY || !((types[index] == JSON_STRING || types[index] == JSON_OBJECT || types[index] == JSON_NUMERIC) && WaveDims(subArray) == 1 && numpnts(subArray) == 1))
+					// subArray will be inserted into the current array, thus the dimension will be WaveDims(subArray) + 1
+					// Thus, [1, [2]] returns the correct wave of size (2, 1) with {{1, 2}}.
+					effectiveArrayDimCount = max(effectiveArrayDimCount, WaveDims(subArray) + 1)
+				endif
 			endif
 
 			// If the whole JSON array consists of STRING or NUMERIC types then topArraySize already is of the correct size.
 			// If we encounter an Object aka operation it could return an array that is larger than a single element,
 			// then we might have to resize beyond the original topArraySize.
 			// Increase 4D array size tracking according to new data
-			topArraySize[1, *] = max(topArraySize[p], DimSize(subArray, p - 1))
-			WAVE outCombinedType = SelectWave(WaveExists(outT), out, outT)
+			// (skipped for outW — datasets are opaque references, not spread across the outer array's dims)
+			if(!WaveExists(outW))
+				topArraySize[1, *] = max(topArraySize[p], DimSize(subArray, p - 1))
+			endif
+
+			if(WaveExists(outW))
+				WAVE outCombinedType = outW
+			elseif(WaveExists(outT))
+				WAVE outCombinedType = outT
+			else
+				WAVE outCombinedType = out
+			endif
 			// resize data according to new topArraySize adapted by sub array size and fill new elements with NaN
 			if((DimSize(outCombinedType, COLS) < topArraySize[1]) ||   \
 			   (DimSize(outCombinedType, LAYERS) < topArraySize[2]) || \
@@ -295,13 +315,17 @@ Function/WAVE SFE_FormulaExecutor(STRUCT SF_ExecutionData &exd, [variable srcLoc
 				if(WaveExists(outT))
 					Redimension/N=(topArraySize[0], topArraySize[1], topArraySize[2], topArraySize[3]) outT
 				endif
+				if(WaveExists(outW))
+					Redimension/N=(topArraySize[0]) outW
+				endif
 			endif
 			if(WaveExists(out))
 				SFE_PlaceSubArrayAt(out, subArray, index)
-			else
+			elseif(WaveExists(outT))
 				SFE_PlaceSubArrayAt(outT, subArray, index)
+			else
+				SFE_PlaceSubArrayAt(outW, subArray, index)
 			endif
-
 			// Save indices of operation/subArray evaluations that returned scalar results
 			if(numpnts(subArray) == 1)
 				EnsureLargeEnoughWave(indicesOfOperationsWithScalarResult, indexShouldExist = operationsWithScalarResultCount)
@@ -332,10 +356,11 @@ Function/WAVE SFE_FormulaExecutor(STRUCT SF_ExecutionData &exd, [variable srcLoc
 				Multithread out[index][][][] = out[index][0][0][0]
 			endfor
 		endif
-
 		// out can be text or numeric, afterwards if following code has no type expectations
 		if(WaveExists(outT))
 			WAVE out = outT
+		elseif(WaveExists(outW))
+			WAVE out = outW
 		endif
 		// shrink data to actual array size
 		for(dim = effectiveArrayDimCount; dim < MAX_DIMENSION_COUNT; dim += 1)
@@ -664,9 +689,25 @@ static Function [WAVE outNum, WAVE/T outText] SFE_ExecutorCreateOrCheckTextual(W
 	return [out, outT]
 End
 
+static Function/WAVE SFE_ExecutorCreateOrCheckWaveRef(WAVE/Z/WAVE outW, variable size0)
+
+	if(!WaveExists(outW))
+		Make/FREE/WAVE/N=(size0) outW
+	endif
+
+	return outW
+End
+
 static Function SFE_PlaceSubArrayAt(WAVE/Z out, WAVE/Z subArray, variable index)
 
 	if(!WaveExists(out))
+		return NaN
+	endif
+
+	if(IsWaveRefWave(out))
+		WAVE/WAVE outW = out
+		outW[index] = subArray
+
 		return NaN
 	endif
 

--- a/Packages/MIES/MIES_SweepFormula_Helpers.ipf
+++ b/Packages/MIES/MIES_SweepFormula_Helpers.ipf
@@ -1282,13 +1282,13 @@ Function/WAVE SFH_GetArgumentSelect(STRUCT SF_ExecutionData &exd, variable argNu
 		endif
 		SFH_ASSERT(cond, "Expected a single array")
 		WAVE array = selectComp[0]
-		cond = IsTextWave(array)
+		cond = IsWaveRefWave(array)
 		if(doNotEnforce && !cond)
 			return $""
 		endif
-		SFH_ASSERT(cond, "Expected a text wave")
+		SFH_ASSERT(cond, "Expected a wave ref wave")
 
-		Make/FREE/WAVE/N=(DimSize(array, ROWS)) selectArray = SFH_AttemptDatasetResolve(WaveText(array, row = p), checkWithSFHAssert = 1)
+		Duplicate/FREE/WAVE array, selectArray
 		for(WAVE/Z/WAVE selectComp : selectArray)
 			cond = WaveExists(selectComp)
 			if(doNotEnforce && !cond)
@@ -2008,18 +2008,11 @@ Function/WAVE SFH_MoveDatasetHigherIfCompatible(WAVE/WAVE data)
 		return data
 	endif
 
-	WAVE array = data[0]
-	if(!IsTextWave(array))
+	WAVE/WAVE resolved = data[0]
+	if(!IsWaveRefWave(resolved))
 		return data
 	endif
-	if(DimSize(array, COLS))
-		return data
-	endif
-
-	numOldSets = DimSize(array, ROWS)
-	Make/FREE/WAVE/N=(numOldSets) resolved
-
-	resolved[] = SFH_AttemptDatasetResolve(WaveText(array, row = p))
+	numOldSets = DimSize(resolved, ROWS)
 
 	// check pre-conditions
 	WAVE/ZZ prevSets
@@ -2336,11 +2329,9 @@ Function/WAVE SFH_GetDatasetArrayAsResolvedWaverefs(STRUCT SF_ExecutionData &exd
 
 	if(!WaveExists(dataFromEachGroup))
 		WAVE/WAVE input = SF_ResolveDatasetFromJSON(exd, argNum)
-		SFH_ASSERT(IsTextWave(input[0]), "Expected a dataset")
-		WAVE/T elemRefs = input[0]
-		numGroups = DimSize(elemRefs, ROWS)
-		SFH_ASSERT(numGroups >= 2, "First argument must be an array with at least two elements")
-		Make/FREE/WAVE/N=(numGroups) dataFromEachGroup = SFH_AttemptDatasetResolve(elemRefs[p], checkWithSFHAssert = 1)
+		SFH_ASSERT(IsWaveRefWave(input[0]), "Expected a dataset")
+		WAVE dataFromEachGroup = input[0]
+		SFH_ASSERT(DimSize(dataFromEachGroup, ROWS) >= 2, "First argument must be an array with at least two elements")
 	endif
 
 	return dataFromEachGroup

--- a/Packages/tests/Basic/UTF_SweepFormula.ipf
+++ b/Packages/tests/Basic/UTF_SweepFormula.ipf
@@ -1915,6 +1915,107 @@ static Function TestParseFitConstraints()
 	endtry
 End
 
+// check for formulas:
+// [dataset(1, \"abcd\"), dataset(2, \"cdef\")]
+// var1 = dataset(1, \"abcd\")\r[$var1, dataset(2, \"cdef\")]
+static Function TestOperationOrVariableInArrayDSCheck1(WAVE/WAVE output)
+
+	CHECK(SFH_IsArray(output))
+	WAVE/WAVE arrayContent = output[0]
+	CHECK_WAVE(arrayContent, WAVE_WAVE)
+	CHECK_EQUAL_VAR(DimSize(arrayContent, ROWS), 2) // from two dataset statements
+	WAVE/WAVE datasets0 = arrayContent[0]
+	CHECK_WAVE(datasets0, WAVE_WAVE) // from first dataset statement
+	CHECK_EQUAL_VAR(DimSize(datasets0, ROWS), 2) // from first dataset statement
+	CHECK_EQUAL_WAVES(datasets0[0], {1}, mode = WAVE_DATA)
+	CHECK_EQUAL_TEXTWAVES(datasets0[1], {"abcd"}, mode = WAVE_DATA)
+	WAVE/WAVE datasets1 = arrayContent[1]
+	CHECK_WAVE(datasets1, WAVE_WAVE) // from second dataset statement
+	CHECK_EQUAL_VAR(DimSize(datasets1, ROWS), 2) // from second dataset statement
+	CHECK_EQUAL_WAVES(datasets1[0], {2}, mode = WAVE_DATA)
+	CHECK_EQUAL_TEXTWAVES(datasets1[1], {"cdef"}, mode = WAVE_DATA)
+End
+
+// check for formulas:
+// [\"text\", dataset(2, \"cdef\")]
+// var1 = dataset(2, \"cdef\")\r[\"text\", $var1]
+static Function TestOperationOrVariableInArrayDSCheck2(WAVE/WAVE output)
+
+	CHECK(SFH_IsArray(output))
+	WAVE/WAVE arrayContent = output[0]
+	CHECK_WAVE(arrayContent, WAVE_WAVE)
+	CHECK_EQUAL_VAR(DimSize(arrayContent, ROWS), 2) // from promoted dataset and dataset statements
+	WAVE/WAVE datasets0 = arrayContent[0]
+	CHECK_WAVE(datasets0, WAVE_WAVE) // from promoted dataset
+	CHECK_EQUAL_VAR(DimSize(datasets0, ROWS), 1) // from promoted dataset
+	CHECK_EQUAL_TEXTWAVES(datasets0[0], {"text"}, mode = WAVE_DATA)
+	WAVE/WAVE datasets1 = arrayContent[1]
+	CHECK_WAVE(datasets1, WAVE_WAVE) // from dataset statement
+	CHECK_EQUAL_VAR(DimSize(datasets1, ROWS), 2) // from dataset statement
+	CHECK_EQUAL_WAVES(datasets1[0], {2}, mode = WAVE_DATA)
+	CHECK_EQUAL_TEXTWAVES(datasets1[1], {"cdef"}, mode = WAVE_DATA)
+End
+
+// check for formulas:
+// [dataset(2, \"cdef\"), \"text\"]
+// var1 = dataset(2, \"cdef\")\r[$var1, \"text\"]
+static Function TestOperationOrVariableInArrayDSCheck3(WAVE/WAVE output)
+
+	CHECK(SFH_IsArray(output))
+	WAVE/WAVE arrayContent = output[0]
+	CHECK_WAVE(arrayContent, WAVE_WAVE)
+	CHECK_EQUAL_VAR(DimSize(arrayContent, ROWS), 2) // from promoted dataset and dataset statements
+	WAVE/WAVE datasets0 = arrayContent[0]
+	CHECK_WAVE(datasets0, WAVE_WAVE) // from promoted dataset
+	CHECK_EQUAL_VAR(DimSize(datasets0, ROWS), 2) // from dataset statement
+	CHECK_EQUAL_WAVES(datasets0[0], {2}, mode = WAVE_DATA)
+	CHECK_EQUAL_TEXTWAVES(datasets0[1], {"cdef"}, mode = WAVE_DATA)
+	WAVE/WAVE datasets1 = arrayContent[1]
+	CHECK_WAVE(datasets1, WAVE_WAVE) // from dataset statement
+	CHECK_EQUAL_VAR(DimSize(datasets1, ROWS), 1) // from promoted dataset
+	CHECK_EQUAL_TEXTWAVES(datasets1[0], {"text"}, mode = WAVE_DATA)
+End
+
+// check for formulas:
+// [123, dataset(2, \"cdef\")]
+// var1 = dataset(2, \"cdef\")\r[123, $var1]
+static Function TestOperationOrVariableInArrayDSCheck4(WAVE/WAVE output)
+
+	CHECK(SFH_IsArray(output))
+	WAVE/WAVE arrayContent = output[0]
+	CHECK_WAVE(arrayContent, WAVE_WAVE)
+	CHECK_EQUAL_VAR(DimSize(arrayContent, ROWS), 2) // from promoted dataset and dataset statements
+	WAVE/WAVE datasets0 = arrayContent[0]
+	CHECK_WAVE(datasets0, WAVE_WAVE) // from promoted dataset
+	CHECK_EQUAL_VAR(DimSize(datasets0, ROWS), 1) // from promoted dataset
+	CHECK_EQUAL_WAVES(datasets0[0], {123}, mode = WAVE_DATA)
+	WAVE/WAVE datasets1 = arrayContent[1]
+	CHECK_WAVE(datasets1, WAVE_WAVE) // from dataset statement
+	CHECK_EQUAL_VAR(DimSize(datasets1, ROWS), 2) // from dataset statement
+	CHECK_EQUAL_WAVES(datasets1[0], {2}, mode = WAVE_DATA)
+	CHECK_EQUAL_TEXTWAVES(datasets1[1], {"cdef"}, mode = WAVE_DATA)
+End
+
+// check for formulas:
+// [dataset(2, \"cdef\"), 123]
+// var1 = dataset(2, \"cdef\")\r[$var1, 123]
+static Function TestOperationOrVariableInArrayDSCheck5(WAVE/WAVE output)
+
+	CHECK(SFH_IsArray(output))
+	WAVE/WAVE arrayContent = output[0]
+	CHECK_WAVE(arrayContent, WAVE_WAVE)
+	CHECK_EQUAL_VAR(DimSize(arrayContent, ROWS), 2) // from promoted dataset and dataset statements
+	WAVE/WAVE datasets0 = arrayContent[0]
+	CHECK_WAVE(datasets0, WAVE_WAVE) // from promoted dataset
+	CHECK_EQUAL_VAR(DimSize(datasets0, ROWS), 2) // from dataset statement
+	CHECK_EQUAL_WAVES(datasets0[0], {2}, mode = WAVE_DATA)
+	CHECK_EQUAL_TEXTWAVES(datasets0[1], {"cdef"}, mode = WAVE_DATA)
+	WAVE/WAVE datasets1 = arrayContent[1]
+	CHECK_WAVE(datasets1, WAVE_WAVE) // from dataset statement
+	CHECK_EQUAL_VAR(DimSize(datasets1, ROWS), 1) // from promoted dataset
+	CHECK_EQUAL_WAVES(datasets1[0], {123}, mode = WAVE_DATA)
+End
+
 static Function TestOperationOrVariableInArray()
 
 	string win, device, code
@@ -2014,77 +2115,155 @@ static Function TestOperationOrVariableInArray()
 	endtry
 
 	// operation with dataset return
+
+	// outer array -> size 1 wave ref wave
+	//   -> array elements -> size 2 wave ref wave - two dataset statements
+	//      -> array element 0 -> size 2 wave ref wave - from first dataset statement
+	//         -> element 0 -> size 1 DP wave
+	//         -> element 1 -> size 1 TEXT wave
+	//      -> array element 1 -> size 2 wave ref wave - from second dataset statement
+	//         -> element 0 -> size 1 DP wave
+	//         -> element 1 -> size 1 TEXT wave
 	code = "[dataset(1, \"abcd\"), dataset(2, \"cdef\")]"
 	WAVE/WAVE output = SFE_ExecuteFormula(code, win, useVariables = 0)
-	CHECK_WAVE(output, WAVE_WAVE)
-	CHECK_EQUAL_VAR(DimSize(output, ROWS), 1) // array return
-	WAVE/T array = output[0]
-	CHECK_WAVE(array, TEXT_WAVE)
-	CHECK_EQUAL_VAR(DimSize(array, ROWS), 2) // array elements wrapped
+	TestOperationOrVariableInArrayDSCheck1(output)
 
-	Make/FREE/T wrap = {array[0]}
-	WAVE/WAVE element0 = MIES_SF#SF_ResolveDataset(wrap)
-	CHECK_WAVE(element0, WAVE_WAVE)
-	CHECK_EQUAL_VAR(DimSize(element0, ROWS), 2)
-	CHECK_EQUAL_WAVES(element0[0], {1}, mode = WAVE_DATA)
-	CHECK_EQUAL_TEXTWAVES(element0[1], {"abcd"}, mode = WAVE_DATA)
-
-	Make/FREE/T wrap = {array[1]}
-	WAVE/WAVE element1 = MIES_SF#SF_ResolveDataset(wrap)
-	CHECK_WAVE(element1, WAVE_WAVE)
-	CHECK_EQUAL_VAR(DimSize(element1, ROWS), 2)
-	CHECK_EQUAL_WAVES(element1[0], {2}, mode = WAVE_DATA)
-	CHECK_EQUAL_TEXTWAVES(element1[1], {"cdef"}, mode = WAVE_DATA)
-
+	// outer array -> size 1 wave ref wave
+	//   -> array elements -> size 2 wave ref wave - two array elements
+	//      -> array element 0 -> size 1 wave ref wave - from first wave promoted to dataset
+	//         -> element 0 -> size 1 TEXT wave
+	//      -> array element 1 -> size 2 wave ref wave - from second dataset statement
+	//         -> element 0 -> size 1 DP wave
+	//         -> element 1 -> size 1 TEXT wave
 	code = "[\"text\", dataset(2, \"cdef\")]"
 	WAVE/WAVE output = SFE_ExecuteFormula(code, win, useVariables = 0)
-	CHECK_WAVE(output, WAVE_WAVE)
-	CHECK_EQUAL_VAR(DimSize(output, ROWS), 1) // array return
-	WAVE/T array = output[0]
-	CHECK_WAVE(array, TEXT_WAVE)
-	CHECK_EQUAL_VAR(DimSize(array, ROWS), 2) // array elements wrapped
+	TestOperationOrVariableInArrayDSCheck2(output)
 
-	CHECK_EQUAL_STR(array[0], "text")
-
-	Make/FREE/T wrap = {array[1]}
-	WAVE/WAVE element1 = MIES_SF#SF_ResolveDataset(wrap)
-	CHECK_WAVE(element1, WAVE_WAVE)
-	CHECK_EQUAL_VAR(DimSize(element1, ROWS), 2)
-	CHECK_EQUAL_WAVES(element1[0], {2}, mode = WAVE_DATA)
-	CHECK_EQUAL_TEXTWAVES(element1[1], {"cdef"}, mode = WAVE_DATA)
-
-	code = "[dataset(1, \"abcd\"), \"text\"]"
+	// outer array -> size 1 wave ref wave
+	//   -> array elements -> size 2 wave ref wave - two array elements
+	//      -> array element 0 -> size 1 wave ref wave - from first wave promoted to dataset
+	//         -> element 0 -> size 1 DP wave
+	//      -> array element 1 -> size 2 wave ref wave - from second dataset statement
+	//         -> element 0 -> size 1 DP wave
+	//         -> element 1 -> size 1 TEXT wave
+	code = "[123, dataset(2, \"cdef\")]"
 	WAVE/WAVE output = SFE_ExecuteFormula(code, win, useVariables = 0)
-	CHECK_WAVE(output, WAVE_WAVE)
-	CHECK_EQUAL_VAR(DimSize(output, ROWS), 1) // array return
-	WAVE/T array = output[0]
-	CHECK_WAVE(array, TEXT_WAVE)
-	CHECK_EQUAL_VAR(DimSize(array, ROWS), 2) // array elements wrapped
+	TestOperationOrVariableInArrayDSCheck4(output)
 
-	Make/FREE/T wrap = {array[0]}
-	WAVE/WAVE element0 = MIES_SF#SF_ResolveDataset(wrap)
-	CHECK_WAVE(element0, WAVE_WAVE)
-	CHECK_EQUAL_VAR(DimSize(element0, ROWS), 2)
-	CHECK_EQUAL_WAVES(element0[0], {1}, mode = WAVE_DATA)
-	CHECK_EQUAL_TEXTWAVES(element0[1], {"abcd"}, mode = WAVE_DATA)
+	// outer array -> size 1 wave ref wave
+	//   -> array elements -> size 2 wave ref wave - two array elements
+	//      -> array element 0 -> size 1 wave ref wave - from first wave
+	//         -> element 0 -> size 2 DP wave
+	//      -> array element 1 -> size 2 wave ref wave - from second dataset statement
+	//         -> element 0 -> size 1 DP wave
+	//         -> element 1 -> size 1 TEXT wave
+	code = "[[123, 234], dataset(2, \"cdef\")]"
+	WAVE/WAVE output = SFE_ExecuteFormula(code, win, useVariables = 0)
+	CHECK(SFH_IsArray(output))
+	WAVE/WAVE arrayContent = output[0]
+	CHECK_WAVE(arrayContent, WAVE_WAVE)
+	CHECK_EQUAL_VAR(DimSize(arrayContent, ROWS), 2) // from promoted dataset and dataset statements
+	WAVE/WAVE array0 = arrayContent[0]
+	CHECK(SFH_IsArray(array0))
+	CHECK_EQUAL_WAVES(array0[0], {123, 234}, mode = WAVE_DATA)
+	WAVE/WAVE datasets1 = arrayContent[1]
+	CHECK_WAVE(datasets1, WAVE_WAVE) // from dataset statement
+	CHECK_EQUAL_VAR(DimSize(datasets1, ROWS), 2) // from dataset statement
+	CHECK_EQUAL_WAVES(datasets1[0], {2}, mode = WAVE_DATA)
+	CHECK_EQUAL_TEXTWAVES(datasets1[1], {"cdef"}, mode = WAVE_DATA)
 
-	CHECK_EQUAL_STR(array[1], "text")
+	// outer array -> size 1 wave ref wave
+	//   -> array elements -> size 2 wave ref wave - two array elements
+	//      -> array element 0 -> size 1 wave ref wave - from first wave
+	//         -> element 0 -> size 2 TEXT wave
+	//      -> array element 1 -> size 2 wave ref wave - from second dataset statement
+	//         -> element 0 -> size 1 DP wave
+	//         -> element 1 -> size 1 TEXT wave
+	code = "[[abc, def], dataset(2, \"cdef\")]"
+	WAVE/WAVE output = SFE_ExecuteFormula(code, win, useVariables = 0)
+	CHECK(SFH_IsArray(output))
+	WAVE/WAVE arrayContent = output[0]
+	CHECK_WAVE(arrayContent, WAVE_WAVE)
+	CHECK_EQUAL_VAR(DimSize(arrayContent, ROWS), 2) // from promoted dataset and dataset statements
+	WAVE/WAVE array0 = arrayContent[0]
+	CHECK(SFH_IsArray(array0))
+	CHECK_EQUAL_TEXTWAVES(array0[0], {"abc", "def"}, mode = WAVE_DATA)
+	WAVE/WAVE datasets1 = arrayContent[1]
+	CHECK_WAVE(datasets1, WAVE_WAVE) // from dataset statement
+	CHECK_EQUAL_VAR(DimSize(datasets1, ROWS), 2) // from dataset statement
+	CHECK_EQUAL_WAVES(datasets1[0], {2}, mode = WAVE_DATA)
+	CHECK_EQUAL_TEXTWAVES(datasets1[1], {"cdef"}, mode = WAVE_DATA)
 
-	code = "[123, dataset(1, \"abcd\")]"
-	try
-		WAVE/WAVE output = SFE_ExecuteFormula(code, win, useVariables = 0)
-		FAIL()
-	catch
-		PASS()
-	endtry
+	// outer array -> size 1 wave ref wave
+	//   -> array elements -> size 2 wave ref wave - two array elements
+	//      -> outer array element 0 -> size 2 wave ref wave - from inner array
+	//         -> inner array element 0 -> size 2 wave ref wave - from first dataset statement
+	//            -> element 0 -> size 1 DP wave value 1
+	//            -> element 1 -> size 1 TEXT wave value abc
+	//         -> inner array element 1 -> size 2 wave ref wave - from second dataset statement
+	//            -> element 0 -> size 1 DP wave value 2
+	//            -> element 1 -> size 1 TEXT wave value def
+	//      -> outer array element 1 -> size 2 wave ref wave - from third dataset statement
+	//         -> element 0 -> size 1 DP wave
+	//         -> element 1 -> size 1 TEXT wave
+	code = "[[dataset(1, \"abc\"), dataset(2, \"def\")], dataset(3, \"ghi\")]"
+	WAVE/WAVE output = SFE_ExecuteFormula(code, win, useVariables = 0)
+	CHECK(SFH_IsArray(output))
 
-	code = "[dataset(1, \"abcd\"), 123]"
-	try
-		WAVE/WAVE output = SFE_ExecuteFormula(code, win, useVariables = 0)
-		FAIL()
-	catch
-		PASS()
-	endtry
+	WAVE/WAVE arrayContent = output[0] // outer array
+	CHECK_WAVE(arrayContent, WAVE_WAVE)
+	CHECK_EQUAL_VAR(DimSize(arrayContent, ROWS), 2)
+
+	WAVE/WAVE outerArray0 = arrayContent[0] // inner array that is element 0 of outer array
+	CHECK_WAVE(outerArray0, WAVE_WAVE)
+	CHECK_EQUAL_VAR(DimSize(outerArray0, ROWS), 2)
+
+	WAVE/WAVE outerArray0Sub0 = outerArray0[0] // first dataset statement in inner array
+	CHECK_WAVE(outerArray0Sub0, WAVE_WAVE)
+	CHECK_EQUAL_VAR(DimSize(outerArray0Sub0, ROWS), 2)
+	WAVE outerArray0Sub0Sub0 = outerArray0Sub0[0] // and its content
+	CHECK_EQUAL_WAVES(outerArray0Sub0Sub0, {1}, mode = WAVE_DATA)
+	WAVE outerArray0Sub0Sub1 = outerArray0Sub0[1]
+	CHECK_EQUAL_TEXTWAVES(outerArray0Sub0Sub1, {"abc"}, mode = WAVE_DATA)
+
+	WAVE/WAVE outerArray0Sub1 = outerArray0[1] // second dataset statement in inner array
+	CHECK_WAVE(outerArray0Sub1, WAVE_WAVE)
+	CHECK_EQUAL_VAR(DimSize(outerArray0Sub1, ROWS), 2)
+	WAVE outerArray0Sub1Sub0 = outerArray0Sub1[0] // and its content
+	CHECK_EQUAL_WAVES(outerArray0Sub1Sub0, {2}, mode = WAVE_DATA)
+	WAVE outerArray0Sub1Sub1 = outerArray0Sub1[1]
+	CHECK_EQUAL_TEXTWAVES(outerArray0Sub1Sub1, {"def"}, mode = WAVE_DATA)
+
+	WAVE/WAVE outerArray1 = arrayContent[1] // dataset statement in element 1 of outer array
+	CHECK_WAVE(outerArray1, WAVE_WAVE)
+	CHECK_EQUAL_VAR(DimSize(outerArray1, ROWS), 2)
+
+	WAVE outerArray1Sub0 = outerArray1[0] // and its content
+	CHECK_EQUAL_WAVES(outerArray1Sub0, {3}, mode = WAVE_DATA)
+	WAVE outerArray1Sub1 = outerArray1[1]
+	CHECK_EQUAL_TEXTWAVES(outerArray1Sub1, {"ghi"}, mode = WAVE_DATA)
+
+	// outer array -> size 1 wave ref wave
+	//   -> array elements -> size 2 wave ref wave - two array elements
+	//      -> array element 0 -> size 2 wave ref wave - from first dataset statement
+	//         -> element 0 -> size 1 DP wave
+	//         -> element 1 -> size 1 TEXT wave
+	//      -> array element 1 -> size 1 wave ref wave - from text wave promoted to dataset
+	//         -> element 0 -> size 1 TEXT wave
+	code = "[dataset(2, \"cdef\"), \"text\"]"
+	WAVE/WAVE output = SFE_ExecuteFormula(code, win, useVariables = 0)
+	TestOperationOrVariableInArrayDSCheck3(output)
+
+	// outer array -> size 1 wave ref wave
+	//   -> array elements -> size 2 wave ref wave - two array elements
+	//      -> array element 0 -> size 2 wave ref wave - from second dataset statement
+	//         -> element 0 -> size 1 DP wave
+	//         -> element 1 -> size 1 TEXT wave
+	//      -> array element 1 -> size 1 wave ref wave - from first wave promoted to dataset
+	//         -> element 0 -> size 1 DP wave
+	code = "[dataset(2, \"cdef\"), 123]"
+	WAVE/WAVE output = SFE_ExecuteFormula(code, win, useVariables = 0)
+	TestOperationOrVariableInArrayDSCheck5(output)
 
 	// with variables
 	code = "var1 = selchannels(AD2)\r[$var1, selchannels(DA3)]"
@@ -2193,97 +2372,27 @@ static Function TestOperationOrVariableInArray()
 
 	code = "var1 = dataset(1, \"abcd\")\r[$var1, dataset(2, \"cdef\")]"
 	WAVE/WAVE output = SFE_ExecuteFormula(code, win, useVariables = 1)
-	CHECK_WAVE(output, WAVE_WAVE)
-	CHECK_EQUAL_VAR(DimSize(output, ROWS), 1) // array return
-	WAVE/T array = output[0]
-	CHECK_WAVE(array, TEXT_WAVE)
-	CHECK_EQUAL_VAR(DimSize(array, ROWS), 2) // array elements wrapped
-
-	Make/FREE/T wrap = {array[0]}
-	WAVE/WAVE element0 = MIES_SF#SF_ResolveDataset(wrap)
-	CHECK_WAVE(element0, WAVE_WAVE)
-	CHECK_EQUAL_VAR(DimSize(element0, ROWS), 2)
-	CHECK_EQUAL_WAVES(element0[0], {1}, mode = WAVE_DATA)
-	CHECK_EQUAL_TEXTWAVES(element0[1], {"abcd"}, mode = WAVE_DATA)
-
-	Make/FREE/T wrap = {array[1]}
-	WAVE/WAVE element1 = MIES_SF#SF_ResolveDataset(wrap)
-	CHECK_WAVE(element1, WAVE_WAVE)
-	CHECK_EQUAL_VAR(DimSize(element1, ROWS), 2)
-	CHECK_EQUAL_WAVES(element1[0], {2}, mode = WAVE_DATA)
-	CHECK_EQUAL_TEXTWAVES(element1[1], {"cdef"}, mode = WAVE_DATA)
+	TestOperationOrVariableInArrayDSCheck1(output)
 
 	code = "var1 = dataset(2, \"cdef\")\r[dataset(1, \"abcd\"), $var1]"
 	WAVE/WAVE output = SFE_ExecuteFormula(code, win, useVariables = 1)
-	CHECK_WAVE(output, WAVE_WAVE)
-	CHECK_EQUAL_VAR(DimSize(output, ROWS), 1) // array return
-	WAVE/T array = output[0]
-	CHECK_WAVE(array, TEXT_WAVE)
-	CHECK_EQUAL_VAR(DimSize(array, ROWS), 2) // array elements wrapped
-
-	Make/FREE/T wrap = {array[0]}
-	WAVE/WAVE element0 = MIES_SF#SF_ResolveDataset(wrap)
-	CHECK_WAVE(element0, WAVE_WAVE)
-	CHECK_EQUAL_VAR(DimSize(element0, ROWS), 2)
-	CHECK_EQUAL_WAVES(element0[0], {1}, mode = WAVE_DATA)
-	CHECK_EQUAL_TEXTWAVES(element0[1], {"abcd"}, mode = WAVE_DATA)
-
-	Make/FREE/T wrap = {array[1]}
-	WAVE/WAVE element1 = MIES_SF#SF_ResolveDataset(wrap)
-	CHECK_WAVE(element1, WAVE_WAVE)
-	CHECK_EQUAL_VAR(DimSize(element1, ROWS), 2)
-	CHECK_EQUAL_WAVES(element1[0], {2}, mode = WAVE_DATA)
-	CHECK_EQUAL_TEXTWAVES(element1[1], {"cdef"}, mode = WAVE_DATA)
+	TestOperationOrVariableInArrayDSCheck1(output)
 
 	code = "var1 = dataset(2, \"cdef\")\r[\"text\", $var1]"
 	WAVE/WAVE output = SFE_ExecuteFormula(code, win, useVariables = 1)
-	CHECK_WAVE(output, WAVE_WAVE)
-	CHECK_EQUAL_VAR(DimSize(output, ROWS), 1) // array return
-	WAVE/T array = output[0]
-	CHECK_WAVE(array, TEXT_WAVE)
-	CHECK_EQUAL_VAR(DimSize(array, ROWS), 2) // array elements wrapped
+	TestOperationOrVariableInArrayDSCheck2(output)
 
-	CHECK_EQUAL_STR(array[0], "text")
-
-	Make/FREE/T wrap = {array[1]}
-	WAVE/WAVE element1 = MIES_SF#SF_ResolveDataset(wrap)
-	CHECK_WAVE(element1, WAVE_WAVE)
-	CHECK_EQUAL_VAR(DimSize(element1, ROWS), 2)
-	CHECK_EQUAL_WAVES(element1[0], {2}, mode = WAVE_DATA)
-	CHECK_EQUAL_TEXTWAVES(element1[1], {"cdef"}, mode = WAVE_DATA)
-
-	code = "var1 = dataset(1, \"abcd\")\r[$var1, \"text\"]"
+	code = "var1 = dataset(2, \"cdef\")\r[$var1, \"text\"]"
 	WAVE/WAVE output = SFE_ExecuteFormula(code, win, useVariables = 1)
-	CHECK_WAVE(output, WAVE_WAVE)
-	CHECK_EQUAL_VAR(DimSize(output, ROWS), 1) // array return
-	WAVE/T array = output[0]
-	CHECK_WAVE(array, TEXT_WAVE)
-	CHECK_EQUAL_VAR(DimSize(array, ROWS), 2) // array elements wrapped
+	TestOperationOrVariableInArrayDSCheck3(output)
 
-	Make/FREE/T wrap = {array[0]}
-	WAVE/WAVE element0 = MIES_SF#SF_ResolveDataset(wrap)
-	CHECK_WAVE(element0, WAVE_WAVE)
-	CHECK_EQUAL_VAR(DimSize(element0, ROWS), 2)
-	CHECK_EQUAL_WAVES(element0[0], {1}, mode = WAVE_DATA)
-	CHECK_EQUAL_TEXTWAVES(element0[1], {"abcd"}, mode = WAVE_DATA)
+	code = "var1 = dataset(2, \"cdef\")\r[123, $var1]"
+	WAVE/WAVE output = SFE_ExecuteFormula(code, win, useVariables = 1)
+	TestOperationOrVariableInArrayDSCheck4(output)
 
-	CHECK_EQUAL_STR(array[1], "text")
-
-	code = "var1 = dataset(1, \"abcd\")\r[123, $var1]"
-	try
-		WAVE/WAVE output = SFE_ExecuteFormula(code, win, useVariables = 1)
-		FAIL()
-	catch
-		PASS()
-	endtry
-
-	code = "var1 = dataset(1, \"abcd\")\r[$var1, 123]"
-	try
-		WAVE/WAVE output = SFE_ExecuteFormula(code, win, useVariables = 1)
-		FAIL()
-	catch
-		PASS()
-	endtry
+	code = "var1 = dataset(2, \"cdef\")\r[$var1, 123]"
+	WAVE/WAVE output = SFE_ExecuteFormula(code, win, useVariables = 1)
+	TestOperationOrVariableInArrayDSCheck5(output)
 End
 
 static Function CheckMixingNonFiniteAndText()

--- a/Packages/tests/Basic/UTF_SweepFormula.ipf
+++ b/Packages/tests/Basic/UTF_SweepFormula.ipf
@@ -1798,11 +1798,9 @@ static Function TestOnlyVariablesNotebookFixup()
 	CHECK(StringEndsWith(nbText, "\r"))
 End
 
-// Test-only testop() implementation returning a single dataset whose sole payload is itself a
-// WAVE/WAVE (neither text nor numeric), to drive the array-literal wrapping test below.
 Function/WAVE TestOp_NestedComposite(STRUCT SF_ExecutionData &exd)
 
-	WAVE/WAVE inner = SFH_CreateSFRefWave(exd.graph, "claudeInner", 1)
+	WAVE/WAVE inner = SFH_CreateSFRefWave(exd.graph, SF_OP_TESTOP, 1)
 	Make/FREE/D innerData = {42}
 	inner[0] = innerData
 
@@ -1812,9 +1810,6 @@ Function/WAVE TestOp_NestedComposite(STRUCT SF_ExecutionData &exd)
 	return SFH_GetOutputForExecutor(output, exd.graph, SF_OP_TESTOP)
 End
 
-// Covers MIES_SweepFormula_Executor.ipf: SFE_FormulaExecutor's array literal handling for an
-// element whose resolved dataset is itself neither a text nor a numeric wave (i.e. another
-// WAVE/WAVE), which must be wrapped as a "WrappedArrayElement" dataset marker.
 static Function TestArrayWithNestedComposite()
 
 	string win, str
@@ -1824,16 +1819,23 @@ static Function TestArrayWithNestedComposite()
 	SVAR funcName = $GetSFTestopName(win)
 	funcName = "TestOp_NestedComposite"
 
-	str = "[testop()]"
-	WAVE/T output = SFE_ExecuteFormula(str, win, singleResult = 1, useVariables = 0)
+	// The outermost array brackets are implicit, thus if there are outermost array bracket
+	// the resulting data structure is that minus one array level
+	// therefore, we see here array -> dataset -> content
+	str = "[[testop()]]"
+	WAVE/WAVE output = SFE_ExecuteFormula(str, win, singleResult = 1, useVariables = 0)
 
+	CHECK_WAVE(output, WAVE_WAVE)
 	CHECK_EQUAL_VAR(DimSize(output, ROWS), 1)
 
-	WAVE/Z/WAVE resolved = SFH_AttemptDatasetResolve(output[0])
-	CHECK_WAVE(resolved, WAVE_WAVE)
-	CHECK_EQUAL_VAR(DimSize(resolved, ROWS), 1)
+	WAVE/WAVE array = output[0]
+	CHECK(SFH_IsArray(array))
 
-	WAVE/Z leaf = resolved[0]
+	WAVE/WAVE dataset = array[0]
+	CHECK_WAVE(dataset, WAVE_WAVE)
+	CHECK_EQUAL_VAR(DimSize(dataset, ROWS), 1)
+
+	WAVE/Z leaf = dataset[0]
 	CHECK_WAVE(leaf, NUMERIC_WAVE)
 	CHECK_EQUAL_VAR(leaf[0], 42)
 End


### PR DESCRIPTION
Until now the SF executor did not support waveref wave arrays. waveref wave arrays were wrapped through text waves with references to global waves. This required that all callers needed to unpack the text waves to wave ref waves itself.
The addition of "native" wave ref wave support in the executor solves this and makes the handling on caller side much easier.
