### PR TITLE
MIES_Include.ipf: Fix platform symbol for the MacOSX nightly download link

### DIFF
--- a/Packages/MIES_Include.ipf
+++ b/Packages/MIES_Include.ipf
@@ -70,7 +70,7 @@ static Function/S GetDownloadLink()
 
 #if defined(WINDOWS)
 	os = "Windows"
-#elif defined(MACINTHOSH)
+#elif defined(MACINTOSH)
 	os = "MacOSX"
 #else
 	FATAL_ERROR("Unsupported OS")

--- a/tools/check-code.sh
+++ b/tools/check-code.sh
@@ -199,6 +199,21 @@ then
   ret=1
 fi
 
+# Igor Pro predefines the platform symbols WINDOWS and MACINTOSH. A misspelled
+# platform symbol is never defined, so the branch it guards is silently dropped
+# and the #else branch is compiled in its place.
+matches=$(git grep $opts                                                                \
+                   -e '^#[[:space:]]*(if|elif|ifdef|ifndef)\b.*\b(WIND|MACINT)[A-Z]*\b' \
+                   --and --not -e '\b(WINDOWS|MACINTOSH)\b'                             \
+                   -- '*.ipf')
+
+if [[ -n "$matches" ]]
+then
+  echo "The conditional compilation platform symbol check failed, only WINDOWS and MACINTOSH exist, and found the following occurrences:"
+  echo "$matches"
+  ret=1
+fi
+
 # ripgrep checks
 
 files=$(git ls-files '*.ipf' '*.sh' '*.rst' '*.dot' '*.md' ':!:**/releasenotes_template.rst' ':^*/IPA_Control.ipf')


### PR DESCRIPTION
This PR proposes fixing the misspelled conditional compilation platform symbol that makes MIES treat MacOSX as an unsupported OS in the too-old-Igor-Pro download path, so that the update panel and its download button actually appear on a Mac. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/444. You can sign in with your GitHub ID to claim ownership of the project.

## What is broken

`GetDownloadLink()` in `Packages/MIES_Include.ipf` selects the MacOSX nightly link with `#elif defined(MACINTHOSH)`. Igor Pro predefines `MACINTOSH`, so `MACINTHOSH` is never defined: on a Mac that branch is dropped and the `#else` branch is compiled in its place. That `#else` branch calls `FATAL_ERROR()`, which is defined in `Packages/MIES/MIES_Utilities_ProgramFlow.ipf` — a file `MIES_Include.ipf` only `#include`s when `TOO_OLD_IGOR` is *not* defined. The whole block exists for the case where `TOO_OLD_IGOR` *is* defined, so on MacOSX with an Igor Pro build older than the required nightly the include fails to compile on an unresolved function. `AfterCompiledHook()` then never runs, and instead of the "MIES requires a newer version of Igor Pro" panel with its "Download approved Igor Pro version" button, the user gets a compile error.

`e2289058` ("Add support for nightly IP versions on MacOSX", 2023-08-22) added both this branch and the `|IgorPro9MacOSXNightly|` substitution that `GetDownloadLink()` greps for, so the MacOSX support that commit added has never been reachable.

## Reproduction on current `main` (76ff63c)

```
$ git grep -n 'MACINT' -- '*.ipf'
Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf:160:#elif defined(MACINTOSH)
Packages/MIES/MIES_GlobalStringAndVariableAccess.ipf:331:#elif defined(MACINTOSH)
Packages/MIES/MIES_Menu.ipf:219:#elif defined(MACINTOSH)
Packages/MIES/MIES_Utilities_File.ipf:179:#elif defined(MACINTOSH)
Packages/MIES/MIES_Utilities_File.ipf:645:#if defined(MACINTOSH)
Packages/MIES/MIES_Utilities_File.ipf:767:#ifdef MACINTOSH
Packages/MIES/MIES_Utilities_File.ipf:774:#endif // MACINTOSH
Packages/MIES/MIES_Utilities_ProgramFlow.ipf:441:#ifdef MACINTOSH
Packages/MIES/MIES_Utilities_ProgramFlow.ipf:450:#endif // MACINTOSH
Packages/MIES_Include.ipf:73:#elif defined(MACINTHOSH)
Packages/tests/Basic/UTF_Utils_File.ipf:60:#elif defined(MACINTOSH)
Packages/tests/Basic/UTF_Utils_File.ipf:76:#elif defined(MACINTOSH)
```

The odd one out is also the only OS switch that sits inside the `TOO_OLD_IGOR` block, and that the fallback it drops through to is unavailable there is one more grep away:

```
$ git grep -n 'Function FATAL_ERROR' -- '*.ipf'
Packages/MIES/MIES_Utilities_ProgramFlow.ipf:436:threadsafe Function FATAL_ERROR(string errorMsg)
$ grep -n 'MIES_Utilities_ProgramFlow' Packages/MIES_Include.ipf
298:#include "MIES_Utilities_ProgramFlow"
```

Line 298 is inside the `#else` that starts at line 140, so it is not compiled in exactly the situation `GetDownloadLink()` is written for.

## The change

`Packages/MIES_Include.ipf` — `MACINTHOSH` becomes `MACINTOSH`, the symbol the rest of the tree already uses and the one the original commit intended. `FATAL_ERROR("Unsupported OS")` in the `#else` branch is deliberately left alone: with the symbol corrected it is unreachable on both supported platforms, and it is mentioned here only because it is the reason this misspelling was fatal rather than merely wrong.

`tools/check-code.sh` — a new check, in the same style as its neighbours, so that a misspelled platform symbol fails your linting run instead of silently deleting the branch it guards.

## Verification

The corrected branch is compiled only when MIES itself refuses to load, so no Igor Pro test suite can reach it. The regression guard therefore lives in `tools/check-code.sh`, which the "Pre-Commit Linting" job already runs. It is red without the `MIES_Include.ipf` change and green with it — both states observed on this tree:

```
$ ./tools/check-code.sh     # with MACINTHOSH restored
The conditional compilation platform symbol check failed, only WINDOWS and MACINTOSH exist, and found the following occurrences:
Packages/MIES_Include.ipf=65=static Function/S GetDownloadLink()
Packages/MIES_Include.ipf:73:#elif defined(MACINTHOSH)
$ echo $?
1

$ ./tools/check-code.sh     # with the fix applied
$ echo $?
0
```

Against a baseline taken on `main` before touching anything, nothing new goes red: `./tools/run-ipt.sh check`, `./tools/run-ipt.sh lint --noreturn-func='FATAL_ERROR|SFH_FATAL_ERROR|FAIL'` over every tracked `.ipf`, and `./tools/check-code.sh` all exited 0 before the change and all exit 0 after it. `./tools/run-ipt.sh lint -i` leaves `Packages/MIES_Include.ipf` byte-identical, so formatting is untouched.

## How this was managed

The work was tracked on a live agile board imported from this repository's own issues and pull requests (2295 stories, 66 labels): the story for this change is [macOS is treated as an unsupported OS in the too-old-Igor nightly download path](https://eastagiletracker.com/projects/444/stories/395109), on the board at https://eastagiletracker.com/projects/444.

![board](https://raw.githubusercontent.com/eastagiletracker/MIES/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
