### PR TITLE
MIES_Include.ipf: Fix platform symbol for the MacOSX nightly download…

### DIFF
--- a/Packages/MIES_Include.ipf
+++ b/Packages/MIES_Include.ipf
@@ -70,7 +70,7 @@ static Function/S GetDownloadLink()
 
 #if defined(WINDOWS)
 	os = "Windows"
-#elif defined(MACINTHOSH)
+#elif defined(MACINTOSH)
 	os = "MacOSX"
 #else
 	FATAL_ERROR("Unsupported OS")


### PR DESCRIPTION
… link

GetDownloadLink() selected the MacOSX branch with `defined(MACINTHOSH)`. Igor Pro predefines `MACINTOSH`, so the branch was never taken and the `#else` branch was compiled on MacOSX instead.

That branch calls `FATAL_ERROR()`, which lives in
MIES_Utilities_ProgramFlow.ipf and is only included when `TOO_OLD_IGOR` is not defined. On MacOSX with a too old Igor Pro build the include therefore failed to compile at all, so neither the update panel nor its download button ever appeared.

Will merge when CI passes.
