### PR TITLE
Utils: fix GetRowIndex returned 0 for -Inf / Inf when not found

### DIFF
--- a/Packages/MIES/MIES_Utilities_Algorithm.ipf
+++ b/Packages/MIES/MIES_Utilities_Algorithm.ipf
@@ -333,12 +333,10 @@ threadsafe Function GetRowIndex(WAVE wv, [variable val, string str, WAVE/Z refWa
 								return i
 							endif
 						endfor
-					else
-						FindValue/V=(val)/T=(tol) wv
+						return NaN
 					endif
-#else
-					FindValue/V=(val)/T=(tol) wv
 #endif
+					FindValue/V=(val)/T=(tol) wv
 				endif
 			else
 				if(IsNaN(val))
@@ -352,12 +350,10 @@ threadsafe Function GetRowIndex(WAVE wv, [variable val, string str, WAVE/Z refWa
 								return i
 							endif
 						endfor
-					else
-						FindValue/V=(val)/R/T=(tol) wv
+						return NaN
 					endif
-#else
-					FindValue/V=(val)/R/T=(tol) wv
 #endif
+					FindValue/V=(val)/R/T=(tol) wv
 				endif
 			endif
 

--- a/Packages/tests/Basic/UTF_Utils_Algorithm.ipf
+++ b/Packages/tests/Basic/UTF_Utils_Algorithm.ipf
@@ -214,6 +214,18 @@ static Function TestGetRowIndex()
 	CHECK_EQUAL_VAR(GetRowIndex(floatWave, str = "inf"), 4)
 	CHECK_EQUAL_VAR(GetRowIndex(floatWave, str = "-inf"), 5)
 	CHECK_EQUAL_VAR(GetRowIndex(floatWave, val = 123), NaN)
+	// handle non-finite properly
+	Make/FREE floatWave = {Inf}
+	CHECK_EQUAL_VAR(GetRowIndex(floatWave, val = -Inf), NaN)
+	CHECK_EQUAL_VAR(GetRowIndex(floatWave, val = -Inf, reverseSearch = 1), NaN)
+	CHECK_EQUAL_VAR(GetRowIndex(floatWave, val = NaN), NaN)
+	Make/FREE floatWave = {-Inf}
+	CHECK_EQUAL_VAR(GetRowIndex(floatWave, val = Inf), NaN)
+	CHECK_EQUAL_VAR(GetRowIndex(floatWave, val = Inf, reverseSearch = 1), NaN)
+	CHECK_EQUAL_VAR(GetRowIndex(floatWave, val = NaN), NaN)
+	Make/FREE floatWave = {NaN}
+	CHECK_EQUAL_VAR(GetRowIndex(floatWave, val = Inf), NaN)
+	CHECK_EQUAL_VAR(GetRowIndex(floatWave, val = -Inf), NaN)
 
 	// text waves
 	Make/FREE/T textWave = {"a", "b", "c", "d", "1"}


### PR DESCRIPTION
GetRowIndex can find Inf/-Inf values. It has different paths for Igor9 and Igor 10 because Igor 10 supports Inf/-Inf directly with FindValue.

In the legacy Igor 9 path GetRowIndex returned index 0 when Inf or -Inf was searched and not found. This is wrong as 0 is a valid wave index. Correct is returning NaN.

This fix adds a missing return of NaN for the not-found case for the normal and reverse search.

Since the introduction of Inf support in GetRowIndex: 7d41c287 (GetRowIndex: Add support for finding inf/-inf, 2024-07-24)

Taken from #2762.
