### PR TITLE
Wrap zeromq_stop() in a define case to prevent zmq socket closing after test case run

### DIFF
--- a/Packages/MIES/MIES_MiesUtilities_ZeroMQ.ipf
+++ b/Packages/MIES/MIES_MiesUtilities_ZeroMQ.ipf
@@ -14,6 +14,17 @@ Function GetZeroMQXOPFlags()
 	return ZeroMQ_SET_FLAGS_DEFAULT | ZeroMQ_SET_FLAGS_NOBUSYWAITRECV
 End
 
+/// @brief Stop every ZeroMQ socket/handler in this Igor Pro instance, then
+/// immediately rebind an active Igor Pro Bridge session (if present).
+Function StopZeroMQSockets()
+
+	zeromq_stop()
+
+#if exists("ZBR#ZBR_EnsureZeroMQBound")
+	ZBR#ZBR_EnsureZeroMQBound()
+#endif
+End
+
 /// @brief Start the ZeroMQ sockets and the message handler
 ///
 /// Debug note: Tracking the connection state can be done via
@@ -32,6 +43,15 @@ Function StartZeroMQSockets([variable forceRestart])
 		forceRestart = !!forceRestart
 	endif
 
+#if exists("ZBR#ZBR_EnsureZeroMQBound")
+	// The MIES code assumes that it is the only package that uses zeromq
+	// As optimization this function checks if the zeromq handler is running and if yes,
+	// assumes that MIES is already bound.
+	// With another zeromq user, like the Igor Pro Bridge, this assumption does not hold.
+	// forceRestart = 1 disables this optimization.
+	forceRestart = 1
+#endif
+
 	if(!forceRestart)
 		// do nothing if we are already running
 		AssertOnAndClearRTError()
@@ -42,7 +62,7 @@ Function StartZeroMQSockets([variable forceRestart])
 		endif
 	endif
 
-	zeromq_stop()
+	StopZeroMQSockets()
 
 	flags = GetZeroMQXOPFlags()
 
@@ -73,13 +93,20 @@ Function StartZeroMQSockets([variable forceRestart])
 	endif
 
 	if(numBinds == expectedBinds)
-		zeromq_handler_start()
-		return 0
+		AssertOnAndClearRTError()
+		zeromq_handler_start(); err = GetRTError(1) // see developer docu section Preventing Debugger Popup
+		err = ConvertXOPErrorCode(err)
+		if(!err || err == ZeroMQ_HANDLER_ALREADY_RUNNING)
+			DEBUGPRINT("Successfully started zeromq handler")
+			return 0
+		endif
+		printf "Error %d starting ZeroMQ handler\r", err
+	else
+		printf "Could only establish %d ZeroMQ bind connections and not %d. Shutting down ZeroMQ subsystem.\r", numBinds, expectedBinds
 	endif
 
-	printf "Could only establish %d ZeroMQ bind connections and not %d. Shutting down ZeroMQ subsystem.\r", numBinds, expectedBinds
 	ControlWindowToFront()
-	zeromq_stop()
+	StopZeroMQSockets()
 
 	return 2
 End

--- a/Packages/tests/Basic/UTF_Basic_Includes.ipf
+++ b/Packages/tests/Basic/UTF_Basic_Includes.ipf
@@ -48,6 +48,7 @@
 #include "UTF_Utils_Mies_Config"
 #include "UTF_Utils_Mies_Logging"
 #include "UTF_Utils_Mies_Sweep"
+#include "UTF_Utils_Mies_ZeroMQ"
 #include "UTF_Utils_Numeric"
 #include "UTF_Utils_ProgramFlow"
 #include "UTF_Utils_Strings"

--- a/Packages/tests/Basic/UTF_Utils_Mies_ZeroMQ.ipf
+++ b/Packages/tests/Basic/UTF_Utils_Mies_ZeroMQ.ipf
@@ -1,0 +1,47 @@
+#pragma TextEncoding     = "UTF-8"
+#pragma rtGlobals        = 3 // Use modern global access method and strict wave access.
+#pragma rtFunctionErrors = 1
+#pragma ModuleName       = UTILSTEST_MIES_ZEROMQ
+
+/// @brief StopZeroMQSockets() must leave the ZeroMQ subsystem in a state that
+/// StartZeroMQSockets() can cleanly rebuild from
+///
+/// Deliberately does not assert on whether the message handler itself is left
+/// running: with the Igor Pro Bridge active, StopZeroMQSockets() intentionally
+/// restarts it again immediately (rebinding the bridge), so that end state
+/// differs depending on whether a bridge session is present.
+static Function StopZeroMQSocketsAllowsRestart()
+
+	variable err
+
+	CHECK_EQUAL_VAR(StartZeroMQSockets(forceRestart = 1), 0)
+
+	StopZeroMQSockets()
+
+	zeromq_handler_start(); err = GetRTError(1)
+	err = ConvertXOPErrorCode(err)
+#if exists("ZBR#ZBR_EnsureZeroMQBound")
+	CHECK_EQUAL_VAR(err, ZeroMQ_HANDLER_ALREADY_RUNNING)
+#else
+	CHECK_EQUAL_VAR(err, ZeroMQ_HANDLER_NO_CONNECTION)
+#endif
+
+	// restore MIES ZeroMQ sockets
+	CHECK_EQUAL_VAR(StartZeroMQSockets(forceRestart = 1), 0)
+End
+
+/// @brief StopZeroMQSockets() must be safe to call even when nothing is running
+static Function StopZeroMQSocketsIsSafeWhenNotRunning()
+
+	StopZeroMQSockets()
+
+	try
+		StopZeroMQSockets()
+		CHECK_NO_RTE()
+	catch
+		FAIL()
+	endtry
+
+	// restore MIES ZeroMQ sockets
+	CHECK_EQUAL_VAR(StartZeroMQSockets(forceRestart = 1), 0)
+End

--- a/Packages/tests/UTF_HelperFunctions.ipf
+++ b/Packages/tests/UTF_HelperFunctions.ipf
@@ -957,7 +957,7 @@ End
 
 Function TestEndCommon()
 
-	zeromq_stop()
+	StopZeroMQSockets()
 End
 
 Function TestCaseBeginCommon(string testcase)
@@ -1932,6 +1932,7 @@ static Function/S GetDefaultTestSuitesForExperiment()
 			list = AddListItem("UTF_Utils_Mies_Config.ipf", list, ";", Inf)
 			list = AddListItem("UTF_Utils_Mies_Logging.ipf", list, ";", Inf)
 			list = AddListItem("UTF_Utils_Mies_Sweep.ipf", list, ";", Inf)
+			list = AddListItem("UTF_Utils_Mies_ZeroMQ.ipf", list, ";", Inf)
 			list = AddListItem("UTF_Utils_Numeric.ipf", list, ";", Inf)
 			list = AddListItem("UTF_Utils_ProgramFlow.ipf", list, ";", Inf)
 			list = AddListItem("UTF_Utils_Strings.ipf", list, ";", Inf)


### PR DESCRIPTION
The Igor Pro Bridge MCP server relies on zeromq. Currently zeromq_stop causes all socket binds to be closed.
Therefore the Igor Pro Bridge becomes unresponsive after a test is run, if in the Test End hook zeromq_stop is called.

- [ ] Wait for fixed ZeroMQ XOP
